### PR TITLE
fix(container): agent-image C toolchain + safe /host-auth/*.env parsing (gh#9, gh#10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   Git 2.42.0); on older Git they now fall back to an equivalent sequence
   (detached worktree + `git checkout --orphan` + clearing the tree) that yields
   the same empty unborn orphan branch (forecast-bio/crosslink#655).
+- The container entrypoint no longer `source`s `/host-auth/*.env` (gh#10).
+  Sourcing executed the file as shell: a token containing spaces or shell
+  metacharacters ran as commands, leaked credential fragments into the
+  container log, and silently truncated the exported value. The entrypoint
+  now parses the files line-by-line, honors only `CLAUDE_CODE_OAUTH_TOKEN`
+  and `ANTHROPIC_API_KEY` (optionally `export`-prefixed, quoted, or CRLF),
+  takes the value verbatim after the first `=` without executing or echoing
+  it, and reports `env-file:` auth resolution only when a recognized key was
+  actually found.
+- The agent container image installs `build-essential` (gh#9). The
+  entrypoint's rustup install provided `rustc`/`cargo` but the image had no
+  C toolchain or linker, so `cargo test`/`clippy`/`check` failed at link
+  inside every container agent — one of the tracked contributors to the
+  gh#55 kickoff stall.
 
 ## [0.9.0-beta.1] - 2026-06-13
 

--- a/crosslink/resources/container/Dockerfile
+++ b/crosslink/resources/container/Dockerfile
@@ -13,9 +13,11 @@ FROM ubuntu:24.04
 ARG TARGETARCH=amd64
 ARG GOSU_VERSION=1.17
 
-# Core tooling (python3 required for crosslink hooks)
+# Core tooling (python3 required for crosslink hooks; build-essential
+# provides the C toolchain/linker the entrypoint's rustup install has no
+# counterpart for — without cc, cargo test/clippy/check fail at link, GH#9)
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    git openssh-client curl ca-certificates jq python3 sudo \
+    git openssh-client curl ca-certificates jq python3 sudo build-essential \
     && rm -rf /var/lib/apt/lists/*
 
 # Remove default ubuntu user (occupies UID 1000, conflicts with host UID remapping)

--- a/crosslink/resources/container/entrypoint.sh
+++ b/crosslink/resources/container/entrypoint.sh
@@ -30,15 +30,35 @@ if [ -f /host-auth/.credentials.json ]; then
     AUTH_RESOLVED="credentials-file"
 fi
 
-# 2. Env files from host mount. Any `/host-auth/*.env` is sourced so callers can
-#    drop a `kickoff.env` containing CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_API_KEY.
+# 2. Env files from host mount. Callers can drop a `kickoff.env` containing
+#    CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_API_KEY. Parsed line-by-line, never
+#    sourced (GH#10): sourcing executes the file as shell, so a token
+#    containing spaces or shell metacharacters ran as commands, leaked
+#    fragments into the container log, and silently truncated the exported
+#    value. Only the two auth keys are honored; the value is everything after
+#    the first `=`, taken verbatim (one layer of matching quotes and any
+#    trailing CR stripped), and is never echoed.
 shopt -s nullglob
 for env_file in /host-auth/*.env; do
-    # shellcheck disable=SC1090
-    set -a
-    source "$env_file"
-    set +a
-    if [ -z "$AUTH_RESOLVED" ]; then
+    file_resolved=""
+    while IFS= read -r line || [ -n "$line" ]; do
+        line="${line%$'\r'}"
+        line="${line#export }"
+        case "$line" in
+            CLAUDE_CODE_OAUTH_TOKEN=* | ANTHROPIC_API_KEY=*) ;;
+            *) continue ;;
+        esac
+        key="${line%%=*}"
+        value="${line#*=}"
+        case "$value" in
+            \"*\") value="${value#\"}"; value="${value%\"}" ;;
+            \'*\') value="${value#\'}"; value="${value%\'}" ;;
+        esac
+        [ -n "$value" ] || continue
+        export "$key=$value"
+        file_resolved="1"
+    done < "$env_file"
+    if [ -n "$file_resolved" ] && [ -z "$AUTH_RESOLVED" ]; then
         AUTH_RESOLVED="env-file:$(basename "$env_file")"
     fi
 done


### PR DESCRIPTION
Fixes #9. Fixes #10. Together with #59 (PR in flight), this addresses every tracked container-side contributor to the #55 kickoff stall.

## gh#10 — entrypoint `source`s `/host-auth/*.env` (`d40526d3`)

`source "$env_file"` (under `set -a`) executes the file as shell. A token whose value contains spaces or shell metacharacters was word-split: the exported value silently truncated at the first space, and the remainder ran as a command inside the container — with fragments landing in the docker log via the container's stdout.

The entrypoint now parses the files line-by-line and honors exactly two keys — `CLAUDE_CODE_OAUTH_TOKEN` and `ANTHROPIC_API_KEY` (optional leading `export ` accepted for compatibility). The value is everything after the first `=`, taken verbatim — never executed, never echoed — with one layer of matching surrounding quotes and any trailing CR stripped. Other keys, comments, and blank lines are ignored, and `env-file:` auth resolution is only reported when a recognized key was actually found (previously any `*.env` claimed resolution even if it set nothing).

Verified against an adversarial fixture (extracting the real parsing block): an injection payload embedded in the token value does not execute, the metachar token exports verbatim, quoted/CRLF/`export`-prefixed values parse correctly, and a `PATH=` line is ignored by the allowlist.

## gh#9 — agent image has no C toolchain (`0fbd11b6`)

The entrypoint's rustup install provides `rustc`/`cargo`, but the image's apt set (`git openssh-client curl ca-certificates jq python3 sudo`) contains no `cc`/linker — so `cargo test`/`clippy`/`check` failed at link inside every container agent, one of the tracked #55 contributors. `build-essential` is added to the core tooling layer.

## Testing

- `bash -n` clean; adversarial fixture test above for the parsing block.
- Both files are `include_str!`-embedded (`container.rs`) and shipped by `container build`; container tests green, full bin suite green.
- `cargo clippy -- -D warnings -W clippy::unwrap_used -W clippy::expect_used` clean; `cargo fmt --check` clean.

Part of the vsdd kickoff-bundle epic (magnificentlycursed/crosslink#2, container dispatch cluster).

Note: the CHANGELOG entries are placed at the tail of `### Fixed` (rather than the top) so this PR and #59's PR merge cleanly in either order — their hunks are disjoint; verified with a 3-way merge simulation.

Authored by Claude Code on behalf of @magnificentlycursed.

Generated with [Claude Code](https://claude.com/claude-code)
