### PR TITLE
Fix silent issue loss on create after legacy import (v3 hub)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- `crosslink create` / `quick` after a legacy `import` no longer silently lose
+  the new issue while reporting success (#5, related #4). Three fixes:
+  `crosslink import` on a v3 hub now promotes the whole batch through the
+  event log in a single commit, so imported issues get reduction-assigned
+  display ids and are hub-visible like created issues; hydration no longer
+  lets a preserved local-only issue silently REPLACE (INSERT OR REPLACE) a hub
+  issue occupying the same id — the local row is remapped to a negative local
+  id with a warning and both survive; and `create` verifies the new issue is
+  actually visible in `SQLite` after hydration, failing loudly instead of
+  reporting a phantom id. Also starts v3 negative comment-id numbering below
+  preserved comment ids (the v3 analogue of #681).
 - `crosslink sync` / `crosslink init` no longer fail on Git < 2.42.0 (e.g.
   Ubuntu 22.04 LTS, which ships Git 2.34.1) with `unknown option 'orphan'`.
   Hub-v3 and knowledge cache setup used `git worktree add --orphan` (added in

--- a/crosslink/src/commands/hub_v3_operation_tests.rs
+++ b/crosslink/src/commands/hub_v3_operation_tests.rs
@@ -1029,3 +1029,121 @@ fn hub_branches_rename_round_trip() {
     assert!(rev(&hub.cache_dir, "refs/crosslink/checkpoint").is_none());
     assert!(rev(&hub.cache_dir, "refs/heads/crosslink/checkpoint").is_some());
 }
+
+#[test]
+fn v3_import_issues_promotes_batch_to_hub() {
+    // GH#4/GH#5: `SharedWriter::import_issues` emits the whole batch as hub
+    // events in one commit — display ids come from the reduction, the issues
+    // are visible in both the reduced state and SQLite, and children
+    // (labels, comments, closed status, parent, blockers) survive.
+    if !git_ok() {
+        return;
+    }
+    let hub = setup_migrated_v3_hub();
+    let db = Database::open(&hub.crosslink_dir.join("issues.db")).unwrap();
+    let writer = SharedWriter::new(&hub.crosslink_dir).unwrap().unwrap();
+
+    let parent_uuid = uuid::Uuid::new_v4();
+    let child_uuid = uuid::Uuid::new_v4();
+    let specs = vec![
+        crate::shared_writer::ImportedIssueSpec {
+            uuid: parent_uuid,
+            title: "imported parent".to_string(),
+            description: Some("desc".to_string()),
+            priority: "high".to_string(),
+            parent_uuid: None,
+            closed: false,
+            labels: vec!["migrated".to_string()],
+            comments: vec![crate::shared_writer::ImportedCommentSpec {
+                author: "import".to_string(),
+                content: "carried over".to_string(),
+                created_at: chrono::Utc::now(),
+                kind: "note".to_string(),
+            }],
+            blockers: vec![],
+        },
+        crate::shared_writer::ImportedIssueSpec {
+            uuid: child_uuid,
+            title: "imported child".to_string(),
+            description: None,
+            priority: "low".to_string(),
+            parent_uuid: Some(parent_uuid),
+            closed: true,
+            labels: vec![],
+            comments: vec![],
+            blockers: vec![parent_uuid],
+        },
+    ];
+
+    let assigned = writer.import_issues(&db, &specs).unwrap();
+    assert_eq!(assigned.len(), 2);
+    let (parent_id, child_id) = (assigned[0].1, assigned[1].1);
+    assert!(parent_id > 0 && child_id > 0, "reduction-assigned ids");
+
+    // Visible in SQLite with children intact.
+    let parent = db.get_issue(parent_id).unwrap().expect("parent hydrated");
+    assert_eq!(parent.title, "imported parent");
+    assert!(db
+        .get_labels(parent_id)
+        .unwrap()
+        .iter()
+        .any(|l| l == "migrated"));
+    assert!(!db.get_comments(parent_id).unwrap().is_empty());
+    let child = db.get_issue(child_id).unwrap().expect("child hydrated");
+    assert_eq!(child.status, crate::models::IssueStatus::Closed);
+    assert_eq!(child.parent_id, Some(parent_id));
+
+    // Visible in the reduced hub state (the whole point of promotion).
+    let source = crate::hub_source::RefHubSource::new(&hub.cache_dir).unwrap();
+    let state = crate::compaction::reduce(&source).unwrap().state;
+    assert!(state.issues.contains_key(&parent_uuid));
+    assert!(state.issues.contains_key(&child_uuid));
+}
+
+#[test]
+fn v3_create_after_direct_sqlite_rows_keeps_both_issues() {
+    // GH#5 regression: rows written straight into SQLite (the legacy import
+    // path) occupy the same positive id space the reduction assigns. A
+    // subsequent create must not vanish: the hub issue keeps the
+    // reduction-assigned id, the local-only row is remapped, and the id the
+    // CLI reports must exist in SQLite.
+    if !git_ok() {
+        return;
+    }
+    let hub = setup_migrated_v3_hub();
+    let db = Database::open(&hub.crosslink_dir.join("issues.db")).unwrap();
+    let writer = SharedWriter::new(&hub.crosslink_dir).unwrap().unwrap();
+
+    // Hydrate the migrated hub first so the direct row lands after the
+    // existing display ids — exactly where the reduction's next id will land.
+    writer.hydrate_with_retry(&db);
+    let direct_id = db.create_issue("direct sqlite row", None, "low").unwrap();
+
+    let created_id = writer
+        .create_issue(&db, "hub created after import", None, "medium", None, None)
+        .unwrap();
+    assert_eq!(
+        created_id, direct_id,
+        "test precondition: reduction assigns the id the direct row occupied"
+    );
+
+    // The reported id must be the hub issue, visible in SQLite (the GH#5
+    // guard makes create fail loudly rather than report a phantom id).
+    let hub_issue = db
+        .get_issue(created_id)
+        .unwrap()
+        .expect("hub issue visible");
+    assert_eq!(hub_issue.title, "hub created after import");
+
+    // The direct row survives at a remapped negative id.
+    let issues = db.list_issues(Some("all"), None, None).unwrap();
+    let direct_row = issues
+        .iter()
+        .find(|i| i.title == "direct sqlite row")
+        .expect("direct row survives");
+    assert!(
+        direct_row.id < 0,
+        "direct row remapped, got {}",
+        direct_row.id
+    );
+}

--- a/crosslink/src/commands/import.rs
+++ b/crosslink/src/commands/import.rs
@@ -6,12 +6,13 @@ use std::path::Path;
 use super::export::{ExportData, ExportedIssue};
 use crate::db::Database;
 use crate::issue_file::IssueFile;
+use crate::shared_writer::{ImportedCommentSpec, ImportedIssueSpec, SharedWriter};
 use crate::utils::format_issue_id;
 
 /// Maximum import file size (10 MB).
 const MAX_IMPORT_SIZE: u64 = 10 * 1024 * 1024;
 
-pub fn run_json(db: &Database, input_path: &Path) -> Result<()> {
+pub fn run_json(db: &Database, writer: Option<&SharedWriter>, input_path: &Path) -> Result<()> {
     let metadata = fs::metadata(input_path).context("Failed to read import file metadata")?;
     if metadata.len() > MAX_IMPORT_SIZE {
         anyhow::bail!(
@@ -24,11 +25,110 @@ pub fn run_json(db: &Database, input_path: &Path) -> Result<()> {
 
     // Try new IssueFile array format first, then fall back to legacy ExportData envelope.
     if let Ok(issue_files) = serde_json::from_str::<Vec<IssueFile>>(&content) {
+        // GH#4/GH#5: on a v3 hub, promote imported issues through the event
+        // log so the reduction assigns their display ids. Direct-SQLite rows
+        // stay invisible to the reduction and shadow future display ids.
+        if let Some(w) = writer.filter(|w| w.is_v3_public()) {
+            let specs: Vec<ImportedIssueSpec> =
+                issue_files.iter().map(spec_from_issue_file).collect();
+            return import_shared(db, w, &specs, "IssueFile", input_path);
+        }
         return import_issue_files(db, &issue_files, input_path);
     }
 
     let data: ExportData = serde_json::from_str(&content).context("Failed to parse JSON")?;
+    if let Some(w) = writer.filter(|w| w.is_v3_public()) {
+        let specs = specs_from_legacy(&data);
+        return import_shared(db, w, &specs, "legacy", input_path);
+    }
     import_legacy(db, &data, input_path)
+}
+
+/// Lower an `IssueFile` into an [`ImportedIssueSpec`], preserving its uuid
+/// (and therefore parent/blocker references, which are uuid-keyed already).
+fn spec_from_issue_file(issue: &IssueFile) -> ImportedIssueSpec {
+    ImportedIssueSpec {
+        uuid: issue.uuid,
+        title: issue.title.clone(),
+        description: issue.description.clone(),
+        priority: issue.priority.as_str().to_string(),
+        parent_uuid: issue.parent_uuid,
+        closed: issue.status == crate::models::IssueStatus::Closed,
+        labels: issue.labels.clone(),
+        comments: issue
+            .comments
+            .iter()
+            .map(|c| ImportedCommentSpec {
+                author: c.author.clone(),
+                content: c.content.clone(),
+                created_at: c.created_at,
+                kind: c.kind.clone(),
+            })
+            .collect(),
+        blockers: issue.blockers.clone(),
+    }
+}
+
+/// Lower a legacy `ExportData` envelope into specs. Legacy issues have no
+/// uuids, so fresh ones are generated; parent references (old display ids)
+/// are resolved through the generated uuids.
+fn specs_from_legacy(data: &ExportData) -> Vec<ImportedIssueSpec> {
+    let old_id_to_uuid: HashMap<i64, uuid::Uuid> = data
+        .issues
+        .iter()
+        .map(|i| (i.id, uuid::Uuid::new_v4()))
+        .collect();
+
+    data.issues
+        .iter()
+        .map(|issue| ImportedIssueSpec {
+            uuid: old_id_to_uuid[&issue.id],
+            title: issue.title.clone(),
+            description: issue.description.clone(),
+            priority: issue.priority.clone(),
+            parent_uuid: issue
+                .parent_id
+                .and_then(|pid| old_id_to_uuid.get(&pid).copied()),
+            closed: issue.status == "closed",
+            labels: issue.labels.clone(),
+            comments: issue
+                .comments
+                .iter()
+                .map(|c| ImportedCommentSpec {
+                    author: "import".to_string(),
+                    content: c.content.clone(),
+                    created_at: c
+                        .created_at
+                        .parse::<chrono::DateTime<chrono::Utc>>()
+                        .unwrap_or_else(|_| chrono::Utc::now()),
+                    kind: "note".to_string(),
+                })
+                .collect(),
+            blockers: Vec::new(),
+        })
+        .collect()
+}
+
+/// Import via the shared writer: one hub commit for the whole batch, display
+/// ids assigned by the reduction (GH#4, GH#5).
+fn import_shared(
+    db: &Database,
+    writer: &SharedWriter,
+    specs: &[ImportedIssueSpec],
+    format: &str,
+    input_path: &Path,
+) -> Result<()> {
+    println!(
+        "Importing {} issues from {} ({format} format, promoting to hub)",
+        specs.len(),
+        input_path.display()
+    );
+    let assigned = writer.import_issues(db, specs)?;
+    for (spec, (_uuid, new_id)) in specs.iter().zip(&assigned) {
+        println!("  Imported: {} {}", format_issue_id(*new_id), spec.title);
+    }
+    println!("Successfully imported {} issues", assigned.len());
+    Ok(())
 }
 
 fn import_issue_files(db: &Database, issues: &[IssueFile], input_path: &Path) -> Result<()> {
@@ -225,7 +325,7 @@ mod tests {
         let json = create_test_export(vec![make_issue(1, "Test issue", None, "open")]);
         let import_path = dir.path().join("import.json");
         fs::write(&import_path, json).unwrap();
-        let result = run_json(&db, &import_path);
+        let result = run_json(&db, None, &import_path);
         assert!(result.is_ok());
         let issues = db.list_issues(Some("all"), None, None).unwrap();
         assert_eq!(issues.len(), 1);
@@ -240,7 +340,7 @@ mod tests {
         ]);
         let import_path = dir.path().join("import.json");
         fs::write(&import_path, json).unwrap();
-        run_json(&db, &import_path).unwrap();
+        run_json(&db, None, &import_path).unwrap();
         let issues = db.list_issues(Some("all"), None, None).unwrap();
         assert_eq!(issues.len(), 2);
     }
@@ -251,7 +351,7 @@ mod tests {
         let json = create_test_export(vec![make_issue(1, "Closed", None, "closed")]);
         let import_path = dir.path().join("import.json");
         fs::write(&import_path, json).unwrap();
-        run_json(&db, &import_path).unwrap();
+        run_json(&db, None, &import_path).unwrap();
         let issues = db.list_issues(Some("closed"), None, None).unwrap();
         assert_eq!(issues.len(), 1);
     }
@@ -264,7 +364,7 @@ mod tests {
         let json = create_test_export(vec![issue]);
         let import_path = dir.path().join("import.json");
         fs::write(&import_path, json).unwrap();
-        run_json(&db, &import_path).unwrap();
+        run_json(&db, None, &import_path).unwrap();
         let issues = db.list_issues(Some("all"), None, None).unwrap();
         let labels = db.get_labels(issues[0].id).unwrap();
         assert!(labels.contains(&"bug".to_string()));
@@ -275,7 +375,7 @@ mod tests {
         let (db, dir) = setup_test_db();
         let import_path = dir.path().join("invalid.json");
         fs::write(&import_path, "not valid json").unwrap();
-        let result = run_json(&db, &import_path);
+        let result = run_json(&db, None, &import_path);
         assert!(result.is_err());
     }
 
@@ -283,7 +383,7 @@ mod tests {
     fn test_import_missing_file() {
         let (db, dir) = setup_test_db();
         let import_path = dir.path().join("nonexistent.json");
-        let result = run_json(&db, &import_path);
+        let result = run_json(&db, None, &import_path);
         assert!(result.is_err());
     }
 
@@ -293,7 +393,7 @@ mod tests {
         let json = create_test_export(vec![]);
         let import_path = dir.path().join("import.json");
         fs::write(&import_path, json).unwrap();
-        let result = run_json(&db, &import_path);
+        let result = run_json(&db, None, &import_path);
         assert!(result.is_ok());
     }
 
@@ -324,7 +424,7 @@ mod tests {
         let json = serde_json::to_string_pretty(&vec![issue]).unwrap();
         let import_path = dir.path().join("import.json");
         fs::write(&import_path, &json).unwrap();
-        run_json(&db, &import_path).unwrap();
+        run_json(&db, None, &import_path).unwrap();
         let issues = db.list_issues(Some("all"), None, None).unwrap();
         assert_eq!(issues.len(), 1);
         assert_eq!(issues[0].title, "New format issue");
@@ -339,7 +439,7 @@ mod tests {
             let json = create_test_export(vec![make_issue(1, &title, None, "open")]);
             let import_path = dir.path().join("import.json");
             fs::write(&import_path, json).unwrap();
-            let result = run_json(&db, &import_path);
+            let result = run_json(&db, None, &import_path);
             prop_assert!(result.is_ok());
         }
     }

--- a/crosslink/src/commands/migrate_hub_v3.rs
+++ b/crosslink/src/commands/migrate_hub_v3.rs
@@ -468,10 +468,8 @@ fn github_branches_url(cache_dir: &Path, remote: &str) -> Option<String> {
     // git@github.com:owner/repo.git  OR  https://github.com/owner/repo(.git)
     let slug = if let Some(rest) = url.strip_prefix("git@github.com:") {
         rest.to_string()
-    } else if let Some(rest) = url.strip_prefix("https://github.com/") {
-        rest.to_string()
     } else {
-        return None;
+        url.strip_prefix("https://github.com/")?.to_string()
     };
     let slug = slug.strip_suffix(".git").unwrap_or(&slug);
     Some(format!("https://github.com/{slug}/branches"))

--- a/crosslink/src/hub_v3_operation_tests.rs
+++ b/crosslink/src/hub_v3_operation_tests.rs
@@ -116,6 +116,81 @@ fn hydrate_from_state_maps_issue_children() {
     assert!(!db.get_comments(1).unwrap().is_empty());
 }
 
+#[test]
+fn hydrate_from_state_remaps_local_only_issue_colliding_with_hub_display_id() {
+    // GH#5: a local-only issue (e.g. from a legacy `import`) occupying id 1
+    // must not silently REPLACE the hub issue the reduction assigned display
+    // id 1 — the hub issue keeps the id, the local-only issue is remapped to
+    // a negative local id, and both survive with their children.
+    let db = Database::open(Path::new(":memory:")).unwrap();
+    let local = db.create_issue("local only", None, "low").unwrap();
+    assert_eq!(
+        local, 1,
+        "test precondition: local-only issue occupies id 1"
+    );
+    db.add_label(local, "keep").unwrap();
+    db.add_comment(local, "local note", "note").unwrap();
+
+    let mut state = crate::checkpoint::CheckpointState::default();
+    let uuid = uuid::Uuid::new_v4();
+    state.display_id_map.insert(uuid, 1);
+    state
+        .issues
+        .insert(uuid, sample_compact_issue(uuid, 1, "from hub"));
+
+    crate::hydration::hydrate_from_state(&state, &db).unwrap();
+
+    let hub = db.get_issue(1).unwrap().expect("hub issue at id 1");
+    assert_eq!(hub.title, "from hub", "hub issue must not be shadowed");
+
+    let issues = db.list_issues(Some("all"), None, None).unwrap();
+    let local_row = issues
+        .iter()
+        .find(|i| i.title == "local only")
+        .expect("colliding local-only issue must survive hydration");
+    assert!(
+        local_row.id < 0,
+        "colliding local-only issue is remapped to a negative id, got {}",
+        local_row.id
+    );
+    assert!(
+        db.get_labels(local_row.id)
+            .unwrap()
+            .iter()
+            .any(|l| l == "keep"),
+        "labels follow the remapped issue"
+    );
+    assert!(
+        !db.get_comments(local_row.id).unwrap().is_empty(),
+        "comments follow the remapped issue"
+    );
+}
+
+#[test]
+fn hydrate_from_state_remap_is_stable_across_repeated_hydrations() {
+    // After the first pass remaps a colliding local-only issue to a negative
+    // id, subsequent hydrations must keep both issues without error.
+    let db = Database::open(Path::new(":memory:")).unwrap();
+    db.create_issue("local only", None, "low").unwrap();
+
+    let mut state = crate::checkpoint::CheckpointState::default();
+    let uuid = uuid::Uuid::new_v4();
+    state.display_id_map.insert(uuid, 1);
+    state
+        .issues
+        .insert(uuid, sample_compact_issue(uuid, 1, "from hub"));
+
+    crate::hydration::hydrate_from_state(&state, &db).unwrap();
+    crate::hydration::hydrate_from_state(&state, &db).unwrap();
+
+    let issues = db.list_issues(Some("all"), None, None).unwrap();
+    assert_eq!(issues.len(), 2, "both issues survive repeated hydration");
+    assert_eq!(
+        db.get_issue(1).unwrap().expect("hub issue").title,
+        "from hub"
+    );
+}
+
 fn sample_compact_issue(
     uuid: uuid::Uuid,
     display_id: i64,

--- a/crosslink/src/hydration.rs
+++ b/crosslink/src/hydration.rs
@@ -360,6 +360,17 @@ pub fn hydrate_from_state(
     let preserved_ids: Vec<i64> = sqlite_only_rows.iter().map(|r| r.id).collect();
     let saved_children = snapshot_children(db, &preserved_ids)?;
 
+    // Preserved SQLite-only comments may carry negative ids from a previous
+    // hydration. Start this pass's negative comment numbering below the lowest
+    // preserved id so the plain-INSERT comment rows never collide (the v3
+    // analogue of #681).
+    let comment_id_start = saved_children
+        .comments
+        .iter()
+        .map(|c| c.0)
+        .min()
+        .map_or(-1, |min| min.min(0) - 1);
+
     // Build uuid -> display_id lookup for cross-references (blockers/related/
     // parent/milestone). Issues without a frozen display id get a deterministic
     // negative local id assigned during insertion below.
@@ -404,6 +415,7 @@ pub fn hydrate_from_state(
             state,
             &mut uuid_to_id,
             &milestone_uuid_to_id,
+            comment_id_start,
             &mut stats,
         )?;
         hydrate_state_dependencies(db, state, &uuid_to_id, &mut stats);
@@ -461,12 +473,16 @@ fn hydrate_state_issues(
     state: &crate::checkpoint::CheckpointState,
     uuid_to_id: &mut HashMap<String, i64>,
     milestone_uuid_to_id: &HashMap<String, i64>,
+    comment_id_start: i64,
     stats: &mut HydrationStats,
 ) -> Result<()> {
     // Negative local ids for issues without a frozen display id, and for v3
     // comments/time-entries (event-only identity, no counter-claimed i64).
+    // `comment_id_start` begins below the lowest preserved SQLite-only comment
+    // id so this pass's negative ids never collide with rows re-inserted by
+    // `restore_sqlite_only_issues` (the v3 analogue of #681).
     let mut next_local_id: i64 = -1;
-    let mut next_v2_comment_id: i64 = -1;
+    let mut next_v2_comment_id: i64 = comment_id_start;
 
     for issue in topo_sort_state_issues(state) {
         let display_id = issue.display_id.unwrap_or_else(|| {
@@ -897,21 +913,49 @@ fn snapshot_children(db: &Database, preserved_ids: &[i64]) -> Result<SavedChildr
 }
 
 /// Re-insert SQLite-only issues and their child data after hydration clears shared tables.
+///
+/// Runs AFTER the hub-derived rows are inserted, and `insert_hydrated_issue`
+/// is INSERT OR REPLACE — so a preserved local-only issue whose id equals a
+/// reduction-assigned display id would silently REPLACE the hub issue at that
+/// id (GH#5: creates after a legacy `import` vanish while the CLI reports
+/// success). Ids that collide are remapped to fresh negative local ids so
+/// both issues survive; the local-only issue keeps its identity via uuid.
 fn restore_sqlite_only_issues(
     db: &Database,
     sqlite_only_rows: &[SavedIssue],
     saved_children: &SavedChildren,
     stats: &mut HydrationStats,
 ) -> Result<()> {
+    let occupied = occupied_issue_ids(db)?;
+    let mut next_local = occupied.iter().copied().min().unwrap_or(0).min(0) - 1;
+    let mut remap: HashMap<i64, i64> = HashMap::new();
+    for row in sqlite_only_rows {
+        if occupied.contains(&row.id) {
+            remap.insert(row.id, next_local);
+            next_local -= 1;
+        }
+    }
+    if !remap.is_empty() {
+        let mut collided: Vec<i64> = remap.keys().copied().collect();
+        collided.sort_unstable();
+        tracing::warn!(
+            "hydration: {} local-only issue(s) collide with hub-assigned display id(s) \
+             {:?}; remapped to negative local ids so the hub issues are not overwritten",
+            remap.len(),
+            collided
+        );
+    }
+    let mapped = |id: i64| remap.get(&id).copied().unwrap_or(id);
+
     for row in sqlite_only_rows {
         db.insert_hydrated_issue(&HydratedIssue {
-            id: row.id,
+            id: mapped(row.id),
             uuid: &row.uuid,
             title: &row.title,
             description: row.description.as_deref(),
             status: &row.status,
             priority: &row.priority,
-            parent_id: row.parent_id,
+            parent_id: row.parent_id.map(mapped),
             created_by: row.created_by.as_deref(),
             created_at: &row.created_at,
             updated_at: &row.updated_at,
@@ -923,7 +967,7 @@ fn restore_sqlite_only_issues(
     }
 
     for (issue_id, label) in &saved_children.labels {
-        db.insert_hydrated_label(*issue_id, label)?;
+        db.insert_hydrated_label(mapped(*issue_id), label)?;
     }
     for (
         id,
@@ -940,7 +984,7 @@ fn restore_sqlite_only_issues(
     {
         db.insert_hydrated_comment(
             *id,
-            *issue_id,
+            mapped(*issue_id),
             uuid.as_deref(),
             author.as_deref(),
             content,
@@ -953,27 +997,38 @@ fn restore_sqlite_only_issues(
         stats.comments += 1;
     }
     for (blocker_id, blocked_id) in &saved_children.deps {
-        db.insert_dependency_raw(*blocker_id, *blocked_id)?;
+        db.insert_dependency_raw(mapped(*blocker_id), mapped(*blocked_id))?;
         stats.dependencies += 1;
     }
     for (id1, id2) in &saved_children.relations {
-        db.insert_relation_raw(*id1, *id2)?;
+        db.insert_relation_raw(mapped(*id1), mapped(*id2))?;
         stats.relations += 1;
     }
     for (id, issue_id, started_at, ended_at, duration_seconds) in &saved_children.time_entries {
         db.insert_hydrated_time_entry(
             *id,
-            *issue_id,
+            mapped(*issue_id),
             started_at,
             ended_at.as_deref(),
             *duration_seconds,
         )?;
     }
     for (milestone_id, issue_id) in &saved_children.milestone_issues {
-        db.insert_hydrated_milestone_issue(*milestone_id, *issue_id)?;
+        db.insert_hydrated_milestone_issue(*milestone_id, mapped(*issue_id))?;
     }
 
     Ok(())
+}
+
+/// All issue ids currently present in `SQLite` (the hub-derived rows inserted
+/// earlier in this hydration pass, since shared tables were cleared first).
+fn occupied_issue_ids(db: &Database) -> Result<std::collections::HashSet<i64>> {
+    let ids = db
+        .conn
+        .prepare("SELECT id FROM issues")?
+        .query_map([], |row| row.get(0))?
+        .collect::<std::result::Result<std::collections::HashSet<i64>, _>>()?;
+    Ok(ids)
 }
 
 /// Hydrate the dependencies table from `blockers` arrays in issue files.

--- a/crosslink/src/knowledge/core.rs
+++ b/crosslink/src/knowledge/core.rs
@@ -541,8 +541,8 @@ pub fn serialize_frontmatter(fm: &PageFrontmatter) -> String {
         let _ = writeln!(out, "contributors: [{}]", escaped_contribs.join(", "));
     }
 
-    let _ = writeln!(out, "created: {}", &fm.created);
-    let _ = writeln!(out, "updated: {}", &fm.updated);
+    let _ = writeln!(out, "created: {}", fm.created);
+    let _ = writeln!(out, "updated: {}", fm.updated);
     out.push_str("---\n");
 
     out

--- a/crosslink/src/main.rs
+++ b/crosslink/src/main.rs
@@ -3043,8 +3043,10 @@ fn main() -> Result<()> {
 
         Commands::Import { input } => {
             let db = get_db()?;
+            let crosslink_dir = find_crosslink_dir()?;
+            let writer = get_writer(&crosslink_dir);
             let path = std::path::Path::new(&input);
-            commands::import::run_json(&db, path)
+            commands::import::run_json(&db, writer.as_ref(), path)
         }
 
         Commands::Archive { action } => {

--- a/crosslink/src/seam.rs
+++ b/crosslink/src/seam.rs
@@ -319,11 +319,8 @@ fn extract_mod_name(line: &str) -> Option<String> {
     // Remove visibility qualifiers.
     let rest = if line.starts_with("pub(") {
         // pub(crate) mod foo, pub(super) mod foo, etc.
-        if let Some(idx) = line.find(')') {
-            line[idx + 1..].trim()
-        } else {
-            return None;
-        }
+        let idx = line.find(')')?;
+        line[idx + 1..].trim()
     } else if let Some(rest) = line.strip_prefix("pub ") {
         rest.trim()
     } else {

--- a/crosslink/src/shared_writer/mod.rs
+++ b/crosslink/src/shared_writer/mod.rs
@@ -18,4 +18,6 @@ mod tests;
 // continue to use `crate::shared_writer::SharedWriter`, etc.
 pub use self::core::{PushOutcome, SharedWriter};
 pub use locks::LockClaimResult;
-pub use mutations::{DescriptionUpdate, FieldUpdate, IssueUpdate};
+pub use mutations::{
+    DescriptionUpdate, FieldUpdate, ImportedCommentSpec, ImportedIssueSpec, IssueUpdate,
+};

--- a/crosslink/src/shared_writer/mutations.rs
+++ b/crosslink/src/shared_writer/mutations.rs
@@ -21,6 +21,36 @@ use crate::db::Database;
 
 use super::core::{SharedWriter, WriteSet};
 
+/// One issue to promote to the hub during `crosslink import` (GH#4, GH#5).
+///
+/// A neutral shape both import formats (legacy `ExportData` envelope and
+/// `IssueFile` array) lower into, so the writer does not depend on command
+/// types. `uuid` is preserved from `IssueFile` input (keeping cross-machine
+/// identity) and freshly generated for legacy input.
+#[derive(Debug, Clone)]
+pub struct ImportedIssueSpec {
+    pub uuid: Uuid,
+    pub title: String,
+    pub description: Option<String>,
+    pub priority: String,
+    pub parent_uuid: Option<Uuid>,
+    pub closed: bool,
+    pub labels: Vec<String>,
+    pub comments: Vec<ImportedCommentSpec>,
+    /// Uuids of issues blocking this one (dangling references are skipped by
+    /// the reduction).
+    pub blockers: Vec<Uuid>,
+}
+
+/// A comment carried by an [`ImportedIssueSpec`].
+#[derive(Debug, Clone)]
+pub struct ImportedCommentSpec {
+    pub author: String,
+    pub content: String,
+    pub created_at: DateTime<Utc>,
+    pub kind: String,
+}
+
 /// Represents an update to a description field with three possible states:
 /// unchanged, cleared, or set to a new value.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -163,10 +193,22 @@ impl SharedWriter {
         )?;
 
         self.hydrate_with_retry(db);
+        // GH#5 guard: the reduction assigned a display id, but hydration can
+        // fail (or the row can be shadowed by a colliding local-only issue),
+        // leaving SQLite without the row while the CLI reports success.
+        // Confirm the uuid is actually visible in SQLite before reporting.
+        let sqlite_id = db.get_issue_id_by_uuid(&uuid.to_string());
         if let Some(id) = self.v3_assigned_display_id(&uuid) {
+            if sqlite_id.is_err() {
+                anyhow::bail!(
+                    "issue {uuid} was committed to the hub (display id {id}) but is not \
+                     visible in the local database after hydration; run `crosslink sync` \
+                     to recover, then verify with `crosslink list`"
+                );
+            }
             return Ok(id);
         }
-        db.get_issue_id_by_uuid(&uuid.to_string())
+        sqlite_id
     }
 
     /// Create a new issue: generate UUID, claim display ID, write JSON, push, hydrate.
@@ -200,6 +242,107 @@ impl SharedWriter {
             },
             &format!("create issue: {title}"),
         )
+    }
+
+    /// Import a batch of issues as hub events in a single commit (GH#4, GH#5).
+    ///
+    /// The direct-SQLite import path writes rows the reduction never sees:
+    /// they stay invisible to other agents, and their positive ids collide
+    /// with the display ids the reduction later assigns to new issues —
+    /// silently shadowing them. Routing the import through the event log
+    /// gives every imported issue a reduction-assigned display id and makes
+    /// it hub-visible like any created issue.
+    ///
+    /// All events (`IssueCreated`, plus `CommentAdded` / `StatusChanged` /
+    /// `DependencyAdded` per issue) are emitted in ONE `write_commit_push`,
+    /// so a large import is a single commit and a single hydration.
+    ///
+    /// Returns `(uuid, display_id)` pairs in input order.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a priority fails to parse, git operations fail, or
+    /// an imported issue is not visible in `SQLite` after hydration.
+    pub fn import_issues(
+        &self,
+        db: &Database,
+        specs: &[ImportedIssueSpec],
+    ) -> Result<Vec<(Uuid, i64)>> {
+        let mut events = Vec::new();
+        for spec in specs {
+            // Parse up front so a bad priority fails before anything is committed.
+            let priority: crate::models::Priority = spec.priority.parse()?;
+            events.push(crate::events::Event::IssueCreated {
+                uuid: spec.uuid,
+                title: spec.title.clone(),
+                description: spec.description.clone(),
+                priority: priority.to_string(),
+                labels: spec.labels.clone(),
+                parent_uuid: spec.parent_uuid,
+                created_by: self.agent.agent_id.clone(),
+                display_id: None,
+                scheduled_at: None,
+                due_at: None,
+            });
+            for c in &spec.comments {
+                events.push(crate::events::Event::CommentAdded {
+                    issue_uuid: spec.uuid,
+                    comment_uuid: Uuid::new_v4(),
+                    display_id: None,
+                    author: c.author.clone(),
+                    content: c.content.clone(),
+                    created_at: c.created_at,
+                    kind: c.kind.clone(),
+                    trigger_type: None,
+                    intervention_context: None,
+                    driver_key_fingerprint: None,
+                    signed_by: None,
+                    signature: None,
+                });
+            }
+            for blocker in &spec.blockers {
+                events.push(crate::events::Event::DependencyAdded {
+                    blocked_uuid: spec.uuid,
+                    blocker_uuid: *blocker,
+                });
+            }
+            if spec.closed {
+                events.push(crate::events::Event::StatusChanged {
+                    uuid: spec.uuid,
+                    new_status: "closed".to_string(),
+                    closed_at: Some(Utc::now()),
+                });
+            }
+        }
+
+        self.write_commit_push(
+            |_writer| {
+                Ok(WriteSet {
+                    events: events.clone(),
+                })
+            },
+            &format!("import {} issues", specs.len()),
+        )?;
+
+        self.hydrate_with_retry(db);
+
+        let mut assigned = Vec::with_capacity(specs.len());
+        for spec in specs {
+            // Same visibility guard as create_issue_inner (GH#5): never report
+            // an id that `list` cannot see.
+            let Ok(sqlite_id) = db.get_issue_id_by_uuid(&spec.uuid.to_string()) else {
+                anyhow::bail!(
+                    "imported issue {} ('{}') was committed to the hub but is not \
+                     visible in the local database after hydration; run \
+                     `crosslink sync` to recover, then verify with `crosslink list`",
+                    spec.uuid,
+                    spec.title
+                );
+            };
+            let id = self.v3_assigned_display_id(&spec.uuid).unwrap_or(sqlite_id);
+            assigned.push((spec.uuid, id));
+        }
+        Ok(assigned)
     }
 
     /// Create a subissue under a parent.


### PR DESCRIPTION
Fixes #5, and the import half of #4.

## Problem

On a v3 hub, `crosslink import` writes rows straight into SQLite. The reduction never sees them, so their positive ids squat on the display ids the reduction will later assign. When a subsequent `create` receives one of those ids, hydration inserts the hub issue and then `restore_sqlite_only_issues` re-inserts the preserved local-only row **over it** (`insert_hydrated_issue` is `INSERT OR REPLACE`). The new issue vanishes from SQLite while the CLI reports `Created issue #N` from the in-memory reduced state — silent data loss (#5 has the full repro).

## Fixes (defense in depth)

1. **`crosslink import` promotes to the hub** (root cause; the direction suggested in #4). New `SharedWriter::import_issues` emits the whole batch — `IssueCreated` (labels inline, parent by uuid) plus `CommentAdded` / `StatusChanged` / `DependencyAdded` — in **one** `write_commit_push` commit and one hydration. Imported issues get reduction-assigned display ids and are hub-visible like any created issue. `IssueFile` input keeps its uuids; legacy `ExportData` input gets fresh ones. Repos without a hub (no writer / v2) keep the existing direct-SQLite path.

2. **Hydration never stomps hub rows.** In `restore_sqlite_only_issues`, a preserved local-only issue whose id collides with an id already inserted this pass is remapped to a fresh negative local id (children follow; loud `tracing::warn`). This repairs repos already in the broken state: the shadowed hub issues become visible again on the next hydration, and the local-only rows survive as `L<n>`.

3. **`create` fails loudly instead of lying.** `create_issue_inner` now verifies the new uuid is visible in SQLite after `hydrate_with_retry` before returning the reduction-assigned id. If hydration failed, the caller gets an error pointing at `crosslink sync` instead of a phantom id.

Also starts v3 negative comment-id numbering below the lowest preserved comment id — the v3 analogue of the #681 fix on the file path (previously hardcoded `-1`, plain `INSERT`, so a preserved `-1` comment would abort the whole hydration transaction).

## Blast radius

Who this bites, and how hard — the failure is **deterministic, not flaky**:

- **Preconditions:** an active v3 hub writer (sync cache established against a tracker remote) *plus* SQLite-only rows occupying positive ids (typically from `crosslink import` of pre-hub data; also any rows created before the hub was established). Neither alone is enough.
- **Failure window:** once both hold, **every** create is silently lost until the reduction's id counter clears the occupied range — the lost events still advance the counter, so importing N contiguous ids loses exactly the next N creates, then creates succeed forever after in that repo. From the user's side it looks like flaky behavior (N failures, then unexplained success), which is why it's easy to misdiagnose.
- **Aftermath even after the window closes:** the lost issues remain in the event log but stay permanently shadowed in SQLite by the colliding local rows on every hydration (fix 2 surfaces them again as remapped `L`-issues).
- **Who is unaffected:** hubless repos (no tracker remote, `sync` never run) — the writer is `None` and everything routes through direct SQLite consistently, so neither the loss nor the shadowing can occur. Fresh hub repos with no imported/pre-hub data are also safe, which is likely why this survived so long: it specifically hits users migrating existing data (e.g. from chainlink), the same population as #4.
- **Corollary:** switching an existing repo from hubless to hubbed re-creates the preconditions (its rows are invisible to the fresh reduction). Until `migrate to-shared` works on v3 (#4), the collision remap in fix 2 is what keeps that path non-destructive.

## How this was found

Stumbled on during the most ordinary onboarding path there is: migrating a repo from chainlink to crosslink. `chainlink export` → `crosslink init` → `crosslink import backup.json`, then immediately using `quick` to file a couple of chores. `init` had auto-provisioned the signing identity and the hub against `origin`, so the very first post-import creates landed inside the failure window: three consecutive `quick`/`create` calls printed `Created issue #1/#2/#3` and none of them appeared in `list`. It initially read as beta flakiness — the fourth create "just worked" (the counter had cleared the imported range), and the only diagnostic was an easy-to-miss `hydrate_from_state: preserving 3 SQLite-only issue(s)` line at debug level. Since chainlink users migrating their existing data are presumably crosslink's core incoming audience, this window sits directly on the recommended adoption path — every migrated repo walks through it.

## Tests

- `hydrate_from_state_remaps_local_only_issue_colliding_with_hub_display_id` — hub issue keeps the id, local-only issue remapped negative, labels/comments follow.
- `hydrate_from_state_remap_is_stable_across_repeated_hydrations`.
- `v3_import_issues_promotes_batch_to_hub` (e2e) — batch with parent/child, closed status, label, comment, blocker; asserts hydrated SQLite rows and presence in the reduced state.
- `v3_create_after_direct_sqlite_rows_keeps_both_issues` (e2e) — the #5 regression: create after direct-SQLite rows returns an id that exists in SQLite; the direct row survives remapped.

`cargo test` (full suite), `cargo clippy --all-targets` (0 warnings), and `cargo fmt --check` all pass. Manually verified against the #5 repro script in both orderings (import before and after hub establishment): no more lost issues in either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
