### PR TITLE
fix(hooks): resolve crosslink binary via find_crosslink_binary and fail open on non-protocol exit 2

### DIFF
--- a/.claude/hooks/work-check.py
+++ b/.claude/hooks/work-check.py
@@ -21,6 +21,7 @@ sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
 # Add hooks directory to path for shared module import
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from crosslink_config import (
+    find_crosslink_binary,
     find_crosslink_dir,
     is_agent_context,
     load_config_merged,
@@ -278,7 +279,7 @@ def check_control_flags(crosslink_dir):
     import subprocess
     try:
         proc = subprocess.run(
-            ["crosslink", "agent", "flags", "--strict"],
+            [find_crosslink_binary(crosslink_dir), "agent", "flags", "--strict"],
             capture_output=True,
             text=True,
             cwd=crosslink_dir,
@@ -288,38 +289,44 @@ def check_control_flags(crosslink_dir):
         # crosslink not on PATH or hung — fail open (don't block) so
         # missing tooling never wedges Claude Code.
         return
-    if proc.returncode == 0:
+    if proc.returncode != 2:
         return
-    if proc.returncode == 2:
-        try:
-            state = json.loads(proc.stdout.strip())
-        except (json.JSONDecodeError, ValueError):
-            state = {}
-        if state.get("kill"):
-            # GH#624: blocking messages MUST go to stderr — Claude Code only
-            # shows stderr to the model on exit 2; stdout is silently dropped.
-            print(
-                "AGENT KILL REQUESTED — an operator (dashboard or CLI) has "
-                "asked this agent to stop after the current tool use.\n"
-                "Acknowledge the request, summarise progress, then exit "
-                "your session cleanly. Do not attempt further tool calls.",
-                file=sys.stderr,
+    # clap also exits 2 for usage errors (e.g. a PATH binary too old to
+    # know `agent flags`, GH#31). Only valid flag-state JSON on stdout is
+    # the flags protocol; anything else is not a pause/kill signal and
+    # must fail open so version skew never wedges Claude Code.
+    try:
+        state = json.loads(proc.stdout.strip())
+    except (json.JSONDecodeError, ValueError):
+        return
+    if not isinstance(state, dict):
+        return
+    if state.get("kill"):
+        # GH#624: blocking messages MUST go to stderr — Claude Code only
+        # shows stderr to the model on exit 2; stdout is silently dropped.
+        print(
+            "AGENT KILL REQUESTED — an operator (dashboard or CLI) has "
+            "asked this agent to stop after the current tool use.\n"
+            "Acknowledge the request, summarise progress, then exit "
+            "your session cleanly. Do not attempt further tool calls.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    if state.get("paused") or state.get("reprioritise"):
+        hint = state.get("reprioritise")
+        extra = ""
+        if hint:
+            extra = (
+                f"\nReprioritise hint pending: switch focus to issue "
+                f"#{hint.get('issue_id')} when resuming."
             )
-        else:
-            hint = state.get("reprioritise")
-            extra = ""
-            if hint:
-                extra = (
-                    f"\nReprioritise hint pending: switch focus to issue "
-                    f"#{hint.get('issue_id')} when resuming."
-                )
-            print(
-                "AGENT PAUSED — an operator has paused this agent via the "
-                "dashboard. Tool use is blocked until they resume.\n"
-                "Wait for the resume signal or explain to the user that "
-                "you've been paused." + extra,
-                file=sys.stderr,
-            )
+        print(
+            "AGENT PAUSED — an operator has paused this agent via the "
+            "dashboard. Tool use is blocked until they resume.\n"
+            "Wait for the resume signal or explain to the user that "
+            "you've been paused." + extra,
+            file=sys.stderr,
+        )
         sys.exit(2)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Claude hooks now resolve the crosslink binary via `find_crosslink_binary()`
+  instead of a bare PATH lookup (`work-check.py` control-flags check,
+  `heartbeat.py`, `session-start.py`), and `check_control_flags` fails open
+  unless stdout parses as flag-state JSON with a blocking flag actually set.
+  Previously, a PATH binary too old to know `agent flags` exited 2 with a clap
+  usage error - the same exit code as the flags protocol - and every
+  Write/Edit/Bash call was blocked with a false "AGENT PAUSED - an operator
+  has paused this agent" message (gh#31).
 - `crosslink sync` / `crosslink init` no longer fail on Git < 2.42.0 (e.g.
   Ubuntu 22.04 LTS, which ships Git 2.34.1) with `unknown option 'orphan'`.
   Hub-v3 and knowledge cache setup used `git worktree add --orphan` (added in

--- a/crosslink/resources/claude/hooks/heartbeat.py
+++ b/crosslink/resources/claude/hooks/heartbeat.py
@@ -14,6 +14,10 @@ import subprocess
 import sys
 import time
 
+# Add hooks directory to path for shared module import
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from crosslink_config import find_crosslink_binary
+
 HEARTBEAT_INTERVAL_SECONDS = 120  # 2 minutes
 
 
@@ -68,7 +72,7 @@ def main():
     # Push heartbeat in background (don't block the tool call)
     try:
         subprocess.Popen(
-            ["crosslink", "heartbeat"],
+            [find_crosslink_binary(crosslink_dir), "heartbeat"],
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )

--- a/crosslink/resources/claude/hooks/session-start.py
+++ b/crosslink/resources/claude/hooks/session-start.py
@@ -10,16 +10,25 @@ import sys
 import os
 from datetime import datetime, timezone
 
+# Add hooks directory to path for shared module import
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from crosslink_config import find_crosslink_binary, find_crosslink_dir
+
 
 # Sessions older than this (in hours) are considered stale and auto-ended
 STALE_SESSION_HOURS = 4
 
+_crosslink_bin = None
+
 
 def run_crosslink(args):
     """Run a crosslink command and return output."""
+    global _crosslink_bin
+    if _crosslink_bin is None:
+        _crosslink_bin = find_crosslink_binary(find_crosslink_dir())
     try:
         result = subprocess.run(
-            ["crosslink"] + args,
+            [_crosslink_bin] + args,
             capture_output=True,
             text=True,
             timeout=5

--- a/crosslink/resources/claude/hooks/work-check.py
+++ b/crosslink/resources/claude/hooks/work-check.py
@@ -21,6 +21,7 @@ sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
 # Add hooks directory to path for shared module import
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from crosslink_config import (
+    find_crosslink_binary,
     find_crosslink_dir,
     is_agent_context,
     load_config_merged,
@@ -278,7 +279,7 @@ def check_control_flags(crosslink_dir):
     import subprocess
     try:
         proc = subprocess.run(
-            ["crosslink", "agent", "flags", "--strict"],
+            [find_crosslink_binary(crosslink_dir), "agent", "flags", "--strict"],
             capture_output=True,
             text=True,
             cwd=crosslink_dir,
@@ -288,38 +289,44 @@ def check_control_flags(crosslink_dir):
         # crosslink not on PATH or hung — fail open (don't block) so
         # missing tooling never wedges Claude Code.
         return
-    if proc.returncode == 0:
+    if proc.returncode != 2:
         return
-    if proc.returncode == 2:
-        try:
-            state = json.loads(proc.stdout.strip())
-        except (json.JSONDecodeError, ValueError):
-            state = {}
-        if state.get("kill"):
-            # GH#624: blocking messages MUST go to stderr — Claude Code only
-            # shows stderr to the model on exit 2; stdout is silently dropped.
-            print(
-                "AGENT KILL REQUESTED — an operator (dashboard or CLI) has "
-                "asked this agent to stop after the current tool use.\n"
-                "Acknowledge the request, summarise progress, then exit "
-                "your session cleanly. Do not attempt further tool calls.",
-                file=sys.stderr,
+    # clap also exits 2 for usage errors (e.g. a PATH binary too old to
+    # know `agent flags`, GH#31). Only valid flag-state JSON on stdout is
+    # the flags protocol; anything else is not a pause/kill signal and
+    # must fail open so version skew never wedges Claude Code.
+    try:
+        state = json.loads(proc.stdout.strip())
+    except (json.JSONDecodeError, ValueError):
+        return
+    if not isinstance(state, dict):
+        return
+    if state.get("kill"):
+        # GH#624: blocking messages MUST go to stderr — Claude Code only
+        # shows stderr to the model on exit 2; stdout is silently dropped.
+        print(
+            "AGENT KILL REQUESTED — an operator (dashboard or CLI) has "
+            "asked this agent to stop after the current tool use.\n"
+            "Acknowledge the request, summarise progress, then exit "
+            "your session cleanly. Do not attempt further tool calls.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    if state.get("paused") or state.get("reprioritise"):
+        hint = state.get("reprioritise")
+        extra = ""
+        if hint:
+            extra = (
+                f"\nReprioritise hint pending: switch focus to issue "
+                f"#{hint.get('issue_id')} when resuming."
             )
-        else:
-            hint = state.get("reprioritise")
-            extra = ""
-            if hint:
-                extra = (
-                    f"\nReprioritise hint pending: switch focus to issue "
-                    f"#{hint.get('issue_id')} when resuming."
-                )
-            print(
-                "AGENT PAUSED — an operator has paused this agent via the "
-                "dashboard. Tool use is blocked until they resume.\n"
-                "Wait for the resume signal or explain to the user that "
-                "you've been paused." + extra,
-                file=sys.stderr,
-            )
+        print(
+            "AGENT PAUSED — an operator has paused this agent via the "
+            "dashboard. Tool use is blocked until they resume.\n"
+            "Wait for the resume signal or explain to the user that "
+            "you've been paused." + extra,
+            file=sys.stderr,
+        )
         sys.exit(2)
 
 

--- a/crosslink/src/commands/migrate_hub_v3.rs
+++ b/crosslink/src/commands/migrate_hub_v3.rs
@@ -466,13 +466,10 @@ fn github_branches_url(cache_dir: &Path, remote: &str) -> Option<String> {
     }
     let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
     // git@github.com:owner/repo.git  OR  https://github.com/owner/repo(.git)
-    let slug = if let Some(rest) = url.strip_prefix("git@github.com:") {
-        rest.to_string()
-    } else if let Some(rest) = url.strip_prefix("https://github.com/") {
-        rest.to_string()
-    } else {
-        return None;
-    };
+    let slug = url
+        .strip_prefix("git@github.com:")
+        .or_else(|| url.strip_prefix("https://github.com/"))?
+        .to_string();
     let slug = slug.strip_suffix(".git").unwrap_or(&slug);
     Some(format!("https://github.com/{slug}/branches"))
 }

--- a/crosslink/src/knowledge/core.rs
+++ b/crosslink/src/knowledge/core.rs
@@ -541,8 +541,8 @@ pub fn serialize_frontmatter(fm: &PageFrontmatter) -> String {
         let _ = writeln!(out, "contributors: [{}]", escaped_contribs.join(", "));
     }
 
-    let _ = writeln!(out, "created: {}", &fm.created);
-    let _ = writeln!(out, "updated: {}", &fm.updated);
+    let _ = writeln!(out, "created: {}", fm.created);
+    let _ = writeln!(out, "updated: {}", fm.updated);
     out.push_str("---\n");
 
     out

--- a/crosslink/src/seam.rs
+++ b/crosslink/src/seam.rs
@@ -319,11 +319,8 @@ fn extract_mod_name(line: &str) -> Option<String> {
     // Remove visibility qualifiers.
     let rest = if line.starts_with("pub(") {
         // pub(crate) mod foo, pub(super) mod foo, etc.
-        if let Some(idx) = line.find(')') {
-            line[idx + 1..].trim()
-        } else {
-            return None;
-        }
+        let idx = line.find(')')?;
+        line[idx + 1..].trim()
     } else if let Some(rest) = line.strip_prefix("pub ") {
         rest.trim()
     } else {


### PR DESCRIPTION
## Summary

Fixes #31.

The shipped Claude hooks invoked bare `crosslink` from PATH in three places, bypassing the `crosslink_binary` config override and dev-build fallback that `find_crosslink_binary()` provides. The blocking variant: `check_control_flags()` in `work-check.py` ran `crosslink agent flags --strict` against whatever PATH served — with a binary too old to know `agent flags` (e.g. 0.8.0 from crates.io), clap exits 2 for the unknown subcommand, the hook read exit 2 as "blocking flags set", the JSON parse failure collapsed to `state = {}`, and every Write/Edit/Bash call was refused with a false "AGENT PAUSED — an operator has paused this agent via the dashboard" message. Because the pause check runs before the allow-list, the session was fully wedged.

## Changes

- `check_control_flags()` resolves the binary via `find_crosslink_binary(crosslink_dir)`, and treats exit 2 as pause/kill only when stdout parses as flag-state JSON with `kill`/`paused`/`reprioritise` actually set. Anything else is not the flags protocol and fails open, per the hook's existing "missing tooling never wedges Claude Code" policy.
- `heartbeat.py` and `session-start.py` get the same binary resolution for their bare-PATH invocations (silent misdirection rather than blocking, but the same defect class).
- The tracked `.claude/hooks/work-check.py` dogfood copy is kept byte-identical to the resource template.
- Changelog entry under Unreleased / Fixed.

## Testing

- `python3 -m py_compile` clean on all four modified hook files.
- Functional test loading the patched hook and driving `check_control_flags()` against fake binaries via temp `.crosslink` dirs with `crosslink_binary` overrides, 7 cases:
  - clap usage error (0.8.0 simulation), garbage stdout, and valid JSON with no blocking flags: all fail open;
  - genuine `paused`, `kill`, and `reprioritise` states: all still block with exit 2;
  - clean state (exit 0): passes.
- Live verification: reproduced the false AGENT PAUSED with 0.8.0 on PATH before the fix; with the fix, a real Claude Code session gates normally (blocks without an active issue, passes with one).

Generated with [Claude Code](https://claude.com/claude-code)
