### PR TITLE
fix(kickoff): pass claude's permission flag into container agents (gh#59)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- `GET /api/v1/sync/status` reports an accurate `last_fetch_at` on v3 hubs
+- `kickoff run --container` now passes claude's permission flag into the
+  container agent (gh#59). The local (tmux) path emitted
+  `--dangerously-skip-permissions` / `--permission-mode`, and `container start`
+  hardcodes it, but the kickoff container path built its `claude` invocation
+  without any permission flag — so the containerized agent prompted for every
+  tool and, with no TTY, blocked forever (a cause of the gh#55 "agent launches
+  then stalls" signature). Both launch paths now share a single
+  `permission_flag` helper so they cannot drift, and `launch_container`
+  threads `skip_permissions`/`permission_mode` through and emits the flag.
   (gh#53). It was derived from the hub-cache directory's mtime, which tracks a
   fetch on v2 (the worktree is reset) but freezes on v3, where a fetch adopts
   refs into `.git` and never touches the worktree. On v3 it now reads

--- a/crosslink/src/commands/kickoff/launch.rs
+++ b/crosslink/src/commands/kickoff/launch.rs
@@ -135,6 +135,25 @@ pub(super) fn spawn_watchdog(
     Ok(())
 }
 
+/// Resolve claude's permission posture into a command-line flag fragment
+/// (with a leading space, or empty). Shared by the local (tmux) and container
+/// launch paths so they cannot drift (GH#59): `permission_mode` wins with
+/// `--permission-mode <mode>`, else `skip_permissions` emits
+/// `--dangerously-skip-permissions`, else no flag (claude prompts per tool —
+/// which hangs a headless container agent, the GH#55 stall).
+pub(super) fn permission_flag(permission_mode: Option<&str>, skip_permissions: bool) -> String {
+    match (permission_mode, skip_permissions) {
+        (Some(mode), _) if !mode.is_empty() => {
+            format!(
+                " --permission-mode {}",
+                crate::utils::shell_escape_arg(mode)
+            )
+        }
+        (_, true) => " --dangerously-skip-permissions".to_string(),
+        _ => String::new(),
+    }
+}
+
 /// Build the shell command string for launching a claude agent.
 ///
 /// `claude_config_dir` is a caller-side environment variable that must be
@@ -190,13 +209,7 @@ pub(super) fn build_agent_command(
     // `skip_permissions = true` is impossible from the public surface;
     // internal callers (the wizard's WizardStage::Run path) pass both
     // as defaults (None / false) and let this resolution stand.
-    let permission_flag_owned: String = match (permission_mode, skip_permissions) {
-        (Some(mode), _) if !mode.is_empty() => {
-            format!(" --permission-mode {}", shell_escape_arg(mode))
-        }
-        (_, true) => " --dangerously-skip-permissions".to_string(),
-        _ => String::new(),
-    };
+    let permission_flag_owned = permission_flag(permission_mode, skip_permissions);
     let skip_flag = permission_flag_owned.as_str();
     // Fold `CLAUDE_CONFIG_DIR=val` into env(1)'s argv so the assignment takes
     // effect regardless of what wraps the resulting command (timeout, sandbox
@@ -673,6 +686,8 @@ pub(super) fn launch_container(
     allowed_tools: &str,
     timeout: Duration,
     protected_doc_rel: Option<&Path>,
+    skip_permissions: bool,
+    permission_mode: Option<&str>,
 ) -> Result<String> {
     let runtime_cmd = match runtime {
         ContainerMode::Docker => "docker",
@@ -780,12 +795,15 @@ pub(super) fn launch_container(
         }
     }
 
-    // Image and command
+    // Image and command. GH#59: emit the same permission flag the local path
+    // and `container start` use — without it claude prompts for every tool and
+    // the headless container agent blocks forever (a GH#55 stall cause).
+    let skip_flag = permission_flag(permission_mode, skip_permissions);
     args.push(image.to_string());
     args.push("bash".to_string());
     args.push("-c".to_string());
     args.push(format!(
-        "cd /workspaces/repo && timeout {timeout_secs}s claude --model {model} --allowedTools '{allowed_tools}' -- \"$(cat KICKOFF.md)\""
+        "cd /workspaces/repo && timeout {timeout_secs}s claude{skip_flag} --model {model} --allowedTools '{allowed_tools}' -- \"$(cat KICKOFF.md)\""
     ));
 
     let output = Command::new(runtime_cmd)

--- a/crosslink/src/commands/kickoff/run.rs
+++ b/crosslink/src/commands/kickoff/run.rs
@@ -248,6 +248,8 @@ pub fn run(
                 &allowed_tools,
                 opts.timeout,
                 protected_doc_rel.as_deref(),
+                opts.skip_permissions,
+                opts.permission_mode,
             )?;
 
             if opts.quiet {

--- a/crosslink/src/commands/kickoff/tests.rs
+++ b/crosslink/src/commands/kickoff/tests.rs
@@ -2980,3 +2980,25 @@ fn test_reconcile_completion_by_worktree_scans_design_dir() {
     assert_eq!(reread.runs[0].status, "completed");
     assert_eq!(reread.stage, "complete");
 }
+
+// GH#59: the permission flag both the local and container launch paths emit.
+#[test]
+fn test_permission_flag_postures() {
+    // skip_permissions → the full-bypass flag.
+    assert_eq!(
+        permission_flag(None, true),
+        " --dangerously-skip-permissions"
+    );
+    // permission_mode wins over skip_permissions (mode is shell-escaped).
+    assert_eq!(
+        permission_flag(Some("acceptEdits"), true),
+        " --permission-mode 'acceptEdits'"
+    );
+    // Empty permission_mode falls through to skip_permissions.
+    assert_eq!(
+        permission_flag(Some(""), true),
+        " --dangerously-skip-permissions"
+    );
+    // Neither → no flag (claude prompts per tool — the GH#55 container stall).
+    assert_eq!(permission_flag(None, false), "");
+}


### PR DESCRIPTION
Fixes #59. Likely fixes the container-path half of #55.

`kickoff run --container` built the container's `claude` invocation with **no permission flag**, while:
- the local (tmux) path emits `--dangerously-skip-permissions` / `--permission-mode` (via `build_agent_command`), and
- `container start` hardcodes `--dangerously-skip-permissions` (`container.rs`).

So a container agent launched through kickoff prompts for every tool and — with no TTY to answer — **blocks forever**. That's a direct cause of the #55 signature ("agent launches; worktree/branch/tmux come up; in-agent analysis never progresses") on the container path. (The other tracked #55 contributor, #31, is already fixed on develop; #9's C-toolchain gap is separate.)

## Change

- Extracted the permission-posture logic from `build_agent_command` into a shared `permission_flag(permission_mode, skip_permissions)` helper, so the local and container paths **cannot drift**.
- `launch_container` now takes `skip_permissions` / `permission_mode` and emits the flag on the in-container `claude` command (`claude{flag} --model …`).
- `run.rs`'s container call site passes `opts.skip_permissions` / `opts.permission_mode`, matching the local branch.

Behavior is unchanged for the local path (same helper, same output — its existing tests still pass).

## Testing

- New `test_permission_flag_postures` pins the shared helper: `skip_permissions` → `--dangerously-skip-permissions`; `permission_mode` wins and is shell-escaped; empty mode falls through; neither → no flag.
- Existing `test_build_agent_command_*` (14) still green — the local path is unaffected.
- `cargo clippy -- -D warnings -W clippy::unwrap_used -W clippy::expect_used` clean; `cargo fmt --check` clean.

Part of the vsdd kickoff-bundle epic (magnificentlycursed/crosslink#2); filed per its triage (test #59 first as the cheapest plausible #55 cause).

Authored by Claude Code on behalf of @magnificentlycursed.

Generated with [Claude Code](https://claude.com/claude-code)
