### PR TITLE
fix(dashboard): advisory git calls fail fast instead of hanging on a credential prompt (gh#34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Dashboard git calls can no longer hang on a credential prompt (gh#34). The
+  poll loop's per-tick `git fetch` and the track-time `git remote show origin`
+  default-branch probe now run with `GIT_TERMINAL_PROMPT=0`, a neutralized
+  `GIT_ASKPASS`, and `-c credential.helper=`, so a private, moved, or deleted
+  remote (or an interactive askpass like VS Code's) makes them fail fast
+  instead of blocking a headless `dashboard serve` worker indefinitely. The
+  `detect_default_branch` test fixtures now record a local remote-tracking
+  HEAD so they resolve without any network I/O (previously they reached the
+  live network against hardcoded URLs, hanging on interactive-helper hosts).
 - The dashboard is v3-aware (gh#4, final symptom): migrated+finalized repos no
   longer surface as `unreachable_project`. The poll fetch uses the
   `+refs/heads/crosslink/*` glob (the exact v2-only refspec failed every tick

--- a/crosslink/src/dashboard/poll.rs
+++ b/crosslink/src/dashboard/poll.rs
@@ -302,10 +302,20 @@ async fn fetch_hub(clone_path: &Path) -> Result<()> {
     // `+` allows non-fast-forward updates. Dashboard-auto-cloned repos
     // start with no local crosslink branches at all, and the readers
     // resolve `refs/heads/...` only.
+    // GH#34: the poll loop runs this every tick against every tracked remote.
+    // It must never block on a credential prompt — a private/moved/deleted
+    // remote (or an interactive askpass like VS Code's) would otherwise hang
+    // the whole poll loop, freezing the dashboard for the entire fleet.
+    // Disable every credential vector so it fails fast; poll swallows the
+    // failure and reads whatever is already local.
     let status = Command::new("git")
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GIT_ASKPASS", "")
         .arg("-C")
         .arg(clone_path)
         .args([
+            "-c",
+            "credential.helper=",
             "fetch",
             "--quiet",
             "origin",

--- a/crosslink/src/dashboard/projects.rs
+++ b/crosslink/src/dashboard/projects.rs
@@ -205,10 +205,17 @@ fn detect_default_branch(clone_path: &Path) -> Option<String> {
 
     // 2. `git remote show origin` — network-scoped but authoritative.
     // Parses `HEAD branch: main` out of the human-readable output.
+    // GH#34: this advisory query must never prompt for credentials — on a
+    // headless `dashboard serve` (or a host with an interactive askpass like
+    // VS Code) a private/moved/deleted remote would hang the process
+    // indefinitely. Disable every credential vector so it fails fast and the
+    // cascade falls through to the local step 3 instead.
     let out = Command::new("git")
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GIT_ASKPASS", "")
         .arg("-C")
         .arg(clone_path)
-        .args(["remote", "show", "origin"])
+        .args(["-c", "credential.helper=", "remote", "show", "origin"])
         .output()
         .ok()?;
     if out.status.success() {
@@ -870,6 +877,27 @@ mod tests {
             .args(["remote", "add", "origin", origin])
             .status()
             .unwrap();
+        // GH#34: record a local remote-tracking HEAD, exactly as a normal
+        // clone would carry, so detect_default_branch resolves via its local
+        // step 1 and never reaches the network `git remote show origin`.
+        // Keeps these fixtures hermetic (no DNS/connect to the dead-org URLs)
+        // while preserving the URL for the slug-derivation assertions.
+        StdCommand::new("git")
+            .arg("-C")
+            .arg(path)
+            .args(["update-ref", "refs/remotes/origin/main", "HEAD"])
+            .status()
+            .unwrap();
+        StdCommand::new("git")
+            .arg("-C")
+            .arg(path)
+            .args([
+                "symbolic-ref",
+                "refs/remotes/origin/HEAD",
+                "refs/remotes/origin/main",
+            ])
+            .status()
+            .unwrap();
         if with_hub {
             StdCommand::new("git")
                 .arg("-C")
@@ -1121,5 +1149,52 @@ mod tests {
         let (_home, db_path) = temp_db();
         // Just verifies Ok on an empty DB.
         list_with_path(&db_path).unwrap();
+    }
+
+    /// GH#34: a repo carrying a local remote-tracking HEAD (what a normal
+    /// clone has) resolves its default branch via the local step 1 — no
+    /// network `git remote show origin`.
+    #[test]
+    fn detect_default_branch_reads_local_remote_head() {
+        let dir = tempdir().unwrap();
+        make_fake_repo(
+            dir.path(),
+            "https://github.com/forecast-bio/test-x.git",
+            false,
+        );
+        assert_eq!(detect_default_branch(dir.path()).as_deref(), Some("main"));
+    }
+
+    /// GH#34: an origin that cannot be resolved must NOT hang the cascade on a
+    /// credential prompt — it falls through to the local step 3. Uses a
+    /// nonexistent file:// path so `git remote show origin` fails instantly
+    /// with no network and no prompt (the env-scoped https case fails the same
+    /// fast way instead of prompting).
+    #[test]
+    fn detect_default_branch_bogus_origin_falls_through_without_hanging() {
+        let dir = tempdir().unwrap();
+        let p = dir.path();
+        for args in [
+            vec!["init", "-q", "-b", "main"],
+            vec!["config", "user.email", "test@test.local"],
+            vec!["config", "user.name", "Test"],
+            vec!["commit", "--allow-empty", "-q", "-m", "init"],
+            vec![
+                "remote",
+                "add",
+                "origin",
+                "file:///nonexistent/gh34/repo.git",
+            ],
+        ] {
+            StdCommand::new("git")
+                .arg("-C")
+                .arg(p)
+                .args(&args)
+                .status()
+                .unwrap();
+        }
+        // No refs/remotes/origin/HEAD → step 1 fails, step 2 hits the bogus
+        // origin and fails fast, step 3 finds the local `main`.
+        assert_eq!(detect_default_branch(p).as_deref(), Some("main"));
     }
 }


### PR DESCRIPTION
Addresses #34 — the dashboard advisory-network-hang half. (#34 also tracks a second non-hermetic-test member noted in its comments: `commands::agent::tests::test_bootstrap_*` fail on hosts without an unconditional global git identity because the bootstrap hub-cache init commit runs without `-c user.name`/`-c user.email` overrides. That's an agent-bootstrap robustness fix in a different subsystem, left as a separate small follow-up; this PR does not close #34.)

The dashboard's advisory network git calls inherited the ambient credential environment, so a private, moved, or deleted remote — or a host with an interactive askpass like VS Code's — made them block on a credential prompt. On a headless `crosslink dashboard serve` (no TTY to answer) that hangs the worker indefinitely: the poll loop freezes for the whole tracked fleet, and `dashboard track` never returns. This is the same mechanism that wedged this repo's own CI test suite (a 9-hour hang was observed during the v3 dashboard work).

## Changes

- **Poll fetch** (`poll.rs`, per tick, every tracked remote) and the **track-time `git remote show origin`** default-branch probe (`projects.rs`) now run with `GIT_TERMINAL_PROMPT=0`, a neutralized `GIT_ASKPASS`, and `-c credential.helper=` — every credential vector disabled, so the call fails fast and the caller degrades gracefully: poll reads whatever is already local; `detect_default_branch` falls through to its local step 3.
- **Fixtures made hermetic.** `detect_default_branch` tried its network step 2 before the local step 3, and `make_fake_repo` set a dead-org origin URL with no remote-tracking HEAD, so every fixture run reached the live network (the source of the CI hangs). `make_fake_repo` now records a local `refs/remotes/origin/HEAD` exactly as a real clone carries, so the probe resolves via the local step 1 with no network I/O; the URLs stay for the slug-derivation assertions.

## Testing

- New: `detect_default_branch_reads_local_remote_head` (resolves via the local step, no network) and `detect_default_branch_bogus_origin_falls_through_without_hanging` (an unresolvable `file://` origin degrades to the local `main` via step 3 instead of hanging).
- Dashboard suites green: `dashboard::projects` (27), `dashboard::poll` (5).
- Full bin suite: 2848 pass; the only 2 failures are the pre-existing `test_bootstrap_*` tests (the bootstrap-identity half of #34 described above), which fail identically on `develop` and are untouched by this dashboard-only diff.
- `cargo clippy -- -D warnings -W clippy::unwrap_used -W clippy::expect_used` clean; `cargo fmt --check` clean.

## Scope notes

- This covers the two advisory calls in the poll/track path that #34 names. The discovery/onboarding clones (`github_api.rs`, `api.rs`) are also network git calls a headless server makes and would benefit from the same treatment, but "cloning a repo you're actively adding" is a distinct UX where a prompt may be legitimate — left as a deliberate, separate follow-up rather than folded in here.
- Two adjacent dashboard gaps found during this and the #4 work are filed separately: #48 (the `unreachable_project` alert never fires) and #49 (v3 reader returns `ci_status`/`agent_requests` empty).

Authored by Claude Code on behalf of @magnificentlycursed.

Generated with [Claude Code](https://claude.com/claude-code)
