### PR TITLE
fix(sync): hub-cache identity requires non-empty user.email AND user.name (gh#34 bootstrap half)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Hub-cache init no longer fails with "Author identity unknown" on a host whose
+  git identity is present but empty (gh#34). `ensure_cache_git_identity` checked
+  only that `git config user.email` *succeeded* — but `git config` exits 0 for a
+  key set to an empty string (e.g. a global `user.email = ` used to force
+  per-repo identities), so the empty value slipped past as "configured" and the
+  `Initialize crosslink v3 hub worktree` commit then died with no author. It now
+  requires a non-empty value on both `user.email` and `user.name` (the check
+  previously ignored `user.name` entirely), falling back to the
+  `crosslink`/`crosslink@localhost` identity otherwise — hardening real
+  `crosslink agent bootstrap` on CI runners and identity-less/empty-identity
+  hosts.
 - The dashboard is v3-aware (gh#4, final symptom): migrated+finalized repos no
   longer surface as `unreachable_project`. The poll fetch uses the
   `+refs/heads/crosslink/*` glob (the exact v2-only refspec failed every tick

--- a/crosslink/src/sync/core.rs
+++ b/crosslink/src/sync/core.rs
@@ -273,12 +273,17 @@ impl SyncManager {
     /// Uses `--worktree` scope when the cache dir is a linked worktree to
     /// avoid leaking identity config into the shared `.git/config`.
     pub(super) fn ensure_cache_git_identity(&self) -> Result<()> {
-        let has_email = Command::new("git")
-            .current_dir(&self.cache_dir)
-            .args(["config", "user.email"])
-            .output()
-            .is_ok_and(|o| o.status.success());
-        if !has_email {
+        // A usable identity needs BOTH user.email and user.name set to a
+        // NON-EMPTY value. `git config <key>` exits 0 for a key present with an
+        // empty value (e.g. a global `user.email = ` used to force per-repo
+        // identities), so an existence check alone lets an empty identity
+        // through — the housekeeping commit then dies with "empty ident name"
+        // / "Author identity unknown" (gh#34). Check the value, and check both
+        // fields (the previous check looked only at user.email, so an
+        // email-set/name-empty host slipped through the same way).
+        let has_identity = git_config_nonempty(&self.cache_dir, "user.email")
+            && git_config_nonempty(&self.cache_dir, "user.name");
+        if !has_identity {
             let use_worktree = signing::is_linked_worktree(&self.cache_dir);
             if use_worktree {
                 signing::enable_worktree_config(&self.cache_dir)?;
@@ -314,20 +319,71 @@ impl SyncManager {
                 );
             }
 
-            // Verify identity is actually set — don't let commits fail later
-            // with "Author identity unknown" (#469)
-            let verified = Command::new("git")
-                .current_dir(&self.cache_dir)
-                .args(["config", "user.email"])
-                .output()
-                .is_ok_and(|o| o.status.success());
-            if !verified {
+            // Verify identity is actually usable — don't let commits fail later
+            // with "Author identity unknown" (#469). Check for a non-empty
+            // value on both fields, not mere key presence (gh#34).
+            if !(git_config_nonempty(&self.cache_dir, "user.email")
+                && git_config_nonempty(&self.cache_dir, "user.name"))
+            {
                 bail!(
                     "Failed to verify git identity in hub cache: \
-                     git config set succeeded but user.email is not readable"
+                     git config set succeeded but user.email/user.name is empty or unreadable"
                 );
             }
         }
         Ok(())
+    }
+}
+
+/// Whether `git config <key>` resolves to a non-empty value in `dir`.
+///
+/// `git config <key>` exits 0 for a key set to an empty string, so a plain
+/// success check treats an empty identity as configured — the caller then
+/// commits with no author and fails (gh#34). This trims the value and
+/// requires it to be non-empty.
+fn git_config_nonempty(dir: &Path, key: &str) -> bool {
+    Command::new("git")
+        .current_dir(dir)
+        .args(["config", key])
+        .output()
+        .is_ok_and(|o| o.status.success() && !String::from_utf8_lossy(&o.stdout).trim().is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::git_config_nonempty;
+    use std::path::Path;
+    use std::process::Command;
+
+    fn git(dir: &Path, args: &[&str]) {
+        assert!(
+            Command::new("git")
+                .current_dir(dir)
+                .args(args)
+                .status()
+                .unwrap()
+                .success(),
+            "git {args:?} failed"
+        );
+    }
+
+    #[test]
+    fn git_config_nonempty_rejects_unset_and_empty_identity() {
+        let tmp = tempfile::tempdir().unwrap();
+        let d = tmp.path();
+        git(d, &["init", "-q"]);
+
+        // Unset key → not a usable identity.
+        assert!(!git_config_nonempty(d, "user.email"));
+
+        // Empty-string value → `git config` exits 0 with empty output, so the
+        // old existence check treated it as configured; a commit then dies with
+        // "empty ident name" (gh#34). It must NOT count as a usable identity.
+        git(d, &["config", "user.email", ""]);
+        assert!(!git_config_nonempty(d, "user.email"));
+
+        // A real value → usable.
+        git(d, &["config", "user.email", "someone@example.com"]);
+        assert!(git_config_nonempty(d, "user.email"));
     }
 }


### PR DESCRIPTION
Addresses the remaining (bootstrap-identity) half of #34. Together with #50 (the dashboard advisory-network-hang half) this completes #34.

`crosslink agent bootstrap` initializes a hub-cache worktree and commits into it (`Initialize crosslink v3 hub worktree`). On a host whose git identity is present-but-empty, that commit died with `Author identity unknown` / `fatal: empty ident name (for <>) not allowed`.

## Root cause

`ensure_cache_git_identity` (`src/sync/core.rs`) sets a `crosslink`/`crosslink@localhost` fallback identity when none is configured — but it guarded on whether `git config user.email` *succeeded*. `git config <key>` exits 0 for a key set to an **empty string** (e.g. a global `user.email = ` that some setups use to force per-repo identities), so the empty value passed the check as "configured", the fallback was skipped, and the commit ran with no author. The check also looked only at `user.email`, so an email-set/name-empty host failed the same way on the name. The post-set verification block had the identical blind spot.

## Fix

Both the guard and the verification now require a **non-empty** value on **both** `user.email` and `user.name`, via a small `git_config_nonempty` helper that trims the value rather than trusting the exit code. When either is missing or empty, the existing crosslink fallback is applied. No behavior change on a host with a real identity; the fallback now also engages for the empty/partial cases.

This hardens real `crosslink agent bootstrap` on CI runners and identity-less/empty-identity hosts — not just the tests.

## Testing

- The two previously-failing tests now pass: `commands::agent::tests::test_bootstrap_creates_crosslink_dir` and `test_bootstrap_existing_agent_skips` (they exercise the full bootstrap → hub-cache init commit path).
- New unit regression: `git_config_nonempty_rejects_unset_and_empty_identity` pins the exact empty-string case that slipped through the old existence check.
- Suites green: `sync::` (58), `commands::agent` (11). `cargo clippy -- -D warnings -W clippy::unwrap_used -W clippy::expect_used` clean; `cargo fmt --check` clean.

Authored by Claude Code on behalf of @magnificentlycursed.

Generated with [Claude Code](https://claude.com/claude-code)
