### PR TITLE
fix: complete the v3 promotion path - to-shared via the event log, comment-id re-keying (gh#4 second half, gh#11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- `crosslink migrate to-shared` now works on v3 hubs (gh#4, second half). The
+  v2 body wrote worktree JSON and counters the reduction never reads, then
+  pushed the nonexistent legacy `crosslink/hub` ref ("src refspec does not
+  match any"). On v3 it now promotes SQLite-only issues (uuids the reduced
+  state does not know) through the event log via the same batch path
+  `import` uses - one commit, one hydration - preserving existing uuids (so
+  hydration replaces local rows in place instead of duplicating them) and
+  carrying free positive local ids into the reduction so local numbering
+  survives. Idempotent: already-promoted issues are skipped, so it doubles
+  as the recovery sweep for rows created before the hub was established.
+- Post-migrate `crosslink sync` no longer aborts with SQLite `Error code
+  1555: constraint failed` (gh#11). Preserved sqlite-only comments carry
+  positive v2/import-era ids while hydration inserts hub comments at frozen
+  positive display ids through a plain INSERT - a collision killed the whole
+  hydration transaction. The preservation restore now re-keys colliding
+  preserved comment ids to fresh negative local ids (comment ids are not FK
+  targets), mirroring the issue-id remap above it.
 - `crosslink create` / `quick` after a legacy `import` no longer silently lose
   the new issue while reporting success (#5, related #4). Three fixes:
   `crosslink import` on a v3 hub now promotes the whole batch through the

--- a/crosslink/src/commands/hub_v3_operation_tests.rs
+++ b/crosslink/src/commands/hub_v3_operation_tests.rs
@@ -1061,6 +1061,7 @@ fn v3_import_issues_promotes_batch_to_hub() {
                 kind: "note".to_string(),
             }],
             blockers: vec![],
+            display_id: None,
         },
         crate::shared_writer::ImportedIssueSpec {
             uuid: child_uuid,
@@ -1072,6 +1073,7 @@ fn v3_import_issues_promotes_batch_to_hub() {
             labels: vec![],
             comments: vec![],
             blockers: vec![parent_uuid],
+            display_id: None,
         },
     ];
 
@@ -1146,4 +1148,47 @@ fn v3_create_after_direct_sqlite_rows_keeps_both_issues() {
         "direct row remapped, got {}",
         direct_row.id
     );
+}
+
+#[test]
+fn v3_to_shared_promotes_sqlite_only_rows() {
+    if !git_ok() {
+        return;
+    }
+    let hub = setup_migrated_v3_hub();
+    let db = Database::open(&hub.crosslink_dir.join("issues.db")).unwrap();
+
+    // Direct-SQLite rows the hub does not know (the GH#4 stranded population).
+    let a = db.create_issue("direct A", None, "medium").unwrap();
+    let b = db.create_issue("direct B", None, "low").unwrap();
+    db.add_comment(a, "carried comment", "note").unwrap();
+
+    crate::commands::migrate::to_shared(&hub.crosslink_dir, &db).unwrap();
+
+    // Promoted into the reduced state with local numbering preserved.
+    let source = crate::hub_source::RefHubSource::new(&hub.cache_dir).unwrap();
+    let state = crate::compaction::reduce(&source).unwrap().state;
+    let ids: std::collections::HashSet<i64> =
+        state.issues.values().filter_map(|i| i.display_id).collect();
+    assert!(
+        ids.contains(&a) && ids.contains(&b),
+        "promoted with preserved local ids"
+    );
+    let titles: Vec<&str> = state.issues.values().map(|i| i.title.as_str()).collect();
+    assert!(titles.contains(&"direct A") && titles.contains(&"direct B"));
+
+    // Visible and hub-backed locally after the import's hydration.
+    assert!(db.get_issue(a).unwrap().is_some());
+    assert_eq!(
+        db.get_comments(a).unwrap().len(),
+        1,
+        "comment carried through promotion"
+    );
+
+    // Idempotent: a second run migrates nothing and changes nothing.
+    let before = state.issues.len();
+    crate::commands::migrate::to_shared(&hub.crosslink_dir, &db).unwrap();
+    let source2 = crate::hub_source::RefHubSource::new(&hub.cache_dir).unwrap();
+    let state2 = crate::compaction::reduce(&source2).unwrap().state;
+    assert_eq!(state2.issues.len(), before, "second to-shared is a no-op");
 }

