### PR TITLE
fix(dashboard): v3 monitoring completeness — unreachable alert, agent-requests, last_fetch_at (gh#48, gh#49, gh#53)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- The dashboard agent-request pane is populated on v3 hubs (gh#49, agent
+  requests half). `read_snapshot_v3` hardcoded `agent_requests` empty because
+  the request/ack streams live on the agent refs, not a worktree the snapshot
+  reader scans. A new `hub_v3::read_all_agent_requests` walks the agent refs,
+  reads each driver's `requests-out/<target>--<ulid>.json` and each target's
+  `requests-ack/<ulid>.json`, and pairs them by ulid grouped by target — the
+  whole-fleet view the dashboard needs, distinct from the per-inbox
+  `poll_requests_for_agent`. (The `ci_status` half of gh#49 remains: v3 has no
+  CI-status ref home or writer yet — separate work.)
 - The dashboard `unreachable_project` alert can now fire (gh#48). The alert and
   the frontend tile severity key on `projects.status == "error"`, but the poll
   loop never wrote that value — it discarded the fetch outcome and propagated a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- `GET /api/v1/sync/status` reports an accurate `last_fetch_at` on v3 hubs
+  (gh#53). It was derived from the hub-cache directory's mtime, which tracks a
+  fetch on v2 (the worktree is reset) but freezes on v3, where a fetch adopts
+  refs into `.git` and never touches the worktree. On v3 it now reads
+  `FETCH_HEAD`'s mtime (git rewrites it on every fetch), located via
+  `rev-parse --git-path` so it is correct across worktree layouts.
 - The dashboard agent-request pane is populated on v3 hubs (gh#49, agent
   requests half). `read_snapshot_v3` hardcoded `agent_requests` empty because
   the request/ack streams live on the agent refs, not a worktree the snapshot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- The dashboard `unreachable_project` alert can now fire (gh#48). The alert and
+  the frontend tile severity key on `projects.status == "error"`, but the poll
+  loop never wrote that value — it discarded the fetch outcome and propagated a
+  snapshot-read failure without recording it — so a genuinely unreachable
+  project showed stale tiles and stayed silent. `poll_project` now marks
+  `status = "error"` when the clone is gone/unreadable, or when a fetch failed
+  and no local hub data exists, and clears it back to `"active"` on a
+  successful poll (a transient fetch failure over existing local data does not
+  flap).
 - Hub-cache init no longer fails with "Author identity unknown" on a host whose
   git identity is present but empty (gh#34). `ensure_cache_git_identity` checked
   only that `git config user.email` *succeeded* — but `git config` exits 0 for a

--- a/crosslink/src/dashboard/poll.rs
+++ b/crosslink/src/dashboard/poll.rs
@@ -142,15 +142,44 @@ pub struct PollOutcome {
 pub async fn poll_project(db_path: &Path, project: &Project) -> Result<PollOutcome> {
     // 1. `git fetch` the hub branch (best-effort). We don't abort on
     //    fetch failure — the snapshot reader will still observe whatever
-    //    is already in the local clone.
-    let _ = fetch_hub(&project.clone_path).await;
+    //    is already in the local clone. GH#48: capture the outcome (was
+    //    discarded) so the reachability status can reflect it.
+    let fetch_ok = fetch_hub(&project.clone_path).await.is_ok();
 
     // 2. Read snapshot off the filesystem. Blocking operation (rusqlite
     //    + sync I/O) — push to the blocking pool.
     let clone_path = project.clone_path.clone();
-    let snapshot = tokio::task::spawn_blocking(move || reader::read_snapshot(&clone_path))
+    let snapshot = match tokio::task::spawn_blocking(move || reader::read_snapshot(&clone_path))
         .await
-        .map_err(|e| anyhow::anyhow!("snapshot task panicked: {e}"))??;
+        .map_err(|e| anyhow::anyhow!("snapshot task panicked: {e}"))?
+    {
+        Ok(snap) => snap,
+        Err(e) => {
+            // GH#48: the clone path is gone or unreadable — unambiguously
+            // unreachable. Mark the project errored (the `unreachable_project`
+            // alert keys on `projects.status == "error"`, which nothing set
+            // before) and stop this tick; the next successful poll clears it.
+            tracing::warn!("read_snapshot failed for {}: {e}", project.slug);
+            let db_path_owned = db_path.to_path_buf();
+            let project_id = project.id;
+            tokio::task::spawn_blocking(move || {
+                mark_project_status(&db_path_owned, project_id, "error")
+            })
+            .await
+            .map_err(|e| anyhow::anyhow!("status update task panicked: {e}"))??;
+            return Ok(PollOutcome::default());
+        }
+    };
+
+    // GH#48: reachable when we either fetched successfully or have local hub
+    // data to show. Only "fetch failed AND nothing was ever obtained" (e.g. an
+    // auto-cloned repo whose remote is dead) is unreachable — a transient fetch
+    // failure over existing local data stays `active` and does not flap.
+    let status = if fetch_ok || snapshot.hub_sha.is_some() {
+        "active"
+    } else {
+        "error"
+    };
 
     // 3. Derive counters + alerts; write everything in one blocking
     //    pass so the DB sees a consistent view per tick.
@@ -179,6 +208,7 @@ pub async fn poll_project(db_path: &Path, project: &Project) -> Result<PollOutco
                 last_commit_at.as_deref(),
                 counters,
                 ci_state.as_deref(),
+                status,
             )?;
             let db = DashboardDb::open(&db_path_owned)?;
             let stats = alerts_db::sync_alerts_for_project(&db, project_id, &derived_alerts)?;
@@ -237,8 +267,20 @@ fn load_active_projects(db_path: &Path) -> Result<Vec<Project>> {
     Ok(rows)
 }
 
+/// Set only `projects.status` (GH#48). Used when the snapshot read hard-fails
+/// so there are no counters to write, but the project must still be marked
+/// unreachable so the `unreachable_project` alert can fire.
+fn mark_project_status(db_path: &Path, project_id: i64, status: &str) -> Result<()> {
+    let db = DashboardDb::open(db_path)?;
+    db.conn.execute(
+        "UPDATE projects SET status = ?1 WHERE id = ?2",
+        rusqlite::params![status, project_id],
+    )?;
+    Ok(())
+}
+
 /// Upsert `project_state` and refresh `projects.hub_sha` /
-/// `projects.hub_fetched_at` / `projects.last_activity_at`.
+/// `projects.hub_fetched_at` / `projects.last_activity_at` / `projects.status`.
 fn write_project_state(
     db_path: &Path,
     project_id: i64,
@@ -246,6 +288,7 @@ fn write_project_state(
     last_commit_at: Option<&str>,
     counters: super::reader::ProjectCounters,
     ci_status: Option<&str>,
+    status: &str,
 ) -> Result<()> {
     let db = DashboardDb::open(db_path)?;
     let now = Utc::now().to_rfc3339();
@@ -254,9 +297,10 @@ fn write_project_state(
         "UPDATE projects
          SET hub_sha = ?1,
              hub_fetched_at = ?2,
-             last_activity_at = COALESCE(?3, last_activity_at)
-         WHERE id = ?4",
-        rusqlite::params![hub_sha, now, last_commit_at, project_id],
+             last_activity_at = COALESCE(?3, last_activity_at),
+             status = ?4
+         WHERE id = ?5",
+        rusqlite::params![hub_sha, now, last_commit_at, status, project_id],
     )?;
 
     db.conn.execute(
@@ -531,6 +575,53 @@ mod tests {
         assert_eq!(blocked, 0);
         assert_eq!(agents, 0);
         assert_eq!(stale, 0);
+
+        // GH#48: a readable project stays `active`.
+        let status: String = db
+            .conn
+            .query_row(
+                "SELECT status FROM projects WHERE id = ?1",
+                [project_id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(status, "active");
+    }
+
+    #[tokio::test]
+    async fn test_poll_project_marks_unreachable_on_missing_clone() {
+        // GH#48: a tracked project whose clone path is gone is unambiguously
+        // unreachable — the poll must set projects.status='error' so the
+        // `unreachable_project` alert (which keys on that value) can fire.
+        // Before this fix nothing ever wrote 'error', so the alert was dead.
+        let home = tempdir().unwrap();
+        let db_path = home.path().join("dashboard.db");
+        DashboardDb::open(&db_path).unwrap();
+
+        let gone = home.path().join("no-such-clone");
+        let project_id = seed_project(&db_path, "owner/gone", &gone);
+        let project = load_active_projects(&db_path)
+            .unwrap()
+            .into_iter()
+            .find(|p| p.id == project_id)
+            .unwrap();
+        assert_eq!(project.status, "active", "seeded active");
+
+        poll_project(&db_path, &project).await.unwrap();
+
+        let db = DashboardDb::open(&db_path).unwrap();
+        let status: String = db
+            .conn
+            .query_row(
+                "SELECT status FROM projects WHERE id = ?1",
+                [project_id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            status, "error",
+            "missing clone must mark the project errored"
+        );
     }
 
     #[tokio::test]

--- a/crosslink/src/dashboard/reader.rs
+++ b/crosslink/src/dashboard/reader.rs
@@ -203,11 +203,12 @@ pub fn read_snapshot(clone_path: &Path) -> Result<HubSnapshot> {
 /// `compact`, lagging any un-compacted events until the next fetch/compact.
 ///
 /// `meta/ci-status.json` has no v3 ref home and the v2 worktree path is gone,
-/// so `ci_status` is `None`; `signature_state` reuses the shared
-/// [`read_signature_state`] (mode-agnostic — it verifies the hub-tip commit
-/// signature via `SyncManager`). `agent_requests` stays empty: the v3
-/// request/ack streams live on refs and are surfaced through the agent poll
-/// path, not this snapshot reader.
+/// so `ci_status` is `None` (a v3 CI-status writer + home is separate work);
+/// `signature_state` reuses the shared [`read_signature_state`] (mode-agnostic
+/// — it verifies the hub-tip commit signature via `SyncManager`).
+/// `agent_requests` is read from the agent refs via
+/// [`crate::hub_v3::read_all_agent_requests`] (GH#49 — previously hardcoded
+/// empty on v3).
 fn read_snapshot_v3(
     clone_path: &Path,
     hub_sha: Option<String>,
@@ -240,6 +241,16 @@ fn read_snapshot_v3(
             .collect();
     agents.sort_by(|a, b| a.agent_id.cmp(&b.agent_id));
 
+    // GH#49: surface driver→agent control requests (with acks) from the agent
+    // refs. Best-effort — a read error degrades to an empty pane, never fails
+    // the whole snapshot.
+    let agent_requests: Vec<AgentRequestsForAgent> =
+        crate::hub_v3::read_all_agent_requests(clone_path)
+            .unwrap_or_default()
+            .into_iter()
+            .map(|(agent_id, requests)| AgentRequestsForAgent { agent_id, requests })
+            .collect();
+
     Ok(HubSnapshot {
         hub_sha,
         // v3 retires the v1/v2 worktree layout marker; report 3 so downstream
@@ -248,7 +259,7 @@ fn read_snapshot_v3(
         issues,
         agents,
         locks,
-        agent_requests: Vec::new(),
+        agent_requests,
         ci_status: None,
         signature_state: read_signature_state(clone_path),
         last_commit_at,

--- a/crosslink/src/hub_v3.rs
+++ b/crosslink/src/hub_v3.rs
@@ -1068,6 +1068,84 @@ pub fn poll_requests_for_agent(
     Ok(out)
 }
 
+/// Aggregate every agent control request across the hub's agent refs, paired
+/// with its ack, grouped by the TARGET agent (GH#49 — the dashboard view).
+///
+/// Unlike [`poll_requests_for_agent`] (an agent's own filtered inbox), this
+/// returns the whole picture for the dashboard's agent-request pane, which on
+/// v3 had been empty because the requests live on refs, not a worktree the
+/// snapshot reader scans. Requests are read from each driver's
+/// `requests-out/<target>--<ulid>.json`; the ack (if any) is read from the
+/// TARGET's own `requests-ack/<ulid>.json`. Returns `(target_agent_id,
+/// requests)` pairs, sorted by agent id, non-empty only.
+///
+/// # Errors
+///
+/// Returns an error if git plumbing fails or a request/ack blob is malformed.
+pub fn read_all_agent_requests(
+    repo_dir: &Path,
+) -> Result<Vec<(String, Vec<crate::agent_requests::RequestWithAck>)>> {
+    use std::collections::BTreeMap;
+
+    // 1. Requests, grouped by target agent: target -> [(ulid, request)].
+    let mut by_target: BTreeMap<String, Vec<(String, crate::agent_requests::AgentRequest)>> =
+        BTreeMap::new();
+    // 2. Acks, keyed by the target that wrote them: target -> {ulid -> ack}.
+    let mut acks: BTreeMap<String, BTreeMap<String, crate::agent_requests::AgentRequestAck>> =
+        BTreeMap::new();
+
+    for ref_name in for_each_agent_ref(repo_dir)? {
+        let Some(owner) = ref_name.strip_prefix(AGENT_REF_PREFIX) else {
+            continue;
+        };
+        let Some(tip) = git_rev_parse_optional(repo_dir, &ref_name)? else {
+            continue;
+        };
+
+        // Requests this ref's owner (a driver) sent to others.
+        for leaf in list_subtree_leaf_names(repo_dir, &tip, REQUESTS_OUT_DIR)? {
+            let Some((target, ulid)) = parse_request_out_name(&leaf) else {
+                continue;
+            };
+            let spec = format!("{tip}:{REQUESTS_OUT_DIR}/{leaf}");
+            let Some(bytes) = git_cat_file_blob_optional(repo_dir, &spec)? else {
+                continue;
+            };
+            let request: crate::agent_requests::AgentRequest = serde_json::from_slice(&bytes)
+                .with_context(|| format!("failed to parse request '{leaf}' on '{ref_name}'"))?;
+            by_target.entry(target).or_default().push((ulid, request));
+        }
+
+        // Acks this ref's owner (a target) wrote for requests aimed at it.
+        for leaf in list_subtree_leaf_names(repo_dir, &tip, REQUESTS_ACK_DIR)? {
+            let spec = format!("{tip}:{REQUESTS_ACK_DIR}/{leaf}");
+            let Some(bytes) = git_cat_file_blob_optional(repo_dir, &spec)? else {
+                continue;
+            };
+            let ack: crate::agent_requests::AgentRequestAck = serde_json::from_slice(&bytes)
+                .with_context(|| format!("failed to parse ack '{leaf}' on '{ref_name}'"))?;
+            acks.entry(owner.to_string())
+                .or_default()
+                .insert(ack.request_id.clone(), ack);
+        }
+    }
+
+    let mut out = Vec::new();
+    for (target, mut requests) in by_target {
+        requests.sort_by(|a, b| a.0.cmp(&b.0)); // ulid == chronological
+        let target_acks = acks.get(&target);
+        let paired = requests
+            .into_iter()
+            .map(|(ulid, request)| crate::agent_requests::RequestWithAck {
+                request,
+                ack: target_acks.and_then(|m| m.get(&ulid).cloned()),
+            })
+            .collect();
+        out.push((target, paired));
+    }
+    Ok(out)
+}
+
 /// Read the maximum `agent_seq` recorded in this agent's OWN REF `events.log`.
 ///
 /// Returns `Ok(0)` when the ref does not exist or carries no `events.log`
@@ -3848,6 +3926,42 @@ mod tests {
         // Poll no longer returns it.
         let after = poll_requests_for_agent(dir.path(), target).unwrap();
         assert!(after.is_empty(), "acked request must not be returned");
+    }
+
+    #[test]
+    fn read_all_agent_requests_pairs_request_with_ack() {
+        // GH#49: the dashboard aggregator surfaces every request grouped by
+        // target, paired with its ack — the whole picture, unlike the
+        // per-inbox poll (which drops acked requests).
+        let dir = tempfile::tempdir().unwrap();
+        git_init(dir.path());
+        let driver = "driver-1";
+        let target = "target-1";
+        write_request_to_own_ref(dir.path(), driver, target, &make_request("01REQ0001")).unwrap();
+
+        // Before any ack: one target, one request, ack None — and unlike the
+        // per-inbox poll, still visible after acking (below).
+        let all = read_all_agent_requests(dir.path()).unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].0, target, "grouped by target agent");
+        assert_eq!(all[0].1.len(), 1);
+        assert_eq!(all[0].1[0].request.request_id, "01REQ0001");
+        assert!(all[0].1[0].ack.is_none(), "no ack yet");
+
+        // After the target acks: the request is still surfaced, now paired.
+        write_ack_to_own_ref(dir.path(), target, "01REQ0001", &make_ack("01REQ0001")).unwrap();
+        let all = read_all_agent_requests(dir.path()).unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(
+            all[0].1.len(),
+            1,
+            "acked request stays visible to dashboard"
+        );
+        assert_eq!(
+            all[0].1[0].ack.as_ref().map(|a| a.request_id.as_str()),
+            Some("01REQ0001"),
+            "ack is paired with its request"
+        );
     }
 
     #[test]

--- a/crosslink/src/server/handlers/sync.rs
+++ b/crosslink/src/server/handlers/sync.rs
@@ -14,6 +14,35 @@ use crate::server::{
 };
 use crate::sync::SyncManager;
 
+/// Modification time of the hub cache's `FETCH_HEAD`, the v3 "last fetch"
+/// signal (GH#53). `git rev-parse --git-path FETCH_HEAD` resolves its path for
+/// this worktree; `None` when git isn't reachable or no fetch has run yet.
+fn fetch_head_mtime(cache_path: &std::path::Path) -> Option<chrono::DateTime<chrono::Utc>> {
+    let out = std::process::Command::new("git")
+        .current_dir(cache_path)
+        .args(["rev-parse", "--git-path", "FETCH_HEAD"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let rel = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if rel.is_empty() {
+        return None;
+    }
+    let path = std::path::Path::new(&rel);
+    let resolved = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        cache_path.join(path)
+    };
+    std::fs::metadata(&resolved)
+        .ok()?
+        .modified()
+        .ok()
+        .map(chrono::DateTime::<chrono::Utc>::from)
+}
+
 /// Try to construct a `SyncManager` from the shared crosslink dir.
 fn sync_manager(state: &AppState) -> Result<SyncManager, (StatusCode, Json<ApiError>)> {
     SyncManager::new(&state.crosslink_dir)
@@ -52,14 +81,21 @@ pub async fn sync_status(
         (0, 0)
     };
 
-    // Derive last_fetch_at from the hub cache directory's modification time.
-    let last_fetch_at = if hub_initialized {
+    // Derive last_fetch_at. On v2 the fetch resets the cache worktree, so its
+    // directory mtime tracks the fetch. On v3 the fetch adopts refs into
+    // `.git` and never touches the worktree (GH#53), so the directory mtime
+    // freezes at cache-creation time; use FETCH_HEAD instead — git rewrites it
+    // on every fetch, and `rev-parse --git-path` locates it correctly across
+    // worktree layouts.
+    let last_fetch_at = if !hub_initialized {
+        None
+    } else if sm.hub_mode().is_v3() {
+        fetch_head_mtime(sm.cache_path())
+    } else {
         std::fs::metadata(sm.cache_path())
             .ok()
             .and_then(|m| m.modified().ok())
             .map(chrono::DateTime::<chrono::Utc>::from)
-    } else {
-        None
     };
 
     Ok(Json(SyncStatusResponse {


### PR DESCRIPTION
Fixes #48. Fixes #53. Addresses #49 (the agent-requests half; ci_status split out — see below).

The dashboard monitoring/freshness gaps that remained after the v3-awareness work (#4) and the credential-hang fix (#34). Three fixes, one commit each; all fixture-hermetic (no network, no live URLs).

## gh#48 — `unreachable_project` alert can never fire (`3d5e87f5`)

The alert and the frontend tile severity both key on `projects.status == "error"`, and the poll loop's own comment claims it marks that value — but it never did: it discarded the fetch outcome and propagated a snapshot-read failure without recording anything, so `status` never left its `'active'` default. `poll_project` now marks `status = "error"` when the clone is gone/unreadable, or when a fetch failed and no local hub data was ever obtained, and clears it to `"active"` on a successful poll. A transient fetch failure over existing local data stays active and does not flap; a consecutive-failure threshold for the stale-data case is a possible follow-up. Tests: missing clone → errored; readable project → active.

## gh#49 — agent-request pane empty on v3 (`f619d43d`, agent-requests half)

`read_snapshot_v3` hardcoded `agent_requests` empty because v3 keeps the request/ack streams on the agent refs, not a worktree the reader scans. New `hub_v3::read_all_agent_requests` walks the agent refs, reads each driver's `requests-out/<target>--<ulid>.json` paired with the target's `requests-ack/<ulid>.json`, grouped by target — the whole-fleet view the dashboard needs (distinct from `poll_requests_for_agent`, an agent's own inbox that drops acked requests). Test: a request stays visible before and after its ack, paired correctly.

**The `ci_status` half of #49 is intentionally not here.** v2 read it from `meta/ci-status.json` on the worktree; v3 has no such file and **no v3 CI-status writer exists**, so porting only the reader would read nothing. It needs a v3 home (a blob keyed to the checkpoint tip) plus a writer — a design decision, tracked as the remaining half of #49.

## gh#53 — `last_fetch_at` stale on v3 (`607303e5`)

`GET /api/v1/sync/status` derived `last_fetch_at` from the hub-cache directory mtime, which tracks a fetch on v2 (worktree reset) but freezes on v3 (fetch adopts refs into `.git`, never touches the worktree). On v3 it now reads `FETCH_HEAD`'s mtime (rewritten on every fetch), located via `rev-parse --git-path` for worktree-layout correctness. v2 path unchanged.

## Testing

- New tests above, plus green suites: `dashboard::` (133), `hub_v3::tests` (58), `server::handlers::sync` (8).
- `cargo clippy -- -D warnings -W clippy::unwrap_used -W clippy::expect_used` clean; `cargo fmt --check` clean.

Authored by Claude Code on behalf of @magnificentlycursed.

Generated with [Claude Code](https://claude.com/claude-code)
