### PR TITLE
fix: v3 completeness - dashboard v3-awareness and the finalize seeded-genesis guard (gh#4, gh#45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- `migrate hub-v3 --finalize` no longer refuses after legitimate post-migration
+  hub use (gh#45). The finalize gate reused the migration-time invariant
+  (`reduce(current refs) == genesis`), which only holds in the instant after
+  seeding - a single lock release, or even the dispatcher's own v3 fetch
+  advancing the checkpoint ref, permanently blocked the cutover with a
+  misleading "v2 and v3 no longer agree". Migration now persists the seeded
+  genesis checkpoint commit and per-agent seed tips in `HubMeta` (serde-default
+  fields, compatible both directions), and finalize verifies what actually
+  gates safe v2 deletion: the v2 files still reproduce the SEEDED genesis
+  (content-addressed at the recorded commit), every seed tip remains an
+  ancestor of its ref (ancestry, not byte-prefix, so compaction and REQ-11
+  pruning never false-fail), and reducing AT the seeded tips reproduces the
+  genesis. Hubs migrated before the metadata existed fall back to the strict
+  check with an actionable `--remigrate-from-v2` message.
 - `crosslink integrity` no longer false-FAILs `counters` and `hydration` on a
   v3 hub. Both checks read legacy v2 worktree artifacts (meta/counters.json,
   issues/*.json) that v3 never materializes, fabricating "next_display_id is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- The dashboard is v3-aware (gh#4, final symptom): migrated+finalized repos no
+  longer surface as `unreachable_project`. The poll fetch uses the
+  `+refs/heads/crosslink/*` glob (the exact v2-only refspec failed every tick
+  against migrated remotes, so v3 refs never became local and the
+  already-mode-routed reader saw nothing), the v2 hub-cache worktree
+  materialization and the post-action `reset --hard crosslink/hub` are gated
+  off on v3, tile freshness (`hub_sha`/`last_commit_at`) keys off the
+  checkpoint ref, GitHub org discovery falls back to probing the
+  `crosslink/checkpoint` branch, the track-time hub check recognizes v3
+  markers (local refs only), `GET /api/v1/sync/status` names the mode's
+  actual hub ref, and hub signature verification checks the checkpoint tip
+  on v3 instead of the nonexistent `locks.json` history.
 - `migrate hub-v3 --finalize` no longer refuses after legitimate post-migration
   hub use (gh#45). The finalize gate reused the migration-time invariant
   (`reduce(current refs) == genesis`), which only holds in the instant after

--- a/crosslink/src/commands/hub_v3_operation_tests.rs
+++ b/crosslink/src/commands/hub_v3_operation_tests.rs
@@ -784,6 +784,26 @@ fn v3_dashboard_reader_reroutes_to_refs() {
     );
     let snap = crate::dashboard::reader::read_snapshot(&hub.cache_dir).unwrap();
 
+    // GH#4: freshness keys off the checkpoint ref on v3 — with the old
+    // `crosslink/hub` keys these were permanently None on migrated repos,
+    // deadening tile freshness and alert subjects.
+    let ckpt_out = Command::new("git")
+        .current_dir(&hub.cache_dir)
+        .args(["rev-parse", crate::hub_v3::CHECKPOINT_REF])
+        .output()
+        .unwrap();
+    assert!(ckpt_out.status.success());
+    let ckpt_tip = String::from_utf8_lossy(&ckpt_out.stdout).trim().to_string();
+    assert_eq!(
+        snap.hub_sha.as_deref(),
+        Some(ckpt_tip.as_str()),
+        "v3 snapshot hub_sha must be the checkpoint tip"
+    );
+    assert!(
+        snap.last_commit_at.is_some(),
+        "v3 snapshot must carry checkpoint freshness"
+    );
+
     assert_eq!(snap.layout_version, 3, "v3 hub reports layout version 3");
     assert!(
         snap.issues.iter().any(|i| i.title == "First issue"),

--- a/crosslink/src/commands/migrate_hub_v3.rs
+++ b/crosslink/src/commands/migrate_hub_v3.rs
@@ -1024,6 +1024,9 @@ fn seed_v3_refs(cache_dir: &Path, genesis: &CheckpointState, v2_tip: &str) -> Re
     //    dual-write parity invariant; child-commit over any existing shadow tip).
     let agents_dir = cache_dir.join("agents");
     let mut agents = Vec::new();
+    // GH#45: record each seeded tip so finalize can verify the seed is still
+    // an ancestor of every ref instead of demanding the hub was never used.
+    let mut seed_agent_tips = std::collections::BTreeMap::new();
     if agents_dir.exists() {
         for entry in std::fs::read_dir(&agents_dir)
             .with_context(|| format!("failed to read agents dir {}", agents_dir.display()))?
@@ -1044,13 +1047,14 @@ fn seed_v3_refs(cache_dir: &Path, genesis: &CheckpointState, v2_tip: &str) -> Re
             if log_bytes.is_empty() {
                 continue;
             }
-            hub_v3::commit_log_bytes(
+            let seed_sha = hub_v3::commit_log_bytes(
                 cache_dir,
                 &agent_id,
                 &log_bytes,
                 &format!("hub-v3 genesis: seed agent {agent_id} from v2 events.log"),
             )
             .with_context(|| format!("failed to seed agent ref for '{agent_id}'"))?;
+            seed_agent_tips.insert(agent_id.clone(), seed_sha);
             agents.push(agent_id);
         }
     }
@@ -1059,7 +1063,7 @@ fn seed_v3_refs(cache_dir: &Path, genesis: &CheckpointState, v2_tip: &str) -> Re
     // 2. Genesis checkpoint state.json onto CHECKPOINT_REF.
     let state_bytes = serde_json::to_vec_pretty(genesis)
         .context("failed to serialize genesis checkpoint state")?;
-    hub_v3::commit_blob_to_ref(
+    let genesis_checkpoint_commit = hub_v3::commit_blob_to_ref(
         cache_dir,
         CHECKPOINT_REF,
         "state.json",
@@ -1074,6 +1078,8 @@ fn seed_v3_refs(cache_dir: &Path, genesis: &CheckpointState, v2_tip: &str) -> Re
         migrated_from_commit: v2_tip.to_string(),
         migrated_at: Utc::now(),
         finalized_at: None,
+        genesis_checkpoint_commit: Some(genesis_checkpoint_commit),
+        seed_agent_tips: Some(seed_agent_tips),
     };
     let hub_json = serde_json::to_vec_pretty(&meta).context("failed to serialize HubMeta")?;
 
@@ -1424,6 +1430,139 @@ fn retry_push_missing_refs(cache_dir: &Path, remote: &str) -> Result<()> {
 
 // ── Phase B: finalize ────────────────────────────────────────────────
 
+/// `git merge-base --is-ancestor` — true when `ancestor_sha` is an ancestor of
+/// (or equal to) `descendant_rev`. Exit 1 means "not an ancestor"; other
+/// failures (unknown revision, plumbing errors) propagate.
+fn git_is_ancestor(repo_dir: &Path, ancestor_sha: &str, descendant_rev: &str) -> Result<bool> {
+    // Direct invocation, NOT run_git: exit 1 is the meaningful "not an
+    // ancestor" answer here, while run_git treats every nonzero exit as an
+    // error.
+    let out = Command::new("git")
+        .current_dir(repo_dir)
+        .args(["merge-base", "--is-ancestor", ancestor_sha, descendant_rev])
+        .output()
+        .with_context(|| {
+            format!("failed to run git merge-base --is-ancestor {ancestor_sha} {descendant_rev}")
+        })?;
+    match out.status.code() {
+        Some(0) => Ok(true),
+        Some(1) => Ok(false),
+        _ => bail!(
+            "git merge-base --is-ancestor {ancestor_sha} {descendant_rev} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        ),
+    }
+}
+
+/// Finalize-time verification (GH#45).
+///
+/// The migration-time gate ([`verify_against_files`]) demands
+/// `reduce(current refs) == genesis` — an invariant only true in the instant
+/// after seeding. Reused at finalize it meant ANY legitimate post-migration
+/// hub use (a single lock release; even the dispatcher's own v3 fetch, which
+/// advances the checkpoint ref) permanently blocked the cutover with a
+/// misleading "v2 and v3 no longer agree". Finalize instead verifies the two
+/// properties that actually gate safe v2 deletion:
+///
+/// 1. **v2 is still frozen**: the v2 worktree files reproduce the genesis
+///    persisted at migration (the `state.json` blob at
+///    `HubMeta.genesis_checkpoint_commit` — content-addressed and durable,
+///    unlike the moving checkpoint ref).
+/// 2. **The seed is intact**: every tip recorded at seeding is still an
+///    ancestor of its ref (ancestry, not byte-prefix, so compaction and
+///    REQ-11 pruning never false-fail), and reducing AT the seeded tips
+///    reproduces the genesis exactly. Events above the watermark are
+///    expected and irrelevant.
+///
+/// Hubs migrated before the seed metadata existed fall back to the old
+/// strict check; when that fails the error steers to `--remigrate-from-v2`,
+/// which re-seeds and records the metadata.
+fn verify_finalize(cache_dir: &Path) -> Result<()> {
+    let meta = read_hub_meta(cache_dir)?
+        .ok_or_else(|| anyhow::anyhow!("v3 meta marker missing during finalize"))?;
+
+    let (Some(genesis_ckpt), Some(seed_tips)) =
+        (meta.genesis_checkpoint_commit, meta.seed_agent_tips)
+    else {
+        // Pre-GH#45 migration: no persisted seed metadata, so the strict
+        // full check is the only verification available. It passes iff the
+        // hub was never used since migration.
+        let genesis = build_genesis_from_files(cache_dir)?;
+        return verify_against_files(cache_dir, &genesis)
+            .map(|_| ())
+            .context(
+                "refusing to finalize: this hub was migrated before seed metadata was \
+                 recorded, and the strict re-verification failed (any post-migration hub \
+                 use fails it). Run `crosslink migrate hub-v3 --remigrate-from-v2` to \
+                 re-seed with metadata, then finalize immediately",
+            );
+    };
+
+    // The persisted genesis: content-addressed at the seeded checkpoint commit.
+    let spec = format!("{genesis_ckpt}:state.json");
+    let bytes = git_cat_file_blob_optional(cache_dir, &spec)?.ok_or_else(|| {
+        anyhow::anyhow!(
+            "refusing to finalize: the seeded genesis commit {genesis_ckpt} has no state.json \
+             (missing or corrupt object)"
+        )
+    })?;
+    let genesis = CheckpointState::from_slice(&bytes)
+        .context("refusing to finalize: persisted genesis state.json does not parse")?;
+    let genesis_val = serde_json::to_value(&genesis).context("serialize persisted genesis")?;
+
+    // (1) v2 frozen: the files still reproduce the seeded genesis.
+    let rebuilt = build_genesis_from_files(cache_dir)?;
+    if serde_json::to_value(&rebuilt).context("serialize rebuilt genesis")? != genesis_val {
+        bail!(
+            "refusing to finalize: the v2 hub files no longer reproduce the genesis seeded at \
+             migration — the v2 branch changed after migration (a pre-v3 binary kept \
+             writing?). Run `crosslink migrate hub-v3 --remigrate-from-v2` to adopt the newer \
+             v2 state, then finalize immediately."
+        );
+    }
+
+    // (2) seed intact: every recorded tip is still an ancestor of its ref.
+    if !git_is_ancestor(cache_dir, &genesis_ckpt, CHECKPOINT_REF)? {
+        bail!(
+            "refusing to finalize: the seeded genesis checkpoint {genesis_ckpt} is no longer \
+             an ancestor of {CHECKPOINT_REF} (force-reset or tampering). Run `crosslink \
+             migrate hub-v3 --remigrate-from-v2`, then finalize immediately."
+        );
+    }
+    for (agent_id, seed_sha) in &seed_tips {
+        let ref_name = format!("{}{agent_id}", crate::hub_v3::AGENT_REF_PREFIX);
+        if !git_is_ancestor(cache_dir, seed_sha, &ref_name)? {
+            bail!(
+                "refusing to finalize: agent '{agent_id}''s seeded tip {seed_sha} is no \
+                 longer an ancestor of {ref_name} (deleted, force-reset, or tampered). Run \
+                 `crosslink migrate hub-v3 --remigrate-from-v2`, then finalize immediately."
+            );
+        }
+    }
+
+    // (3) bounded AC-6: reduce AT the seeded tips must reproduce the genesis.
+    let meta_sha = crate::hub_v3::git_rev_parse_optional(cache_dir, META_REF)?;
+    let source = RefHubSource::at_tips(
+        cache_dir,
+        Some(genesis_ckpt),
+        meta_sha,
+        seed_tips
+            .iter()
+            .map(|(a, s)| (a.clone(), s.clone()))
+            .collect(),
+    )?;
+    let outcome = compaction::reduce(&source).context("reduce at seeded tips")?;
+    if serde_json::to_value(&outcome.state).context("serialize seeded reduce")? != genesis_val {
+        bail!(
+            "refusing to finalize: reducing the seeded refs does not reproduce the persisted \
+             genesis (seeded history altered — object corruption or ref surgery). Run \
+             `crosslink migrate hub-v3 --remigrate-from-v2`, then finalize immediately."
+        );
+    }
+
+    Ok(())
+}
+
 fn finalize_migration(
     cache_dir: &Path,
     remote: &str,
@@ -1474,11 +1613,11 @@ fn finalize_migration(
     // root (which shares the same object store + ref namespace).
     let repo_root = git_main_repo_root(cache_dir)?;
 
-    // Re-verify the AC-6 gate against the current refs/files: v2 and v3 must
-    // still agree. (fetch already ran in the dispatcher.)
-    let genesis = build_genesis_from_files(cache_dir)?;
-    verify_against_files(cache_dir, &genesis)
-        .context("refusing to finalize: AC-6 re-verification failed; v2 and v3 no longer agree")?;
+    // Finalize-time verification (GH#45): verify against the SEEDED genesis
+    // persisted in HubMeta, not the moving tips — legitimate post-migration
+    // hub use must never block the cutover. (fetch already ran in the
+    // dispatcher.)
+    verify_finalize(cache_dir)?;
 
     // Stamp HubMeta.finalized_at (new commit on META_REF preserving provenance)
     // BEFORE removing the worktree, while ref reads from cache_dir still work.
@@ -3232,5 +3371,191 @@ mod tests {
             ),
             "B must operate v3 after a forced adopt"
         );
+    }
+
+    // ── GH#45: finalize must tolerate legitimate post-migration activity ──
+
+    /// Append one post-genesis event to alpha's ref; returns the new issue uuid.
+    fn append_post_genesis_event(cache_dir: &Path) -> Uuid {
+        use crate::events::{Event, EventEnvelope};
+        let new_uuid = Uuid::new_v4();
+        let env = EventEnvelope {
+            agent_id: "alpha".to_string(),
+            agent_seq: 9999,
+            timestamp: Utc::now() + chrono::Duration::seconds(60),
+            event: Event::IssueCreated {
+                uuid: new_uuid,
+                title: "Post-genesis issue".to_string(),
+                description: None,
+                priority: "medium".to_string(),
+                labels: vec![],
+                parent_uuid: None,
+                created_by: "alpha".to_string(),
+                display_id: None,
+                scheduled_at: None,
+                due_at: None,
+            },
+            signed_by: None,
+            signature: None,
+        };
+        let tip = rev(cache_dir, &agent_ref_name("alpha").unwrap()).unwrap();
+        let mut bytes = git_cat_file_blob_optional(cache_dir, &format!("{tip}:events.log"))
+            .unwrap()
+            .unwrap();
+        bytes.extend_from_slice(serde_json::to_string(&env).unwrap().as_bytes());
+        bytes.push(b'\n');
+        hub_v3::commit_log_bytes(cache_dir, "alpha", &bytes, "test: post-genesis event").unwrap();
+        new_uuid
+    }
+
+    /// Rewrite hub.json without the GH#45 seed metadata (pre-fix migration).
+    fn strip_seed_metadata(cache_dir: &Path) {
+        let mut meta = read_hub_meta(cache_dir).unwrap().unwrap();
+        meta.genesis_checkpoint_commit = None;
+        meta.seed_agent_tips = None;
+        let hub_json = serde_json::to_vec_pretty(&meta).unwrap();
+        let files: Vec<(&str, &[u8])> = vec![("hub.json", &hub_json)];
+        hub_v3::commit_files_to_ref(cache_dir, META_REF, &files, "test: strip seed metadata")
+            .unwrap();
+    }
+
+    #[test]
+    fn finalize_succeeds_after_post_migration_v3_activity() {
+        let (_w, _r, crosslink_dir, cache_dir) = setup_v2_hub();
+        hub_v3(&crosslink_dir, false, false, false, false).unwrap();
+
+        // Seed metadata persisted at migration.
+        let meta = read_hub_meta(&cache_dir).unwrap().unwrap();
+        assert!(
+            meta.genesis_checkpoint_commit.is_some(),
+            "genesis commit recorded"
+        );
+        assert!(
+            meta.seed_agent_tips.clone().unwrap().contains_key("alpha"),
+            "alpha seed tip recorded"
+        );
+
+        // Legitimate post-migration use: a new event above the watermark plus
+        // an advanced checkpoint (what the dispatcher's own fetch_v3 does).
+        append_post_genesis_event(&cache_dir);
+        let advanced = crate::compaction::reduce(&RefHubSource::new(&cache_dir).unwrap())
+            .unwrap()
+            .state;
+        let state_bytes = serde_json::to_vec_pretty(&advanced).unwrap();
+        hub_v3::commit_blob_to_ref(
+            &cache_dir,
+            CHECKPOINT_REF,
+            "state.json",
+            &state_bytes,
+            "test: advance checkpoint past genesis",
+        )
+        .unwrap();
+
+        // GH#45 regression: finalize must SUCCEED despite the activity.
+        let repo_root = wp_of(&crosslink_dir);
+        hub_v3(&crosslink_dir, true, true, false, false).unwrap();
+        assert!(
+            rev(&repo_root, V2_HUB_BRANCH).is_none(),
+            "v2 branch deleted"
+        );
+        let meta = read_hub_meta(&repo_root).unwrap().unwrap();
+        assert!(meta.finalized_at.is_some(), "finalized_at stamped");
+    }
+
+    #[test]
+    fn finalize_refuses_when_seed_ancestry_broken() {
+        let (_w, _r, crosslink_dir, cache_dir) = setup_v2_hub();
+        hub_v3(&crosslink_dir, false, false, false, false).unwrap();
+
+        // Tamper: point alpha's ref at unrelated history (the checkpoint tip),
+        // breaking ancestry with the recorded seed tip.
+        let alpha_ref = agent_ref_name("alpha").unwrap();
+        let ckpt = rev(&cache_dir, CHECKPOINT_REF).unwrap();
+        let out = Command::new("git")
+            .current_dir(&cache_dir)
+            .args(["update-ref", &alpha_ref, &ckpt])
+            .output()
+            .unwrap();
+        assert!(out.status.success());
+
+        let err = hub_v3(&crosslink_dir, true, true, false, false).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("no longer an ancestor") && msg.contains("remigrate-from-v2"),
+            "ancestry break must refuse with remigrate guidance, got: {msg}"
+        );
+        assert!(
+            rev(&cache_dir, V2_HUB_BRANCH).is_some(),
+            "v2 branch preserved"
+        );
+    }
+
+    #[test]
+    fn finalize_refuses_when_v2_files_changed_after_migration() {
+        let (_w, _r, crosslink_dir, cache_dir) = setup_v2_hub();
+        hub_v3(&crosslink_dir, false, false, false, false).unwrap();
+
+        // Same-tip v2 divergence: mutate a worktree issue file in place
+        // (uncommitted, so the explicit tip-divergence guard cannot see it).
+        let issues_dir = cache_dir.join("issues");
+        let entry = std::fs::read_dir(&issues_dir)
+            .unwrap()
+            .flatten()
+            .find(|e| e.path().join("issue.json").exists())
+            .expect("fixture has at least one issue file");
+        let p = entry.path().join("issue.json");
+        let mut v: serde_json::Value = serde_json::from_slice(&std::fs::read(&p).unwrap()).unwrap();
+        v["title"] = serde_json::Value::String("tampered after migration".into());
+        std::fs::write(&p, serde_json::to_vec_pretty(&v).unwrap()).unwrap();
+
+        let err = hub_v3(&crosslink_dir, true, true, false, false).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("no longer reproduce the genesis"),
+            "v2 file change must refuse via the frozen-check, got: {msg}"
+        );
+        assert!(
+            rev(&cache_dir, V2_HUB_BRANCH).is_some(),
+            "v2 branch preserved"
+        );
+    }
+
+    #[test]
+    fn finalize_pre_metadata_hub_unused_falls_back_and_succeeds() {
+        let (_w, _r, crosslink_dir, cache_dir) = setup_v2_hub();
+        hub_v3(&crosslink_dir, false, false, false, false).unwrap();
+        strip_seed_metadata(&cache_dir);
+
+        // Untouched hub: the strict fallback passes and finalize completes.
+        let repo_root = wp_of(&crosslink_dir);
+        hub_v3(&crosslink_dir, true, true, false, false).unwrap();
+        let meta = read_hub_meta(&repo_root).unwrap().unwrap();
+        assert!(meta.finalized_at.is_some(), "fallback finalize stamped");
+    }
+
+    #[test]
+    fn finalize_pre_metadata_hub_with_activity_steers_to_remigrate() {
+        let (_w, _r, crosslink_dir, cache_dir) = setup_v2_hub();
+        hub_v3(&crosslink_dir, false, false, false, false).unwrap();
+        strip_seed_metadata(&cache_dir);
+        append_post_genesis_event(&cache_dir);
+
+        let err = hub_v3(&crosslink_dir, true, true, false, false).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("remigrate-from-v2"),
+            "pre-metadata hub with activity must steer to remigrate, got: {msg}"
+        );
+
+        // Recovery: remigrate re-seeds (and records the metadata), then
+        // immediate finalize succeeds. The post-genesis v3-only event is
+        // dropped by remigrate per its documented semantics.
+        hub_v3(&crosslink_dir, false, false, false, true).unwrap();
+        let meta = read_hub_meta(&cache_dir).unwrap().unwrap();
+        assert!(
+            meta.genesis_checkpoint_commit.is_some(),
+            "remigrate records seed metadata"
+        );
+        hub_v3(&crosslink_dir, true, true, false, false).unwrap();
     }
 }

--- a/crosslink/src/dashboard/actions.rs
+++ b/crosslink/src/dashboard/actions.rs
@@ -206,8 +206,13 @@ pub async fn run_cli(
     // Skip the reset if the worktree has uncommitted state —
     // something else (concurrent CLI call) is mid-write; don't
     // wipe their progress. Same safety as poll::ensure_hub_cache_worktree.
+    // GH#4: v3 hubs have no `crosslink/hub` branch and the v3 reader
+    // consumes refs, not the worktree — the shelled `crosslink sync`
+    // above already advanced them. Only the v2 file-scanning reader
+    // needs this worktree fast-forward (a stale `.hub-cache` dir can
+    // survive migration, so gate on mode, not directory presence).
     let hub_cache = project.clone_path.join(".crosslink").join(".hub-cache");
-    if hub_cache.is_dir() {
+    if hub_cache.is_dir() && !crate::hub_v3::HubMode::resolve(&project.clone_path).is_v3() {
         let porcelain = Command::new("git")
             .arg("-C")
             .arg(&hub_cache)

--- a/crosslink/src/dashboard/github_api.rs
+++ b/crosslink/src/dashboard/github_api.rs
@@ -171,9 +171,11 @@ struct RepoHit {
     default_branch: String,
     ssh_url: String,
     https_url: String,
-    /// True if the repo has a `crosslink/hub` branch (our criterion
-    /// for "crosslink-touched"). Non-matching repos are filtered out
-    /// server-side; this field is always `true` in responses.
+    /// True if the repo has a crosslink hub — a v2 `crosslink/hub` branch
+    /// or the v3 `crosslink/checkpoint` marker branch (our criterion for
+    /// "crosslink-touched"). Non-matching repos are filtered out
+    /// server-side; this field is always `true` in responses. The wire
+    /// name is kept for frontend compatibility.
     has_hub_branch: bool,
 }
 
@@ -430,19 +432,30 @@ async fn enumerate_org_crosslink_repos(org: &str, token: &str) -> Result<Vec<Rep
             break;
         }
         for repo in &repos {
-            // Check for crosslink/hub cheaply — a 200 means yes, 404
-            // means no, anything else we propagate.
-            let check_url = format!(
-                "https://api.github.com/repos/{}/{}/branches/crosslink%2Fhub",
-                repo.owner.login, repo.name
-            );
-            let check = client
-                .get(&check_url)
-                .bearer_auth(token)
-                .header("Accept", "application/vnd.github+json")
-                .send()
-                .await?;
-            if check.status().is_success() {
+            // Check for a crosslink hub cheaply — a 200 means yes, 404 means
+            // no, anything else we propagate. GH#4: probe the v2 branch
+            // first, then fall back to the v3 marker (`crosslink/checkpoint`
+            // is a visible branch on every v3 hub) — migrated+finalized
+            // repos have no `crosslink/hub` at all and used to vanish from
+            // discovery.
+            let mut found = false;
+            for branch in ["crosslink%2Fhub", "crosslink%2Fcheckpoint"] {
+                let check_url = format!(
+                    "https://api.github.com/repos/{}/{}/branches/{branch}",
+                    repo.owner.login, repo.name
+                );
+                let check = client
+                    .get(&check_url)
+                    .bearer_auth(token)
+                    .header("Accept", "application/vnd.github+json")
+                    .send()
+                    .await?;
+                if check.status().is_success() {
+                    found = true;
+                    break;
+                }
+            }
+            if found {
                 out.push(RepoHit {
                     owner: repo.owner.login.clone(),
                     repo: repo.name.clone(),

--- a/crosslink/src/dashboard/poll.rs
+++ b/crosslink/src/dashboard/poll.rs
@@ -290,14 +290,18 @@ fn write_project_state(
 }
 
 async fn fetch_hub(clone_path: &Path) -> Result<()> {
-    // Fetch with an explicit refspec so the local `crosslink/hub` ref
-    // is created/updated, not just the remote-tracking ref. The `+`
-    // allows non-fast-forward updates (shouldn't happen in practice
-    // but doesn't cost anything). Dashboard-auto-cloned repos start
-    // with no local branch, and the reader looks for the local ref
-    // via `git rev-parse crosslink/hub` — without this refspec, hub
-    // state appears empty to the panel despite being present on the
-    // remote.
+    // Fetch with an explicit refspec GLOB so the local crosslink refs are
+    // created/updated, not just remote-tracking refs. The glob matches
+    // whatever the remote has — the v2 `crosslink/hub` branch OR the v3
+    // refs (`crosslink/checkpoint`, `crosslink/meta`,
+    // `crosslink/agents/*`) — and, unlike the old exact
+    // `crosslink/hub` refspec, never fails outright against a
+    // migrated+finalized remote where that branch is deleted (GH#4: that
+    // failure meant v3 refs were never fetched, `HubMode::resolve` saw
+    // V2, and migrated repos surfaced as permanently unreachable). The
+    // `+` allows non-fast-forward updates. Dashboard-auto-cloned repos
+    // start with no local crosslink branches at all, and the readers
+    // resolve `refs/heads/...` only.
     let status = Command::new("git")
         .arg("-C")
         .arg(clone_path)
@@ -305,7 +309,7 @@ async fn fetch_hub(clone_path: &Path) -> Result<()> {
             "fetch",
             "--quiet",
             "origin",
-            "+refs/heads/crosslink/hub:refs/heads/crosslink/hub",
+            "+refs/heads/crosslink/*:refs/heads/crosslink/*",
         ])
         .status()
         .await?;
@@ -314,12 +318,15 @@ async fn fetch_hub(clone_path: &Path) -> Result<()> {
     }
 
     // Materialise the hub branch into `.crosslink/.hub-cache/` as a
-    // worktree so the reader's filesystem scan actually finds the
-    // issues / heartbeats / locks files. For repos that were set up
-    // via `crosslink sync` this already exists (idempotent); for
-    // dashboard-auto-cloned repos it doesn't and we'd otherwise read
-    // from the `main` working tree which has no hub layout.
-    ensure_hub_cache_worktree(clone_path).await;
+    // worktree so the v2 reader's filesystem scan actually finds the
+    // issues / heartbeats / locks files. v3 hubs need no worktree — the
+    // reader consumes the checkpoint ref directly — and a migrated repo
+    // has no `crosslink/hub` branch to add a worktree for (GH#4).
+    // Resolve the mode AFTER the fetch above so a freshly-cloned v3 repo
+    // is recognized on its first poll tick.
+    if !crate::hub_v3::HubMode::resolve(clone_path).is_v3() {
+        ensure_hub_cache_worktree(clone_path).await;
+    }
     Ok(())
 }
 
@@ -615,5 +622,107 @@ mod tests {
             .await
             .expect("poll loop did not exit after cancel")
             .expect("poll loop task panicked");
+    }
+
+    /// GH#4: a migrated+finalized remote has NO `crosslink/hub` branch — the
+    /// old exact refspec failed outright, so v3 refs never became local and
+    /// the repo surfaced as permanently unreachable. The glob refspec must
+    /// fetch the v3 refs, and no v2 hub-cache worktree may be created.
+    #[tokio::test]
+    async fn fetch_hub_fetches_v3_refs_and_skips_worktree() {
+        // Seed repo with v3 refs only.
+        let seed = tempdir().unwrap();
+        let sp = seed.path();
+        for args in [
+            vec!["init", "-q", "-b", "crosslink/checkpoint"],
+            vec!["config", "user.email", "test@test.local"],
+            vec!["config", "user.name", "Test"],
+            vec!["config", "commit.gpgsign", "false"],
+        ] {
+            StdCommand::new("git")
+                .arg("-C")
+                .arg(sp)
+                .args(&args)
+                .status()
+                .unwrap();
+        }
+        let state =
+            serde_json::to_vec_pretty(&crate::checkpoint::CheckpointState::default()).unwrap();
+        fs::write(sp.join("state.json"), &state).unwrap();
+        StdCommand::new("git")
+            .arg("-C")
+            .arg(sp)
+            .args(["add", "-A"])
+            .status()
+            .unwrap();
+        StdCommand::new("git")
+            .arg("-C")
+            .arg(sp)
+            .args(["commit", "-q", "-m", "v3 checkpoint"])
+            .status()
+            .unwrap();
+        StdCommand::new("git")
+            .arg("-C")
+            .arg(sp)
+            .args(["branch", "crosslink/meta"])
+            .status()
+            .unwrap();
+
+        // Bare remote with those refs; NO crosslink/hub anywhere.
+        let remote = tempdir().unwrap();
+        StdCommand::new("git")
+            .arg("-C")
+            .arg(remote.path())
+            .args(["init", "-q", "--bare", "-b", "main"])
+            .status()
+            .unwrap();
+        StdCommand::new("git")
+            .arg("-C")
+            .arg(sp)
+            .args(["remote", "add", "origin", remote.path().to_str().unwrap()])
+            .status()
+            .unwrap();
+        StdCommand::new("git")
+            .arg("-C")
+            .arg(sp)
+            .args([
+                "push",
+                "-q",
+                "origin",
+                "crosslink/checkpoint",
+                "crosslink/meta",
+            ])
+            .status()
+            .unwrap();
+
+        // Dashboard-auto-clone: local crosslink refs absent.
+        let clone = tempdir().unwrap();
+        let cp = clone.path().join("work");
+        StdCommand::new("git")
+            .args([
+                "clone",
+                "-q",
+                remote.path().to_str().unwrap(),
+                cp.to_str().unwrap(),
+            ])
+            .status()
+            .unwrap();
+        assert!(
+            !crate::hub_v3::HubMode::resolve(&cp).is_v3(),
+            "fresh clone has no local v3 refs yet"
+        );
+
+        fetch_hub(&cp).await.unwrap();
+
+        // The glob refspec created the local v3 refs; mode now resolves V3.
+        assert!(
+            crate::hub_v3::HubMode::resolve(&cp).is_v3(),
+            "fetch must create local v3 refs"
+        );
+        // And no v2 hub-cache worktree was materialised.
+        assert!(
+            !cp.join(".crosslink").join(".hub-cache").exists(),
+            "v3 repos must not get a v2 hub-cache worktree"
+        );
     }
 }

--- a/crosslink/src/dashboard/projects.rs
+++ b/crosslink/src/dashboard/projects.rs
@@ -534,18 +534,29 @@ pub fn track_at_path(clone_path: &Path, slug_override: Option<&str>, db_path: &P
     };
     parse_slug(&slug)?;
 
-    // Soft-check for the hub branch — warn if missing, don't block.
-    let hub_check = Command::new("git")
-        .arg("-C")
-        .arg(clone_path)
-        .args(["rev-parse", "--verify", "crosslink/hub"])
-        .output()
-        .ok();
-    let has_hub = hub_check.is_some_and(|o| o.status.success());
+    // Soft-check for hub state — warn if absent, don't block. GH#4:
+    // v2 (`crosslink/hub`) and v3 (`crosslink/checkpoint` + meta/agent
+    // refs) both count; a fresh clone carries the markers only under
+    // `refs/remotes/origin/`, so probe those too. LOCAL refs only — no
+    // network here (track runs against dead origins in tests, gh#34).
+    let has_hub = !matches!(
+        crate::hub_v3::detect_hub_version(clone_path),
+        Ok(crate::hub_v3::HubVersion::Absent)
+    ) || ["origin/crosslink/checkpoint", "origin/crosslink/hub"]
+        .iter()
+        .any(|r| {
+            Command::new("git")
+                .arg("-C")
+                .arg(clone_path)
+                .args(["rev-parse", "--verify", "--quiet", r])
+                .output()
+                .is_ok_and(|o| o.status.success())
+        });
     if !has_hub {
         eprintln!(
-            "warning: {slug} has no `crosslink/hub` branch yet — \
-             tracking anyway, dashboard will surface this as unreachable."
+            "warning: {slug} has no crosslink hub state yet (neither a v2 \
+             `crosslink/hub` branch nor v3 hub refs) — tracking anyway, \
+             dashboard will surface this as unreachable."
         );
     }
 
@@ -1030,6 +1041,39 @@ mod tests {
             "https://github.com/forecast-bio/test-d.git",
             false,
         );
+
+        track_at_path(repo.path(), None, &db_path).unwrap();
+
+        let db = DashboardDb::open(&db_path).unwrap();
+        let count: i64 = db
+            .conn
+            .query_row("SELECT COUNT(*) FROM projects", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn test_track_v3_repo_recognized_as_hubbed() {
+        // GH#4: a migrated repo has no `crosslink/hub` branch but carries the
+        // v3 marker refs — track must recognize it as crosslink-touched
+        // (detect_hub_version), not fall into the "no hub" warning path.
+        let (_home, db_path) = temp_db();
+        let repo = tempdir().unwrap();
+        make_fake_repo(
+            repo.path(),
+            "https://github.com/forecast-bio/test-e.git",
+            false,
+        );
+        // Seed local v3 marker refs off the current HEAD.
+        for branch in ["crosslink/checkpoint", "crosslink/meta"] {
+            let out = Command::new("git")
+                .arg("-C")
+                .arg(repo.path())
+                .args(["branch", branch])
+                .output()
+                .unwrap();
+            assert!(out.status.success());
+        }
 
         track_at_path(repo.path(), None, &db_path).unwrap();
 

--- a/crosslink/src/dashboard/reader.rs
+++ b/crosslink/src/dashboard/reader.rs
@@ -137,17 +137,22 @@ pub fn read_snapshot(clone_path: &Path) -> Result<HubSnapshot> {
         clone_path.display()
     );
 
-    let hub_sha = git_rev_parse(clone_path, "crosslink/hub");
-    let last_commit_at = git_last_commit_at(clone_path, "crosslink/hub");
-
     // Mode-route PER PROJECT: the dashboard aggregates many tracked repos,
     // each independently v2 or v3. A v3 hub keeps no worktree files (issues,
     // locks, heartbeats all live on per-agent refs + the checkpoint ref), so
     // the file-scanning path below would read nothing. Resolve the mode from
     // this project's repo and take the ref-based path when it is v3.
     if crate::hub_v3::HubMode::resolve(clone_path).is_v3() {
+        // GH#4: freshness keys off the CHECKPOINT ref on v3 — a migrated
+        // repo has no `crosslink/hub`, and keeping the v2 keys here left
+        // `hub_sha`/`last_activity_at` permanently NULL on migrated tiles.
+        let hub_sha = git_rev_parse(clone_path, crate::hub_v3::CHECKPOINT_REF);
+        let last_commit_at = git_last_commit_at(clone_path, crate::hub_v3::CHECKPOINT_REF);
         return read_snapshot_v3(clone_path, hub_sha, last_commit_at);
     }
+
+    let hub_sha = git_rev_parse(clone_path, "crosslink/hub");
+    let last_commit_at = git_last_commit_at(clone_path, "crosslink/hub");
 
     // Prefer the hub-cache worktree (`.crosslink/.hub-cache/`) when it
     // exists — that's where `crosslink sync` keeps `crosslink/hub`
@@ -359,7 +364,7 @@ fn read_signature_state(crosslink_workspace: &Path) -> SignatureState {
     if !sync.is_initialized() {
         return SignatureState::Unknown;
     }
-    match sync.verify_locks_signature() {
+    match sync.verify_hub_signature_auto() {
         Ok(crate::signing::SignatureVerification::Valid) => SignatureState::Valid,
         Ok(crate::signing::SignatureVerification::Unsigned) => SignatureState::Unsigned,
         Ok(crate::signing::SignatureVerification::Invalid) => SignatureState::Invalid,

--- a/crosslink/src/hub_source.rs
+++ b/crosslink/src/hub_source.rs
@@ -495,6 +495,38 @@ impl RefHubSource {
         })
     }
 
+    /// Construct a `RefHubSource` pinned to EXPLICIT commits instead of the
+    /// current ref tips (GH#45): finalize verifies the SEEDED genesis by
+    /// reducing at the tips recorded in `HubMeta` at migration time, so
+    /// legitimate post-migration events, compaction, and pruning above the
+    /// watermark never affect the verification. `reduce()` is unchanged —
+    /// the bound comes entirely from the pinned SHAs, exactly as with
+    /// [`Self::new`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if extracting `allowed_signers` from the pinned meta
+    /// commit fails.
+    pub fn at_tips(
+        repo_dir: &Path,
+        checkpoint_sha: Option<String>,
+        meta_sha: Option<String>,
+        agent_tips: Vec<(String, String)>,
+    ) -> Result<Self> {
+        let (allowed_signers_dir, allowed_signers_path) = match &meta_sha {
+            Some(sha) => extract_meta_allowed_signers(repo_dir, sha)?,
+            None => (None, None),
+        };
+        Ok(Self {
+            repo_path: repo_dir.to_path_buf(),
+            checkpoint_sha,
+            meta_sha,
+            agent_tips,
+            _allowed_signers_dir: allowed_signers_dir,
+            allowed_signers_path,
+        })
+    }
+
     /// The pinned checkpoint commit SHA, or `None` if no checkpoint ref exists.
     #[must_use]
     pub fn checkpoint_sha(&self) -> Option<&str> {

--- a/crosslink/src/hub_v3.rs
+++ b/crosslink/src/hub_v3.rs
@@ -749,6 +749,21 @@ pub struct HubMeta {
     /// markers written before this field existed parse cleanly.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub finalized_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// The checkpoint commit written at migration seeding, whose `state.json`
+    /// blob IS the genesis state (content-addressed, durable — the checkpoint
+    /// ref itself advances with every compaction). Recorded so finalize can
+    /// verify against the SEEDED genesis instead of the moving tip (GH#45).
+    /// `None` on hubs migrated before this field existed and on bootstrap
+    /// hubs (which have no v2 branch to finalize).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub genesis_checkpoint_commit: Option<String>,
+    /// Each agent ref's tip commit immediately after seeding
+    /// (`agent_id -> sha`). Finalize verifies the seed is still an ancestor
+    /// of every recorded ref — ancestry, not byte-prefix, so legitimate
+    /// post-migration events, compaction, and REQ-11 pruning never block
+    /// the cutover (GH#45). `BTreeMap` keeps `hub.json` deterministic.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seed_agent_tips: Option<std::collections::BTreeMap<String, String>>,
 }
 
 /// Read the [`HubMeta`] marker from the [`META_REF`] tip, if present.
@@ -1816,6 +1831,8 @@ pub fn bootstrap_v3_hub(
         migrated_from_commit: "genesis".to_string(),
         migrated_at: chrono::Utc::now(),
         finalized_at: None,
+        genesis_checkpoint_commit: None,
+        seed_agent_tips: None,
     };
     let hub_json = serde_json::to_vec_pretty(&meta).context("failed to serialize HubMeta")?;
     let signers_path = repo_dir.join("trust").join("allowed_signers");
@@ -3588,6 +3605,8 @@ mod tests {
             migrated_from_commit: "deadbeefcafe1234".to_string(),
             migrated_at: chrono::Utc::now(),
             finalized_at: None,
+            genesis_checkpoint_commit: None,
+            seed_agent_tips: None,
         };
         let meta_bytes = serde_json::to_vec(&meta).unwrap();
         commit_files_to_ref(

--- a/crosslink/src/server/handlers/sync.rs
+++ b/crosslink/src/server/handlers/sync.rs
@@ -64,7 +64,12 @@ pub async fn sync_status(
 
     Ok(Json(SyncStatusResponse {
         hub_initialized,
-        hub_branch: "crosslink/hub".to_string(),
+        // GH#4: name the ref the hub actually lives on for this mode.
+        hub_branch: if sm.hub_mode().is_v3() {
+            "crosslink/checkpoint".to_string()
+        } else {
+            "crosslink/hub".to_string()
+        },
         remote,
         last_fetch_at,
         active_lock_count,

--- a/crosslink/src/server/watcher.rs
+++ b/crosslink/src/server/watcher.rs
@@ -394,6 +394,8 @@ mod tests {
             migrated_from_commit: "0".repeat(40),
             migrated_at: Utc::now(),
             finalized_at: None,
+            genesis_checkpoint_commit: None,
+            seed_agent_tips: None,
         };
         let hub_json = serde_json::to_vec_pretty(&meta).unwrap();
         crate::hub_v3::commit_files_to_ref(

--- a/crosslink/src/sync/trust.rs
+++ b/crosslink/src/sync/trust.rs
@@ -455,6 +455,28 @@ impl SyncManager {
     /// # Errors
     ///
     /// Returns an error if git log or signature verification commands fail.
+    /// Mode-aware hub signature check (GH#4): v2 verifies the last commit
+    /// that touched `locks.json` in the cache worktree; a v3 hub has no
+    /// `locks.json` history at all — verify the checkpoint ref tip instead
+    /// (the commit carrying the current materialized state).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if git plumbing or signature verification fails.
+    pub fn verify_hub_signature_auto(&self) -> Result<SignatureVerification> {
+        if self.hub_mode.get().is_v3() {
+            let Some(tip) = crate::hub_v3::git_rev_parse_optional(
+                &self.cache_dir,
+                crate::hub_v3::CHECKPOINT_REF,
+            )?
+            else {
+                return Ok(SignatureVerification::NoCommits);
+            };
+            return self.verify_commit_signature(&tip);
+        }
+        self.verify_locks_signature()
+    }
+
     pub fn verify_locks_signature(&self) -> Result<SignatureVerification> {
         // Get the commit that last touched locks.json
         let output = self.git_in_cache(&["log", "-1", "--format=%H", "--", "locks.json"])?;


### PR DESCRIPTION
Fixes #45. Fixes #4 (the dashboard-visibility symptom — the last one standing; the import and `to-shared` halves merged in #6 and #38).

Two fixes bundled as the v3-completeness pair: the last places where the system still assumed a v2 hub. One commit per fix.

## gh#45 — finalize refuses after any legitimate post-migration activity (`57404fa1`)

The finalize gate reused the migration-time invariant (`reduce(current refs) == genesis`), which only holds in the instant after seeding — a single lock release, or the dispatcher's own v3 fetch advancing the checkpoint ref, permanently blocked the cutover with a misleading "v2 and v3 no longer agree" (full analysis in #45).

Migration now records in `HubMeta` what finalize actually needs: the genesis checkpoint commit (whose `state.json` blob IS the genesis — content-addressed and durable while the ref moves) and each agent ref's seeded tip. Both fields serde-default, compatible in both directions. Finalize's new `verify_finalize` checks the three properties that gate safe v2 deletion: the v2 files still reproduce the persisted genesis (catches same-tip content divergence the explicit tip guard cannot see), every seeded tip remains an ancestor of its ref (ancestry, not byte-prefix — compaction and REQ-11 pruning never false-fail; force-resets still refuse), and reducing AT the seeded tips (new `RefHubSource::at_tips` pinned constructor) reproduces the genesis. Pre-fix hubs (no recorded metadata) fall back to the strict check with a `--remigrate-from-v2` steer, which re-seeds and records the fields.

Five new tests: the regression (finalize succeeds after a post-genesis event + advanced checkpoint), same-tip v2 file tamper refusal, broken-ancestry refusal, and both pre-metadata fallback paths.

## gh#4 — dashboard v3-awareness (`b19f05ab`)

The snapshot reader was already mode-routed to the checkpoint ref; the plumbing around it wasn't, so migrated+finalized repos surfaced as permanently unreachable. Seven sites: the poll fetch refspec becomes the `+refs/heads/crosslink/*` glob (the exact v2 refspec failed every tick against migrated remotes, so v3 refs never became local) with the v2 hub-cache worktree gated off on v3; tile freshness keys off the checkpoint ref; post-action `reset --hard crosslink/hub` skipped on v3; org discovery falls back to probing `crosslink/checkpoint`; the track-time check recognizes v3 markers (local refs only — no new network I/O, keeping #34 in mind); `GET /api/v1/sync/status` names the mode's actual hub ref; signature verification checks the checkpoint tip via a new `SyncManager::verify_hub_signature_auto` instead of the nonexistent `locks.json` history.

Noted intentional gaps, out of scope here: v3 parity for `ci_status` and the agent-requests pane (the v2 file sources have no v3 ref home yet), and the pre-existing fact that nothing ever sets `projects.status = 'error'` so the `unreachable_project` alert never actually fires on v2 either — both worth their own issues if you want them.

## Testing

- New: `fetch_hub_fetches_v3_refs_and_skips_worktree` (v3-only bare remote — the exact unreachable-repo scenario), checkpoint-keyed `hub_sha` assertions in the reader-reroute e2e, v3 track recognition, and the five finalize tests. All fixtures are local bare repos — no network URLs.
- Full targeted suites green: migrate_hub_v3 (21+8), dashboard (130), projects (36), server sync handlers (8), trust (19), hub_source (15), watcher (14).
- `cargo clippy -- -D warnings -W clippy::unwrap_used -W clippy::expect_used` clean; `cargo fmt --check` clean.
- Field note: the three production repos migrated on 2026-07-22 (including the one whose finalize refusal produced #45) are the live population this pair serves.

Authored by Claude Code on behalf of @magnificentlycursed.

Generated with [Claude Code](https://claude.com/claude-code)