--- a/crosslink/src/commands/import.rs
+++ b/crosslink/src/commands/import.rs
@@ -66,6 +66,7 @@ fn spec_from_issue_file(issue: &IssueFile) -> ImportedIssueSpec {
             })
             .collect(),
         blockers: issue.blockers.clone(),
+        display_id: None,
     }
 }
 
@@ -105,6 +106,7 @@ fn specs_from_legacy(data: &ExportData) -> Vec<ImportedIssueSpec> {
                 })
                 .collect(),
             blockers: Vec::new(),
+            display_id: None,
         })
         .collect()
 }

--- a/crosslink/src/commands/migrate.rs
+++ b/crosslink/src/commands/migrate.rs
@@ -31,6 +31,14 @@ pub fn to_shared(crosslink_dir: &Path, db: &Database) -> Result<()> {
     sync.init_cache()?;
     sync.fetch()?;
 
+    // GH#4 (second half): on a v3 hub the v2 body below writes worktree JSON
+    // and counters the reduction never reads, then pushes the nonexistent
+    // legacy `crosslink/hub` ref ("src refspec does not match any"). Route
+    // the migration through the event log instead.
+    if sync.hub_mode().is_v3() {
+        return to_shared_v3(crosslink_dir, db, &sync);
+    }
+
     let cache_dir = sync.cache_path().to_path_buf();
     let issues_dir = cache_dir.join("issues");
     let meta_dir = cache_dir.join("meta");
@@ -305,6 +313,152 @@ fn git_in_dir(dir: &Path, args: &[&str]) -> Result<std::process::Output> {
 }
 
 use anyhow::Context;
+
+/// V3 analogue of `to_shared` (GH#4): promote SQLite-only issues — rows whose
+/// uuid the reduced state does not know — through the event log in a single
+/// commit, via the same batch path `crosslink import` uses. Idempotent:
+/// already-promoted issues are skipped, so it can be re-run to sweep up rows
+/// created before the hub was established.
+fn to_shared_v3(crosslink_dir: &Path, db: &Database, sync: &SyncManager) -> Result<()> {
+    let source = crate::hub_source::RefHubSource::new(sync.cache_path())
+        .map_err(|e| anyhow::anyhow!("v3: construct RefHubSource for to-shared: {e}"))?;
+    let outcome = crate::compaction::reduce(&source)
+        .map_err(|e| anyhow::anyhow!("v3: reduce for to-shared: {e}"))?;
+    let state = outcome.state;
+
+    let hub_uuids: std::collections::HashSet<String> =
+        state.issues.keys().map(Uuid::to_string).collect();
+    let used_ids: std::collections::HashSet<i64> =
+        state.issues.values().filter_map(|i| i.display_id).collect();
+
+    let specs = specs_from_db(db, &hub_uuids, &used_ids)?;
+    if specs.is_empty() {
+        println!("No SQLite-only issues to migrate - the hub already covers the local database.");
+        return Ok(());
+    }
+
+    let writer = crate::shared_writer::SharedWriter::new(crosslink_dir)?.ok_or_else(|| {
+        anyhow::anyhow!(
+            "v3 migration needs an initialized shared writer (agent identity and hub cache)"
+        )
+    })?;
+    let assigned = writer.import_issues(db, &specs)?;
+    println!(
+        "Migrated {} issue(s) to the v3 hub event log.",
+        assigned.len()
+    );
+    Ok(())
+}
+
+/// Build [`crate::shared_writer::ImportedIssueSpec`]s for every `SQLite` issue
+/// the hub does not know. Existing uuids are preserved (so hydration replaces
+/// the local row in place instead of duplicating it); rows without a uuid get
+/// a fresh one. Positive local ids are carried into the reduction when free,
+/// preserving local numbering.
+fn specs_from_db(
+    db: &Database,
+    hub_uuids: &std::collections::HashSet<String>,
+    used_ids: &std::collections::HashSet<i64>,
+) -> Result<Vec<crate::shared_writer::ImportedIssueSpec>> {
+    struct Row {
+        id: i64,
+        uuid: Option<String>,
+        title: String,
+        description: Option<String>,
+        priority: String,
+        parent_id: Option<i64>,
+        status: String,
+    }
+
+    let rows: Vec<Row> = db
+        .conn
+        .prepare(
+            "SELECT id, uuid, title, description, priority, parent_id, status \
+             FROM issues ORDER BY id",
+        )?
+        .query_map([], |row| {
+            Ok(Row {
+                id: row.get(0)?,
+                uuid: row.get(1)?,
+                title: row.get(2)?,
+                description: row.get(3)?,
+                priority: row.get(4)?,
+                parent_id: row.get(5)?,
+                status: row.get(6)?,
+            })
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+
+    // id -> uuid over ALL rows (hub-backed parents/blockers resolve too).
+    let mut id_to_uuid: HashMap<i64, Uuid> = HashMap::new();
+    for row in &rows {
+        let uuid = row
+            .uuid
+            .as_deref()
+            .and_then(|u| u.parse::<Uuid>().ok())
+            .unwrap_or_else(Uuid::new_v4);
+        id_to_uuid.insert(row.id, uuid);
+    }
+
+    let mut specs = Vec::new();
+    for row in &rows {
+        let uuid = id_to_uuid[&row.id];
+        if hub_uuids.contains(&uuid.to_string()) {
+            continue; // already promoted
+        }
+
+        let comments = db
+            .conn
+            .prepare(
+                "SELECT author, content, created_at, kind FROM comments \
+                 WHERE issue_id = ?1 ORDER BY id",
+            )?
+            .query_map([row.id], |r| {
+                Ok((
+                    r.get::<_, Option<String>>(0)?,
+                    r.get::<_, String>(1)?,
+                    r.get::<_, String>(2)?,
+                    r.get::<_, String>(3)?,
+                ))
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?
+            .into_iter()
+            .map(
+                |(author, content, created_at, kind)| crate::shared_writer::ImportedCommentSpec {
+                    author: author.unwrap_or_else(|| "migrate".to_string()),
+                    content,
+                    created_at: created_at
+                        .parse::<chrono::DateTime<Utc>>()
+                        .unwrap_or_else(|_| Utc::now()),
+                    kind,
+                },
+            )
+            .collect();
+
+        let blockers: Vec<Uuid> = db
+            .conn
+            .prepare("SELECT blocker_id FROM dependencies WHERE blocked_id = ?1")?
+            .query_map([row.id], |r| r.get::<_, i64>(0))?
+            .collect::<std::result::Result<Vec<i64>, _>>()?
+            .into_iter()
+            .filter_map(|bid| id_to_uuid.get(&bid).copied())
+            .collect();
+
+        specs.push(crate::shared_writer::ImportedIssueSpec {
+            uuid,
+            title: row.title.clone(),
+            description: row.description.clone(),
+            priority: row.priority.clone(),
+            parent_uuid: row.parent_id.and_then(|pid| id_to_uuid.get(&pid).copied()),
+            closed: row.status == "closed",
+            labels: db.get_labels(row.id)?,
+            comments,
+            blockers,
+            display_id: (row.id > 0 && !used_ids.contains(&row.id)).then_some(row.id),
+        });
+    }
+    Ok(specs)
+}
 
 #[cfg(test)]
 mod tests {

--- a/crosslink/src/hub_v3_operation_tests.rs
+++ b/crosslink/src/hub_v3_operation_tests.rs
@@ -218,3 +218,58 @@ fn sample_compact_issue(
         time_entries: Default::default(),
     }
 }
+
+#[test]
+fn hydrate_from_state_rekeys_preserved_comment_colliding_with_frozen_comment_id() {
+    // GH#11: a preserved sqlite-only issue carries a comment at a positive
+    // v2-era id; the state hydrates a hub comment at the SAME frozen display
+    // id. insert_hydrated_comment is a plain INSERT, so before the re-keying
+    // this aborted all of hydrate_from_state with
+    // SQLITE_CONSTRAINT_PRIMARYKEY (error 1555) - the post-migrate sync
+    // failure. Both comments must survive.
+    let db = Database::open(Path::new(":memory:")).unwrap();
+    let local = db.create_issue("local with comment", None, "low").unwrap();
+    let local_comment = db.add_comment(local, "local words", "note").unwrap();
+    assert!(local_comment > 0, "v2-era comment ids are positive");
+
+    let mut state = crate::checkpoint::CheckpointState::default();
+    let uuid = uuid::Uuid::new_v4();
+    let hub_id = local + 1; // no issue-id collision: isolate the comment one
+    state.display_id_map.insert(uuid, hub_id);
+    let mut issue = sample_compact_issue(uuid, hub_id, "hub issue");
+    issue.comments.insert(
+        uuid::Uuid::new_v4(),
+        crate::checkpoint::CompactComment {
+            display_id: Some(local_comment),
+            author: "alpha".to_string(),
+            content: "hub words".to_string(),
+            created_at: chrono::Utc::now(),
+            kind: "note".to_string(),
+            trigger_type: None,
+            intervention_context: None,
+            driver_key_fingerprint: None,
+            signed_by: None,
+            signature: None,
+        },
+    );
+    state.issues.insert(uuid, issue);
+
+    let stats = crate::hydration::hydrate_from_state(&state, &db).unwrap();
+    assert_eq!(stats.issues, 2, "hub issue plus preserved local issue");
+
+    let hub_comments = db.get_comments(hub_id).unwrap();
+    assert_eq!(hub_comments.len(), 1);
+    assert_eq!(hub_comments[0].content, "hub words");
+    assert_eq!(
+        hub_comments[0].id, local_comment,
+        "hub comment keeps its frozen display id"
+    );
+
+    let local_comments = db.get_comments(local).unwrap();
+    assert_eq!(local_comments.len(), 1, "preserved comment survives");
+    assert_eq!(local_comments[0].content, "local words");
+    assert!(
+        local_comments[0].id < 0,
+        "preserved comment re-keyed to a negative local id"
+    );
+}

--- a/crosslink/src/hydration.rs
+++ b/crosslink/src/hydration.rs
@@ -969,6 +969,24 @@ fn restore_sqlite_only_issues(
     for (issue_id, label) in &saved_children.labels {
         db.insert_hydrated_label(mapped(*issue_id), label)?;
     }
+    // GH#11: comment PKs collide the same way issue ids do — preserved
+    // comments carry positive v2/import-era ids while the pass above inserts
+    // hub comments at frozen positive display ids. insert_hydrated_comment
+    // is a plain INSERT, so a collision aborts the whole hydration
+    // transaction with SQLITE_CONSTRAINT_PRIMARYKEY (error 1555): the
+    // post-migrate "sync cannot complete" failure. Re-key colliding
+    // preserved comment ids to fresh negative ids — comment ids are not
+    // FK targets, so only the PK itself moves.
+    let occupied_comments = occupied_comment_ids(db)?;
+    let mut next_comment_local = occupied_comments
+        .iter()
+        .copied()
+        .chain(saved_children.comments.iter().map(|c| c.0))
+        .min()
+        .unwrap_or(0)
+        .min(0)
+        - 1;
+    let mut comment_collisions: Vec<i64> = Vec::new();
     for (
         id,
         issue_id,
@@ -982,8 +1000,16 @@ fn restore_sqlite_only_issues(
         driver_key_fingerprint,
     ) in &saved_children.comments
     {
+        let comment_id = if occupied_comments.contains(id) {
+            let re_keyed = next_comment_local;
+            next_comment_local -= 1;
+            comment_collisions.push(*id);
+            re_keyed
+        } else {
+            *id
+        };
         db.insert_hydrated_comment(
-            *id,
+            comment_id,
             mapped(*issue_id),
             uuid.as_deref(),
             author.as_deref(),
@@ -995,6 +1021,15 @@ fn restore_sqlite_only_issues(
             driver_key_fingerprint.as_deref(),
         )?;
         stats.comments += 1;
+    }
+    if !comment_collisions.is_empty() {
+        comment_collisions.sort_unstable();
+        tracing::warn!(
+            "hydration: {} preserved comment(s) collide with hub-assigned comment id(s) \
+             {:?}; re-keyed to negative local ids so hydration does not abort (GH#11)",
+            comment_collisions.len(),
+            comment_collisions
+        );
     }
     for (blocker_id, blocked_id) in &saved_children.deps {
         db.insert_dependency_raw(mapped(*blocker_id), mapped(*blocked_id))?;
@@ -1018,6 +1053,18 @@ fn restore_sqlite_only_issues(
     }
 
     Ok(())
+}
+
+/// All comment ids currently present in `SQLite` (the hub-derived comment
+/// rows inserted earlier in this hydration pass). The restore pass must not
+/// re-insert a preserved comment at an id the hub already occupies (GH#11).
+fn occupied_comment_ids(db: &Database) -> Result<std::collections::HashSet<i64>> {
+    let ids = db
+        .conn
+        .prepare("SELECT id FROM comments")?
+        .query_map([], |row| row.get(0))?
+        .collect::<std::result::Result<std::collections::HashSet<i64>, _>>()?;
+    Ok(ids)
 }
 
 /// All issue ids currently present in `SQLite` (the hub-derived rows inserted

--- a/crosslink/src/shared_writer/mutations.rs
+++ b/crosslink/src/shared_writer/mutations.rs
@@ -40,6 +40,10 @@ pub struct ImportedIssueSpec {
     /// Uuids of issues blocking this one (dangling references are skipped by
     /// the reduction).
     pub blockers: Vec<Uuid>,
+    /// Carry an existing display id into the reduction (GH#4 to-shared:
+    /// preserves local numbering when promoting SQLite-only rows). `None`
+    /// lets the reduction assign the next free id, as `import` does.
+    pub display_id: Option<i64>,
 }
 
 /// A comment carried by an [`ImportedIssueSpec`].
@@ -280,7 +284,7 @@ impl SharedWriter {
                 labels: spec.labels.clone(),
                 parent_uuid: spec.parent_uuid,
                 created_by: self.agent.agent_id.clone(),
-                display_id: None,
+                display_id: spec.display_id,
                 scheduled_at: None,
                 due_at: None,
             });


### PR DESCRIPTION
Fixes #11. Completes #4 (the `migrate to-shared` half; the import half merged in #6).

Based directly on #6's merged machinery, hence targeting `main` (like #6 itself): the `to-shared` fix routes through `SharedWriter::import_issues`, which `develop` has not received yet. Two commits:

## gh#11 — post-migrate `sync` aborts with SQLite error 1555 (`1431cbfe`)

Preserved sqlite-only comments carry positive v2/import-era ids while `hydrate_from_state` inserts hub comments at frozen positive display ids through a plain `INSERT` — a collision killed the entire hydration transaction with `SQLITE_CONSTRAINT_PRIMARYKEY`, leaving a just-migrated hub unable to sync (the #11 reproduction pairs a v2-era comment with post-migration mutations). The preservation restore now re-keys colliding preserved comment ids to fresh negative local ids, mirroring the issue-id remap #6 introduced directly above it; comment ids are not FK targets, so only the PK moves, and a WARN lists the collisions. Regression test: `hydrate_from_state_rekeys_preserved_comment_colliding_with_frozen_comment_id`.

## gh#4 (second half) — `migrate to-shared` on v3 hubs (`1e912b00`)

`to_shared` wrote v2 worktree JSON and counters the reduction never reads, then pushed the nonexistent legacy `crosslink/hub` ref. It now branches on `SyncManager::hub_mode()` before any v2 worktree writes; the v3 path promotes SQLite-only issues (uuids the reduced state does not know) through `import_issues` — one commit, one hydration. Existing uuids are preserved so hydration replaces local rows in place instead of duplicating them, and free positive local ids are carried into the reduction via a new `ImportedIssueSpec::display_id` field (`assign_issue_display_id` already honors carried ids; `import` keeps passing `None`, so its behavior is unchanged). Idempotent: already-promoted issues are skipped, which makes the command double as the recovery sweep for rows created before the hub was established. E2e test: `v3_to_shared_promotes_sqlite_only_rows` (promotes direct-SQLite rows with preserved numbering and carried comments; a second run is a no-op).

## Note for the develop sync

`develop` (via #35) added a uuid-dedup guard inside the same `restore_sqlite_only_issues` comment loop this PR's re-key touches. The two compose — the guard skips same-uuid duplicates, the re-key handles surviving different-uuid numeric collisions — but the eventual `develop`/`main` sync will hit a small textual conflict in that loop; the resolved form is: uuid-guard `continue` first, then the id re-key on whatever survives.

## Testing

- New regression tests above, plus all of #6's tests green on top of these changes (18 lib + 33 bin across the two v3 suites).
- `cargo clippy -- -D warnings -W clippy::unwrap_used -W clippy::expect_used` clean (the CI lint job command); `cargo fmt --check` clean.
- Full-suite caveats as documented in #34: dashboard tests need `GIT_TERMINAL_PROMPT=0 GIT_ASKPASS=/usr/bin/false` locally, and the two bootstrap tests fail on hosts without an unconditional global git identity.

Authored by Claude Code on behalf of @magnificentlycursed.

Generated with [Claude Code](https://claude.com/claude-code)
