### PR TITLE
fix(kickoff/swarm): flow-integrity and enforcement defect cluster (gh#19, gh#56, gh#57, gh#58, gh#60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,38 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   and no local hub data exists, and clears it back to `"active"` on a
   successful poll (a transient fetch failure over existing local data does not
   flap).
+- `kickoff plan --dry-run` and `kickoff run --dry-run` are side-effect-free
+  (gh#19). Both created a real git worktree, branch, and sentinel files — and
+  `plan` a permanent `PlanRecord` — before their dry-run guard, so repeated
+  dry-runs accumulated orphan worktrees and phantom "planning" rows that no
+  cleanup flag reclaimed. The guards now run before any creation and print the
+  would-be worktree/branch/agent names. (`run --dry-run` still creates the
+  tracker issue when none is passed, since the printed prompt embeds its id.)
+- The launch command writes a `TIMEOUT` sentinel to `.kickoff-status` when the
+  timeout wrapper kills the agent (gh#60) — on both the local (tmux) and
+  container paths, via an exit-code-124 trailer. Killed agents previously kept
+  their `RUNNING` sentinel forever and only the wall-clock check ever noticed;
+  `TIMEOUT` now classifies as `timed-out` in status normalization.
+- Design docs using the documented H2 `## Phase:` / `## Layer:` headers
+  produce requirement groups for swarm phasing (gh#57). The parser previously
+  recognized only H3 `### Phase N:` headers inside `## Requirements`; the
+  documented H2 form silently fell into `unknown_sections` and phasing intent
+  degraded to auto-decomposition.
+- The `/design` skill no longer resets `pipeline.json` on `--continue`
+  (gh#56). Its pipeline-state step wrote the file via an unconditional
+  heredoc, wiping `plans`/`runs` history and regressing `stage` on designs
+  that had already advanced; it now creates the file only when absent and
+  otherwise updates `doc_hash`/`design_doc` in place, preserving history.
+- Agent hook enforcement matches the documented contract (gh#58). The shipped
+  `agent_overrides` (and the hook's built-in agent defaults) blocked only
+  destructive operations while the guides and the generated KICKOFF.md prompt
+  claimed "no push, no merge, gated commits": `git merge`/`rebase`/
+  `cherry-pick`/`reset`, stash/tag/patch, and branch surgery are now
+  mechanically blocked for agents and `git commit` is gated on an active
+  issue. Plain `git push` remains permitted because the CI-verify flow
+  instructs the agent to push a draft PR (force-push stays always blocked) —
+  the prompt and guides now state that contract accurately instead of
+  overclaiming.
 - Hub-cache init no longer fails with "Author identity unknown" on a host whose
   git identity is present but empty (gh#34). `ensure_cache_git_identity` checked
   only that `git config user.email` *succeeded* — but `git config` exits 0 for a

--- a/crosslink/resources/claude/commands/design.md
+++ b/crosslink/resources/claude/commands/design.md
@@ -162,7 +162,9 @@ After validation:
 
 ### Pipeline State Initialization
 
-After writing the design document, create the pipeline state file so the kickoff wizard can track it:
+After writing the design document, ensure the pipeline state file exists so the kickoff wizard can track it. **Never overwrite an existing `pipeline.json` wholesale** — on `--continue`, the design may already have advanced through planning/runs, and resetting the file wipes that history and regresses its stage.
+
+- **If `.design/<slug>.pipeline.json` does not exist yet**, create it:
 
 ```bash
 cat > .design/<slug>.pipeline.json << 'PIPELINE_EOF'
@@ -175,6 +177,15 @@ cat > .design/<slug>.pipeline.json << 'PIPELINE_EOF'
   "runs": []
 }
 PIPELINE_EOF
+```
+
+- **If it already exists** (the `--continue` case), update only `doc_hash` (and `design_doc` if the doc was renamed), preserving `stage`, `plans`, and `runs`:
+
+```bash
+HASH=$(shasum -a 256 .design/<slug>.md | awk '{print "sha256:" $1}')
+jq --arg h "$HASH" --arg d ".design/<slug>.md" '.doc_hash = $h | .design_doc = $d' \
+  .design/<slug>.pipeline.json > .design/<slug>.pipeline.json.tmp \
+  && mv .design/<slug>.pipeline.json.tmp .design/<slug>.pipeline.json
 ```
 
 Compute the `doc_hash` as the SHA-256 hex digest of the design doc file content, prefixed with `sha256:`. You can compute it with: `shasum -a 256 .design/<slug>.md | awk '{print "sha256:" $1}'`

--- a/crosslink/resources/claude/hooks/work-check.py
+++ b/crosslink/resources/claude/hooks/work-check.py
@@ -35,13 +35,19 @@ DEFAULT_BLOCKED_GIT = [
     "git reset", "git clean",
 ]
 
-# Reduced block list for agents — they need push/commit/merge for their workflow
-# but force-push, hard-reset, and clean remain dangerous even for agents.
+# Agent block list (GH#58): matches the contract the generated KICKOFF.md
+# prompt and the guides state — merge/rebase/cherry-pick, resets, stash/tag/
+# patch, and branch surgery are mechanically blocked; `git commit` is gated
+# on an active issue. Plain `git push` stays allowed because the CI-verify
+# flow instructs the agent to push a draft PR (force-push is always blocked).
 DEFAULT_AGENT_BLOCKED_GIT = [
     "git push --force", "git push -f",
-    "git reset --hard",
+    "git merge", "git rebase", "git cherry-pick",
+    "git reset",
     "git clean -f", "git clean -fd", "git clean -fdx",
     "git checkout .", "git restore .",
+    "git stash", "git tag", "git am", "git apply",
+    "git branch -d", "git branch -D", "git branch -m",
 ]
 
 # Git commands that are blocked UNLESS there is an active crosslink issue.
@@ -92,7 +98,8 @@ def load_config(crosslink_dir):
     config = load_config_merged(crosslink_dir)
     if not config:
         if is_agent:
-            return "relaxed", list(DEFAULT_AGENT_BLOCKED_GIT), [], allowed, True, "off"
+            # GH#58: agents get the gated-commit contract even with no config.
+            return "relaxed", list(DEFAULT_AGENT_BLOCKED_GIT), list(DEFAULT_GATED_GIT), allowed, True, "off"
         return mode, blocked, gated, allowed, False, discipline
 
     if config.get("tracking_mode") in ("strict", "normal", "relaxed"):
@@ -111,7 +118,9 @@ def load_config(crosslink_dir):
         overrides = config.get("agent_overrides", {})
         mode = overrides.get("tracking_mode", "relaxed")
         blocked = overrides.get("blocked_git_commands", list(DEFAULT_AGENT_BLOCKED_GIT))
-        gated = overrides.get("gated_git_commands", [])
+        # GH#58: default agents to the gated-commit contract the docs and
+        # generated prompt describe; an explicit override still wins.
+        gated = overrides.get("gated_git_commands", list(DEFAULT_GATED_GIT))
         discipline = overrides.get("comment_discipline", "off")
         # Merge agent lint/test commands into allowed prefixes (#495)
         for cmd in overrides.get("agent_lint_commands", []):

--- a/crosslink/resources/crosslink/hook-config.json
+++ b/crosslink/resources/crosslink/hook-config.json
@@ -30,11 +30,14 @@
     "tracking_mode": "relaxed",
     "blocked_git_commands": [
       "git push --force", "git push -f",
-      "git reset --hard",
+      "git merge", "git rebase", "git cherry-pick",
+      "git reset",
       "git clean -f", "git clean -fd", "git clean -fdx",
-      "git checkout .", "git restore ."
+      "git checkout .", "git restore .",
+      "git stash", "git tag", "git am", "git apply",
+      "git branch -d", "git branch -D", "git branch -m"
     ],
-    "gated_git_commands": [],
+    "gated_git_commands": ["git commit"],
     "agent_lint_commands": [],
     "agent_test_commands": []
   },

--- a/crosslink/src/commands/design_doc.rs
+++ b/crosslink/src/commands/design_doc.rs
@@ -37,6 +37,10 @@ enum Section {
     Architecture,
     OpenQuestions,
     OutOfScope,
+    /// An H2 `## Phase: <name>` / `## Layer: <name>` section — the
+    /// documented explicit-phasing form (gh#57). Carries the raw header
+    /// text after `## `.
+    PhaseGroup(String),
     Unknown(String),
 }
 
@@ -96,14 +100,28 @@ pub(crate) fn parse_design_doc(content: &str) -> DesignDoc {
             flush_block(&mut doc, &section, &current_block);
             current_block.clear();
 
-            section = match rest.trim().to_lowercase().as_str() {
-                "summary" => Section::Summary,
-                "requirements" => Section::Requirements,
-                "acceptance criteria" => Section::AcceptanceCriteria,
-                "architecture" => Section::Architecture,
-                "open questions" => Section::OpenQuestions,
-                "out of scope" => Section::OutOfScope,
-                other => Section::Unknown(other.to_string()),
+            let trimmed = rest.trim();
+            let lowered = trimmed.to_lowercase();
+            // gh#57: the swarm guide documents H2 `## Phase:` / `## Layer:`
+            // headers as the explicit-phasing form; previously only H3
+            // headers inside `## Requirements` were recognized and the H2
+            // form silently fell into unknown_sections.
+            section = if lowered.starts_with("phase:")
+                || lowered.starts_with("phase ")
+                || lowered.starts_with("layer:")
+                || lowered.starts_with("layer ")
+            {
+                Section::PhaseGroup(trimmed.to_string())
+            } else {
+                match lowered.as_str() {
+                    "summary" => Section::Summary,
+                    "requirements" => Section::Requirements,
+                    "acceptance criteria" => Section::AcceptanceCriteria,
+                    "architecture" => Section::Architecture,
+                    "open questions" => Section::OpenQuestions,
+                    "out of scope" => Section::OutOfScope,
+                    other => Section::Unknown(other.to_string()),
+                }
             };
             continue;
         }
@@ -133,6 +151,19 @@ fn flush_block(doc: &mut DesignDoc, section: &Section, block: &str) {
         Section::Architecture => doc.architecture = block.trim().to_string(),
         Section::OpenQuestions => doc.open_questions = parse_list_items(block),
         Section::OutOfScope => doc.out_of_scope = parse_list_items(block),
+        Section::PhaseGroup(header) => {
+            // gh#57: H2 `## Phase:` / `## Layer:` — same group semantics as
+            // the H3-under-Requirements form. Items also extend the flat
+            // requirements list, mirroring how H3 groups flatten.
+            let (name, hint) = parse_layer_header(header);
+            let items = parse_list_items_collapsing_sub_bullets(block);
+            doc.requirements.extend(items.clone());
+            doc.requirement_groups.push(RequirementGroup {
+                name,
+                execution_hint: hint,
+                items,
+            });
+        }
         Section::Unknown(name) => {
             let trimmed = block.trim();
             if !trimmed.is_empty() {
@@ -538,6 +569,40 @@ mod tests {
         assert_eq!(doc.unknown_sections.len(), 1);
         assert_eq!(doc.unknown_sections[0].0, "references");
         assert_eq!(doc.unknown_sections[0].1, "See RFC 1234.");
+    }
+
+    // GH#57: the swarm guide documents H2 `## Phase:` / `## Layer:` headers;
+    // they must produce requirement groups, not fall into unknown_sections.
+    #[test]
+    fn test_parse_h2_phase_headers_documented_form() {
+        let input = "## Phase: Database Migrations\n- Add user table\n- Add session table\n\n## Phase: API Endpoints (parallel)\n- Registration endpoint\n- Login endpoint\n";
+        let doc = parse_design_doc(input);
+        assert_eq!(doc.requirement_groups.len(), 2);
+        assert_eq!(doc.requirement_groups[0].name, "Database Migrations");
+        assert_eq!(
+            doc.requirement_groups[0].items,
+            vec!["Add user table", "Add session table"]
+        );
+        assert_eq!(doc.requirement_groups[1].name, "API Endpoints");
+        assert_eq!(doc.requirement_groups[1].execution_hint, "parallel");
+        // Flat requirements mirror the flattened groups (backward compat),
+        // and nothing lands in unknown_sections.
+        assert_eq!(doc.requirements.len(), 4);
+        assert!(doc.unknown_sections.is_empty());
+    }
+
+    // GH#57: numbered H2 form (`## Layer 1: Foundation (sequential)`) and the
+    // guard that a section merely starting with the word "phased" is NOT
+    // treated as a phase group.
+    #[test]
+    fn test_parse_h2_layer_numbered_and_no_false_positive() {
+        let input = "## Layer 1: Foundation (sequential)\n- Base schema\n\n## Phased Rollout\n\nProse about rollout.\n";
+        let doc = parse_design_doc(input);
+        assert_eq!(doc.requirement_groups.len(), 1);
+        assert_eq!(doc.requirement_groups[0].name, "Foundation");
+        assert_eq!(doc.requirement_groups[0].execution_hint, "sequential");
+        assert_eq!(doc.unknown_sections.len(), 1);
+        assert_eq!(doc.unknown_sections[0].0, "phased rollout");
     }
 
     #[test]

--- a/crosslink/src/commands/kickoff/helpers.rs
+++ b/crosslink/src/commands/kickoff/helpers.rs
@@ -786,6 +786,11 @@ pub(super) fn normalize_status(raw: &str) -> String {
         "done".to_string()
     } else if lower.contains("fail") || lower.contains("error") {
         "failed".to_string()
+    } else if lower.contains("timeout") || lower.contains("timed") {
+        // gh#60: the launch command writes a TIMEOUT sentinel when the
+        // timeout wrapper kills the agent; classify it like the wall-clock
+        // derived "timed-out" value.
+        "timed-out".to_string()
     } else if lower.contains("running") || raw.is_empty() {
         "running".to_string()
     } else {

--- a/crosslink/src/commands/kickoff/launch.rs
+++ b/crosslink/src/commands/kickoff/launch.rs
@@ -212,14 +212,20 @@ pub(super) fn build_agent_command(
     let claude_cmd = format!(
         "env -u CLAUDECODE {env_assignment}claude{skip_flag} --model {escaped_model} --allowedTools {escaped_tools} -- \"$(cat {escaped_kickoff})\""
     );
-    sandbox_command.map_or_else(
+    let launch = sandbox_command.map_or_else(
         || format!("{timeout_cmd} {timeout_secs}s {claude_cmd}"),
         |cmd| {
             let escaped_worktree = shell_escape_arg(&worktree_dir.to_string_lossy());
             let expanded = cmd.replace("{{worktree}}", &escaped_worktree);
             format!("{timeout_cmd} {timeout_secs}s {expanded} {claude_cmd}")
         },
-    )
+    );
+    // gh#60: persist the TIMEOUT sentinel at kill time. GNU timeout exits
+    // 124 when it killed the wrapped command; without this trailer the
+    // sentinel stays RUNNING after a timeout kill and only the wall-clock
+    // check ever notices.
+    let status_path = shell_escape_arg(&worktree_dir.join(".kickoff-status").to_string_lossy());
+    format!("{launch}; if [ $? -eq 124 ]; then printf 'TIMEOUT\\n' > {status_path}; fi")
 }
 
 /// Pre-flight check: verify all required external commands are present before
@@ -785,7 +791,7 @@ pub(super) fn launch_container(
     args.push("bash".to_string());
     args.push("-c".to_string());
     args.push(format!(
-        "cd /workspaces/repo && timeout {timeout_secs}s claude --model {model} --allowedTools '{allowed_tools}' -- \"$(cat KICKOFF.md)\""
+        "cd /workspaces/repo && timeout {timeout_secs}s claude --model {model} --allowedTools '{allowed_tools}' -- \"$(cat KICKOFF.md)\"; if [ $? -eq 124 ]; then printf 'TIMEOUT\\n' > /workspaces/repo/.kickoff-status; fi"
     ));
 
     let output = Command::new(runtime_cmd)

--- a/crosslink/src/commands/kickoff/plan.rs
+++ b/crosslink/src/commands/kickoff/plan.rs
@@ -172,16 +172,35 @@ pub fn plan(crosslink_dir: &Path, db: &Database, opts: &PlanOpts) -> Result<()> 
         None
     };
 
-    // 3. Create worktree
+    // 3. Build prompt (with plan copy instruction if doc_path is known)
+    let plan_copy_target = opts.doc_path.map(super::pipeline::plan_path_for_doc);
+    let prompt = build_plan_prompt(opts.doc, issue_id, plan_copy_target.as_deref());
+
+    // Dry run: print what would happen and exit BEFORE any side effect —
+    // no worktree, no branch, no sentinel, no PlanRecord (gh#19). The
+    // printed worktree/branch are the would-be names create_worktree
+    // derives from the slug.
+    if opts.dry_run {
+        let parent_id =
+            AgentConfig::load(crosslink_dir)?.map_or_else(|| "driver".to_string(), |c| c.agent_id);
+        let agent_id = format!("{parent_id}--{slug}");
+        println!("{prompt}");
+        println!("---");
+        println!(
+            "Worktree: {}",
+            root.join(".worktrees").join(&slug).display()
+        );
+        println!("Branch:   feature/{slug}");
+        println!("Agent:    {agent_id}");
+        return Ok(());
+    }
+
+    // 4. Create worktree
     let (worktree_dir, branch_name) = create_worktree(&root, &slug, None)?;
 
     // Write slug sentinel so other commands can identify this worktree
     std::fs::write(worktree_dir.join(".kickoff-slug"), &slug)
         .context("Failed to write .kickoff-slug sentinel")?;
-
-    // 4. Build prompt (with plan copy instruction if doc_path is known)
-    let plan_copy_target = opts.doc_path.map(super::pipeline::plan_path_for_doc);
-    let prompt = build_plan_prompt(opts.doc, issue_id, plan_copy_target.as_deref());
 
     // 5. Write PLAN_KICKOFF.md
     std::fs::write(worktree_dir.join("PLAN_KICKOFF.md"), &prompt)
@@ -197,19 +216,6 @@ pub fn plan(crosslink_dir: &Path, db: &Database, opts: &PlanOpts) -> Result<()> 
             &format!("driver--{slug}"),
             &worktree_dir.to_string_lossy(),
         );
-    }
-
-    // Dry run: print and exit
-    if opts.dry_run {
-        let parent_id =
-            AgentConfig::load(crosslink_dir)?.map_or_else(|| "driver".to_string(), |c| c.agent_id);
-        let agent_id = format!("{parent_id}--{slug}");
-        println!("{prompt}");
-        println!("---");
-        println!("Worktree: {}", worktree_dir.display());
-        println!("Branch:   {branch_name}");
-        println!("Agent:    {agent_id}");
-        return Ok(());
     }
 
     // 7. Init worktree agent

--- a/crosslink/src/commands/kickoff/prompt.rs
+++ b/crosslink/src/commands/kickoff/prompt.rs
@@ -216,12 +216,15 @@ latest state from other agents, run `crosslink sync`.
 The following commands are blocked by project policy and will be rejected. If you need one of
 these, ask the user to run it manually:
 
-- `git push`, `git merge`, `git rebase`, `git cherry-pick` — remote/branch operations
+- `git merge`, `git rebase`, `git cherry-pick` — branch surgery
 - `git reset`, `git checkout .`, `git restore .`, `git clean` — destructive resets
 - `git stash`, `git tag`, `git am`, `git apply` — stash/tag/patch operations
 - `git branch -d`, `git branch -D`, `git branch -m` — branch deletion/renaming
+- `git push --force`, `git push -f` — always blocked
 
 **Gated** (require active crosslink issue): `git commit`
+**Push**: plain `git push` is reserved for the CI-verification steps above when
+they are present in this prompt; do not push otherwise.
 **Always allowed**: `git status`, `git diff`, `git log`, `git show`, `git branch` (listing)
 
 ## Instructions

--- a/crosslink/src/commands/kickoff/run.rs
+++ b/crosslink/src/commands/kickoff/run.rs
@@ -83,23 +83,18 @@ pub fn run(
         id
     };
 
-    // 3. Create worktree and feature branch (or use existing branch)
-    let (worktree_dir, branch_name) = if let Some(br) = opts.branch {
-        // Use existing branch — check if worktree exists
-        let wt_slug = br.strip_prefix("feature/").unwrap_or(br);
-        let worktree_dir = root.join(".worktrees").join(wt_slug);
-        if worktree_dir.exists() {
-            (worktree_dir, br.to_string())
-        } else {
-            create_worktree(&root, wt_slug, None)?
-        }
-    } else {
-        create_worktree(&root, &compact_name, None)?
-    };
-
-    // Write slug sentinel so other commands can identify this worktree
-    std::fs::write(worktree_dir.join(".kickoff-slug"), &compact_name)
-        .context("Failed to write .kickoff-slug sentinel")?;
+    // 3. Resolve the worktree slug and branch name up front. Creation is
+    //    deferred until after the dry-run gate below so a dry run is
+    //    side-effect-free (gh#19) — these are the exact names
+    //    create_worktree derives.
+    let (wt_slug, branch_name) = opts.branch.map_or_else(
+        || (compact_name.clone(), format!("feature/{compact_name}")),
+        |br| {
+            let wt_slug = br.strip_prefix("feature/").unwrap_or(br);
+            (wt_slug.to_string(), br.to_string())
+        },
+    );
+    let worktree_dir = root.join(".worktrees").join(&wt_slug);
 
     // 4. Detect project conventions, then extend with any explicit additions
     //    from `hook-config.json`'s `kickoff.allowed_tools` array so projects
@@ -113,7 +108,30 @@ pub fn run(
     // 5. Build the prompt
     let prompt = build_prompt(opts, issue_id, &branch_name, &conventions);
 
-    // 6. Write KICKOFF.md to worktree
+    // Dry run: print the prompt and the would-be worktree/branch/agent, then
+    // exit BEFORE creating the worktree, branch, or any sentinel file (gh#19).
+    if opts.dry_run {
+        println!("{prompt}");
+        println!("---");
+        println!("Worktree: {}", worktree_dir.display());
+        println!("Branch:   {branch_name}");
+        println!("Agent:    {compact_name}");
+        return Ok(compact_name);
+    }
+
+    // 6. Create worktree and feature branch (or reuse the existing worktree
+    //    when --branch points at one), then write the kickoff files into it.
+    let (worktree_dir, branch_name) = if worktree_dir.exists() && opts.branch.is_some() {
+        (worktree_dir, branch_name)
+    } else {
+        create_worktree(&root, &wt_slug, None)?
+    };
+
+    // Write slug sentinel so other commands can identify this worktree
+    std::fs::write(worktree_dir.join(".kickoff-slug"), &compact_name)
+        .context("Failed to write .kickoff-slug sentinel")?;
+
+    // 6a. Write KICKOFF.md to worktree
     std::fs::write(worktree_dir.join("KICKOFF.md"), &prompt)
         .context("Failed to write KICKOFF.md")?;
 
@@ -153,16 +171,6 @@ pub fn run(
 
     // 7. Exclude kickoff files from git
     exclude_kickoff_files(&worktree_dir)?;
-
-    // Dry run: print prompt and exit (skip agent init — no launch needed)
-    if opts.dry_run {
-        println!("{prompt}");
-        println!("---");
-        println!("Worktree: {}", worktree_dir.display());
-        println!("Branch:   {branch_name}");
-        println!("Agent:    {compact_name}");
-        return Ok(compact_name);
-    }
 
     // 8. Initialize crosslink + agent in worktree (only for real launches)
     let agent_id = init_worktree_agent(&worktree_dir, crosslink_dir, &compact_name)?;

--- a/crosslink/src/commands/kickoff/tests.rs
+++ b/crosslink/src/commands/kickoff/tests.rs
@@ -1770,7 +1770,7 @@ fn test_build_agent_command_without_sandbox() {
     );
     assert_eq!(
         cmd,
-        "timeout 3600s env -u CLAUDECODE claude --model 'opus' --allowedTools 'Read,Write' -- \"$(cat 'KICKOFF.md')\""
+        "timeout 3600s env -u CLAUDECODE claude --model 'opus' --allowedTools 'Read,Write' -- \"$(cat 'KICKOFF.md')\"; if [ $? -eq 124 ]; then printf 'TIMEOUT\\n' > '/tmp/worktree/.kickoff-status'; fi"
     );
 }
 
@@ -1932,7 +1932,7 @@ fn test_build_agent_command_propagates_claude_config_dir() {
     );
     assert_eq!(
         cmd,
-        "timeout 3600s env -u CLAUDECODE CLAUDE_CONFIG_DIR='/Users/me/.claude-work' claude --model 'opus' --allowedTools 'Read,Write' -- \"$(cat 'KICKOFF.md')\""
+        "timeout 3600s env -u CLAUDECODE CLAUDE_CONFIG_DIR='/Users/me/.claude-work' claude --model 'opus' --allowedTools 'Read,Write' -- \"$(cat 'KICKOFF.md')\"; if [ $? -eq 124 ]; then printf 'TIMEOUT\\n' > '/tmp/worktree/.kickoff-status'; fi"
     );
 }
 
@@ -2979,4 +2979,14 @@ fn test_reconcile_completion_by_worktree_scans_design_dir() {
     let reread = pipeline::read_pipeline_state(&doc).unwrap();
     assert_eq!(reread.runs[0].status, "completed");
     assert_eq!(reread.stage, "complete");
+}
+
+// GH#60: the TIMEOUT sentinel written by the launch command's exit-124
+// trailer classifies as "timed-out", same as the wall-clock derivation.
+#[test]
+fn test_normalize_status_timeout_sentinel() {
+    assert_eq!(normalize_status("TIMEOUT"), "timed-out");
+    assert_eq!(normalize_status("timed-out"), "timed-out");
+    assert_eq!(normalize_status("RUNNING"), "running");
+    assert_eq!(normalize_status("DONE".to_lowercase().as_str()), "done");
 }

--- a/crosslink/tests/cli_integration.rs
+++ b/crosslink/tests/cli_integration.rs
@@ -2870,7 +2870,7 @@ fn test_kickoff_dry_run_prints_prompt_and_metadata() {
 }
 
 #[test]
-fn test_kickoff_dry_run_creates_kickoff_md() {
+fn test_kickoff_dry_run_is_side_effect_free_and_prints_prompt() {
     let dir = test_dir();
     init_git_and_crosslink(dir.path());
 
@@ -2880,38 +2880,36 @@ fn test_kickoff_dry_run_creates_kickoff_md() {
     );
     assert!(success);
 
-    // Extract worktree path from output
+    // GH#19: a dry run must not create the worktree (or anything in it) —
+    // the printed path is the would-be location only.
     let worktree_line = stdout
         .lines()
         .find(|l| l.starts_with("Worktree:"))
         .expect("No Worktree line in output");
     let worktree_path = worktree_line.trim_start_matches("Worktree:").trim();
-
-    // KICKOFF.md should exist in the worktree
-    let kickoff_path = std::path::Path::new(worktree_path).join("KICKOFF.md");
     assert!(
-        kickoff_path.exists(),
-        "KICKOFF.md not found at {}",
-        kickoff_path.display()
+        !std::path::Path::new(worktree_path).exists(),
+        "dry run must not create the worktree, but {worktree_path} exists"
     );
 
-    let content = std::fs::read_to_string(&kickoff_path).unwrap();
-    assert!(content.contains("test file creation"));
+    // The full prompt is printed to stdout instead of being written to a
+    // KICKOFF.md — the same contract markers apply to the printed prompt.
+    assert!(stdout.contains("test file creation"));
     assert!(
-        content.contains("Verify agent setup"),
-        "KICKOFF.md should include agent verification step"
+        stdout.contains("Verify agent setup"),
+        "printed prompt should include agent verification step"
     );
     assert!(
-        content.contains("crosslink agent status"),
-        "KICKOFF.md should instruct agent to check identity"
+        stdout.contains("crosslink agent status"),
+        "printed prompt should instruct agent to check identity"
     );
     assert!(
-        content.contains("Sync periodically"),
-        "KICKOFF.md should instruct agent to sync during work"
+        stdout.contains("Sync periodically"),
+        "printed prompt should instruct agent to sync during work"
     );
     assert!(
-        content.contains("Final sync"),
-        "KICKOFF.md should instruct agent to sync before ending"
+        stdout.contains("Final sync"),
+        "printed prompt should instruct agent to sync before ending"
     );
 }
 

--- a/docs_src/guides/container-agents.qmd
+++ b/docs_src/guides/container-agents.qmd
@@ -16,7 +16,7 @@ Container execution gives your agents the same workflow with stronger sandboxing
 
 - **Isolation** -- agents cannot access your host filesystem outside the worktree
 - **Reproducibility** -- consistent environment regardless of host OS
-- **Security** -- `--dangerously-skip-permissions` becomes safe inside a container because crosslink hooks still enforce policy (no push, no merge, gated commits)
+- **Security** -- `--dangerously-skip-permissions` becomes safe inside a container because crosslink hooks still enforce policy (no merge/rebase, commits gated on an active issue, force-push always blocked; plain push is reserved for the CI-verify draft-PR flow)
 - **Cross-platform** -- works on Windows, Linux, and macOS anywhere Docker runs
 
 &nbsp;

--- a/docs_src/guides/kickoff.qmd
+++ b/docs_src/guides/kickoff.qmd
@@ -218,7 +218,8 @@ Everything from `--verify ci`, plus an adversarial self-review:
 
 The background agent operates under the same crosslink hook enforcement as interactive sessions:
 
-- **Always blocked:** `git push`, `git merge`, `git rebase`, `git reset`, and other destructive git commands (except when CI verification is enabled, where push is allowed)
+- **Always blocked:** `git merge`, `git rebase`, `git cherry-pick`, `git reset`, force-push, and the other destructive git commands
+- **Push:** plain `git push` is permitted only for the CI-verification draft-PR steps the prompt specifies; force-push is always blocked
 - **Gated on active issue:** `git commit` requires an active crosslink work item
 - **Tool auto-approval:** Only pre-approved tools run without prompting; anything else pauses the agent
 - **Isolated worktree:** All changes are confined to `.worktrees/` -- your main checkout is untouched


### PR DESCRIPTION
Fixes #19. Fixes #56. Fixes #57. Fixes #58. Fixes #60.

The kickoff/swarm flow-integrity and enforcement defect cluster from the vsdd kickoff bundle. One commit per issue.

## gh#19 — `plan`/`run --dry-run` side effects (`2cf4fbd4`)
Both dry-run guards ran after worktree creation (`plan` also after its permanent `PlanRecord` write), so repeated dry-runs accumulated orphan worktrees and phantom "planning" rows no cleanup flag reclaims. The guards now run before any creation and print the would-be worktree/branch/agent names. One deliberate remainder: `run --dry-run` still creates the tracker issue when none is passed, since the printed prompt embeds its id.

## gh#60 — TIMEOUT sentinel never written (`d6ee70c3`)
Both launch paths (local/sandbox and container) now append an exit-code-124 trailer that writes `TIMEOUT` to `.kickoff-status` when the timeout wrapper kills the agent; `normalize_status` classifies it as `timed-out`. Killed agents previously kept `RUNNING` at the sentinel layer forever.

## gh#57 — documented H2 phasing headers dropped (`a4d80b40`)
H2 `## Phase:` / `## Layer:` sections (the form the swarm guide documents) now parse into `RequirementGroup`s via the same header/list machinery as the H3-under-Requirements form, extend flat requirements for backward compat, and no longer fall into `unknown_sections`. "Phased Rollout"-style titles don't false-positive.

## gh#56 — `/design --continue` wipes pipeline.json (`a977e8a2`)
The skill's pipeline-state step now creates the file only when absent; when it exists it updates `doc_hash`/`design_doc` in place via jq, preserving `stage`/`plans`/`runs`.

## gh#58 — hook enforcement vs documented contract (`06ac4a67`)
Agent hook enforcement (`agent_overrides` + work-check.py agent defaults) now mechanically blocks `git merge`/`rebase`/`cherry-pick`/`reset`, stash/tag/patch, and branch surgery, and gates `git commit` on an active issue — matching the claims in the guides and generated prompt. Plain `git push` stays allowed **deliberately**: the CI-verify flow instructs the agent to push a draft PR, so blocking it would break that flow. The prompt's Blocked Actions section and both guides now state that contract accurately (force-push always blocked; plain push reserved for the CI-verification steps) instead of overclaiming "no push".

## Testing
- New: `test_parse_h2_phase_headers_documented_form`, `test_parse_h2_layer_numbered_and_no_false_positive`, `test_normalize_status_timeout_sentinel`; exact-command asserts updated for the TIMEOUT trailer.
- Suites green: kickoff (184), design_doc (47), init (154); `py_compile` clean on work-check.py; full bin suite green.
- CI-exact clippy (`-D warnings -W clippy::unwrap_used -W clippy::expect_used`) and `cargo fmt --check` clean.

CHANGELOG entries are placed mid-`### Fixed` (after the merged gh#48 entry) so this PR, #63, and #64 merge cleanly in any order — verified pairwise with 3-way merge simulations.

Part of the vsdd kickoff-bundle epic (magnificentlycursed/crosslink#2).

Authored by Claude Code on behalf of @magnificentlycursed.

Generated with [Claude Code](https://claude.com/claude-code)
