### PR TITLE
fix(kickoff): expose --skip-permissions/--permission-mode on plan (gh#66) — the plan/tmux half of #55

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   refs into `.git` and never touches the worktree. On v3 it now reads
   `FETCH_HEAD`'s mtime (git rewrites it on every fetch), located via
   `rev-parse --git-path` so it is correct across worktree layouts.
+- `kickoff plan` accepts `--skip-permissions` / `--permission-mode` (gh#66).
+  Plan mode is read-only, so it launched its claude session with no permission
+  flag — which meant a fresh worktree triggered claude's interactive
+  workspace-trust dialog, and a headless dispatcher (no TTY to answer it) hung
+  forever (the plan/tmux half of the gh#55 stall). The flags now match
+  `kickoff run`/`launch`; the default stays off (interactive users still get
+  the dialog — fail-closed), and a headless caller passes `--skip-permissions`,
+  which is what actually clears the trust dialog (`--permission-mode` alone does
+  not). The `kickoff <doc> --plan` form now threads the flags too (they were
+  previously accepted and silently dropped).
 - The dashboard agent-request pane is populated on v3 hubs (gh#49, agent
   requests half). `read_snapshot_v3` hardcoded `agent_requests` empty because
   the request/ack streams live on the agent refs, not a worktree the snapshot

--- a/crosslink/src/commands/kickoff/mod.rs
+++ b/crosslink/src/commands/kickoff/mod.rs
@@ -110,6 +110,8 @@ pub fn dispatch(
             model,
             timeout,
             dry_run,
+            skip_permissions,
+            permission_mode,
         } => {
             let content = std::fs::read_to_string(&doc)
                 .with_context(|| format!("Failed to read design doc: {}", doc.display()))?;
@@ -125,6 +127,8 @@ pub fn dispatch(
                 dry_run,
                 issue,
                 quiet,
+                skip_permissions,
+                permission_mode: permission_mode.as_deref(),
             };
             plan(crosslink_dir, db, &plan_opts)
         }
@@ -235,6 +239,8 @@ fn dispatch_launch(
             dry_run,
             issue,
             quiet,
+            skip_permissions,
+            permission_mode,
         };
         return plan(crosslink_dir, db, &plan_opts);
     }
@@ -320,6 +326,10 @@ fn dispatch_launch(
                 dry_run: false,
                 issue,
                 quiet,
+                // Interactive wizard: a TTY is present to answer the trust
+                // dialog, so plan mode keeps the fail-closed default (gh#66).
+                skip_permissions: false,
+                permission_mode: None,
             };
             plan(crosslink_dir, db, &plan_opts)
         }

--- a/crosslink/src/commands/kickoff/plan.rs
+++ b/crosslink/src/commands/kickoff/plan.rs
@@ -239,9 +239,12 @@ pub fn plan(crosslink_dir: &Path, db: &Database, opts: &PlanOpts) -> Result<()> 
         "PLAN_KICKOFF.md",
         preflight.sandbox_command.as_deref(),
         &worktree_dir,
-        false, // plan mode never skips permissions
+        // gh#66: default false keeps plan read-only and fail-closed; a headless
+        // dispatcher passes --skip-permissions so claude's fresh-worktree
+        // workspace-trust dialog does not block the agent forever.
+        opts.skip_permissions,
         claude_config_dir.as_deref(),
-        None, // plan mode never overrides permission_mode (#603)
+        opts.permission_mode,
     );
 
     let output = Command::new("tmux")

--- a/crosslink/src/commands/kickoff/types.rs
+++ b/crosslink/src/commands/kickoff/types.rs
@@ -218,6 +218,14 @@ pub struct PlanOpts<'a> {
     pub dry_run: bool,
     pub issue: Option<i64>,
     pub quiet: bool,
+    /// Pass `--dangerously-skip-permissions` to the plan agent's claude
+    /// session. Default `false` keeps plan mode read-only and fail-closed;
+    /// headless dispatchers set it so claude's workspace-trust dialog does
+    /// not block the agent (gh#66).
+    pub skip_permissions: bool,
+    /// Pass `--permission-mode <mode>`. Mutually exclusive with
+    /// `skip_permissions`; does not itself clear the trust dialog.
+    pub permission_mode: Option<&'a str>,
 }
 
 /// Detect project conventions from the repo root.

--- a/crosslink/src/main.rs
+++ b/crosslink/src/main.rs
@@ -1744,6 +1744,31 @@ enum KickoffCommands {
         /// Print the analysis prompt without launching
         #[arg(long = "dry-run")]
         dry_run: bool,
+        /// Per-invocation: pass --dangerously-skip-permissions to claude CLI.
+        ///
+        /// Plan mode is read-only, so it launches WITHOUT any permission flag
+        /// by default — which means claude shows its interactive workspace-trust
+        /// dialog for the fresh worktree. A headless dispatcher (no TTY to
+        /// answer the dialog) must pass this so the agent can start (gh#66);
+        /// `--permission-mode` alone does NOT clear the trust dialog. The
+        /// read-only `--allowedTools` set still constrains what the agent runs.
+        #[arg(long)]
+        skip_permissions: bool,
+        /// Per-invocation: pass `--permission-mode <mode>` to claude CLI.
+        ///
+        /// Finer-grained alternative to `--skip-permissions` (same modes as
+        /// `kickoff run`). Note it does not, by itself, clear the first-run
+        /// workspace-trust dialog; use `--skip-permissions` for headless plan
+        /// dispatch. Mutually exclusive with `--skip-permissions`.
+        #[arg(
+            long,
+            value_parser = clap::builder::PossibleValuesParser::new([
+                "acceptEdits", "auto", "bypassPermissions",
+                "default", "dontAsk", "plan",
+            ]),
+            conflicts_with = "skip_permissions"
+        )]
+        permission_mode: Option<String>,
     },
     /// Display a gap report from a previous plan analysis
     ShowPlan {

--- a/crosslink/tests/cli_integration.rs
+++ b/crosslink/tests/cli_integration.rs
@@ -3871,3 +3871,32 @@ fn test_sentinel_schema_migration() {
         "Schema version should be >= 16 (sentinel migration), got {version}"
     );
 }
+
+// gh#66: `kickoff plan` exposes --skip-permissions / --permission-mode (so a
+// headless dispatcher can clear claude's workspace-trust dialog), and they are
+// mutually exclusive like on `kickoff run`. Verified at the clap layer (no tmux).
+#[test]
+fn test_kickoff_plan_permission_flags_are_exposed_and_conflict() {
+    let dir = test_dir();
+    init_git_and_crosslink(dir.path());
+    let (success, _out, err) = run_crosslink(
+        dir.path(),
+        &[
+            "kickoff",
+            "plan",
+            "does-not-matter.md",
+            "--skip-permissions",
+            "--permission-mode",
+            "auto",
+        ],
+    );
+    assert!(
+        !success,
+        "conflicting --skip-permissions + --permission-mode must be rejected"
+    );
+    let e = err.to_lowercase();
+    assert!(
+        e.contains("cannot be used with") || e.contains("conflict"),
+        "expected a clap conflict error naming the two flags, got: {err}"
+    );
+}


### PR DESCRIPTION
Fixes #66. Completes the plan/tmux half of #55 (together with #63, which fixes the container half).

A 2026-08-02 live-fire retest reproduced #55's "kickoff plan agents launch but stall": the tmux pane parks on Claude Code's first-run **workspace-trust dialog** ("Is this a project you trust?") in the freshly-created worktree, which a headless dispatcher never answers. `kickoff plan` launched claude with **no** permission flag — `plan.rs` hardcoded `skip_permissions=false` / `permission_mode=None` — and per `claude --help` the trust dialog is only skipped under `--dangerously-skip-permissions`.

## Approach

The original issue proposed pre-seeding `hasTrustDialogAccepted` into `~/.claude.json`. A codebase-conventions review showed crosslink has **no precedent for writing any user-global file under `~/.claude`** (those are strictly read-only inputs), so that would be a convention-breaking first. Instead this exposes on `kickoff plan` the same two flags `kickoff run`/`launch` already have:

- `--skip-permissions` and `--permission-mode <mode>` added to the `Plan` clap command (mutually exclusive, same modes as `run`).
- Threaded through `PlanOpts` into `plan()`'s `build_agent_command` call (replacing the hardcoded literals).
- The `kickoff <doc> --plan` (`dispatch_launch`) form already *received* these flags but dropped them when building `PlanOpts` — now threaded too.

**Default stays off** — plan mode remains read-only and fail-closed; an interactive user still gets the trust dialog. A headless dispatcher passes `--skip-permissions` to clear it. Note (documented on the flags): `--permission-mode` alone does **not** clear the trust dialog; use `--skip-permissions` for headless plan dispatch. The interactive wizard path keeps the default (a TTY is present to answer the dialog).

Not addressed here: swarm's plan/run path has the identical hardcoding (`lifecycle.rs`), best handled in the gh#61 dispatch-dial design pass so the launch surface's dials land coherently.

## Testing

- `test_kickoff_plan_permission_flags_are_exposed_and_conflict` — both flags parse and are mutually exclusive (clap layer, no tmux).
- Full suite green (bin + `tests/cli_integration.rs`); `cargo clippy -- -D warnings -W clippy::unwrap_used -W clippy::expect_used` and `cargo fmt --check` clean.

CHANGELOG entry placed mid-`### Fixed` at a distinct anchor; verified conflict-free (3-way merge) against the other open PRs #63/#64/#65 in any merge order.

Part of the vsdd kickoff-bundle epic (magnificentlycursed/crosslink#2).

Authored by Claude Code on behalf of @magnificentlycursed.

Generated with [Claude Code](https://claude.com/claude-code)
