### PR TITLE
fix(container): make container build work + fork-publishable agent image (gh#75)

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -27,6 +27,10 @@ on:
       - '.github/workflows/container-image.yml'
       - 'crosslink/Cargo.toml'
       - 'crosslink/Cargo.lock'
+  # On-demand publish from any branch (e.g. a fork validating the image before
+  # develop lands), tagged :nightly + :manual-<sha>. Lets a fork produce a
+  # working agent image without a develop push.
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -38,7 +42,10 @@ concurrency:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: dollspace-gay/crosslink-agent
+  # Repo-owner-derived so a fork publishes to its own GHCR namespace instead of
+  # failing to push to the upstream org. On dollspace-gay/crosslink this still
+  # resolves to dollspace-gay/crosslink-agent.
+  IMAGE_NAME: ${{ github.repository_owner }}/crosslink-agent
 
 jobs:
   # ===========================================
@@ -177,6 +184,11 @@ jobs:
           elif [ "$REF" = "refs/heads/develop" ]; then
             VERSION="nightly-${SHORT_SHA}"
             TAGS=("${BASE}:nightly" "${BASE}:nightly-${SHORT_SHA}")
+            PRIMARY="${BASE}:nightly"
+            PUSH=true
+          elif [ "$EVENT" = "workflow_dispatch" ]; then
+            VERSION="manual-${SHORT_SHA}"
+            TAGS=("${BASE}:nightly" "${BASE}:manual-${SHORT_SHA}")
             PRIMARY="${BASE}:nightly"
             PUSH=true
           else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- `crosslink container build` no longer fails with a cryptic
+  `COPY crosslink-<arch>: not found` (gh#75). It staged the binary as
+  `crosslink` while the Dockerfile expects `crosslink-${TARGETARCH}`; it now
+  stages `crosslink-<arch>` and passes `--build-arg TARGETARCH=<arch>` so a
+  plain `docker build` resolves the COPY. Since it packages the *installed*
+  binary (no source tree to cross-compile from), it now fails fast with a
+  clear message on non-Linux hosts — where that binary can't run in the
+  Linux image — pointing at the CI workflow / `just build-image` instead.
+- The container-image workflow's `IMAGE_NAME` is derived from
+  `${{ github.repository_owner }}` (gh#75), so a fork publishes to its own
+  GHCR namespace instead of failing to push to the upstream org (on
+  dollspace-gay it still resolves to `dollspace-gay/crosslink-agent`), and a
+  `workflow_dispatch` trigger lets a fork publish a working agent image
+  on-demand without a `develop` push. Addresses the unpublished
+  `DEFAULT_AGENT_IMAGE` (forecast-bio/crosslink#576).
 - `kickoff run --container` now passes claude's permission flag into the
   container agent (gh#59). The local (tmux) path emitted
   `--dangerously-skip-permissions` / `--permission-mode`, and `container start`

--- a/crosslink/src/commands/container.rs
+++ b/crosslink/src/commands/container.rs
@@ -249,9 +249,35 @@ pub fn build(force: bool, tag: Option<&str>, dockerfile: Option<&str>) -> Result
     // Write entrypoint
     std::fs::write(build_path.join("entrypoint.sh"), ENTRYPOINT)?;
 
-    // Copy crosslink binary
+    // The Dockerfile COPYs `crosslink-${TARGETARCH}`, and the staged binary
+    // must be a Linux binary to run in the agent image. `crosslink container
+    // build` packages the *installed* binary (it has no source tree to
+    // cross-compile from), so it can only produce a runnable image on a Linux
+    // host of a supported arch. For cross-arch or non-Linux hosts, the CI
+    // workflow (.github/workflows/container-image.yml) and `just build-image`
+    // cross-compile a static musl binary instead.
+    let docker_arch = match std::env::consts::ARCH {
+        "x86_64" => "amd64",
+        "aarch64" => "arm64",
+        other => bail!(
+            "unsupported host architecture `{other}` for `crosslink container build`; \
+             build the image via CI (.github/workflows/container-image.yml) or `just build-image`"
+        ),
+    };
+    if !cfg!(target_os = "linux") {
+        bail!(
+            "`crosslink container build` packages the installed crosslink binary, which must \
+             be a Linux binary to run in the agent image — but this host is `{}`. Build on a \
+             Linux host, or use the CI workflow (.github/workflows/container-image.yml) or \
+             `just build-image`, which cross-compile a static musl binary.",
+            std::env::consts::OS
+        );
+    }
+
+    // Copy crosslink binary under the arch-suffixed name the Dockerfile expects.
     let binary = find_crosslink_binary()?;
-    std::fs::copy(&binary, build_path.join("crosslink"))
+    let staged_binary = format!("crosslink-{docker_arch}");
+    std::fs::copy(&binary, build_path.join(&staged_binary))
         .context("Failed to copy crosslink binary to build context")?;
 
     // Compute binary hash for staleness detection
@@ -261,6 +287,9 @@ pub fn build(force: bool, tag: Option<&str>, dockerfile: Option<&str>) -> Result
 
     let mut cmd = Command::new("docker");
     cmd.args(["build", "-t", &image]);
+    // Pin TARGETARCH so plain `docker build` (not buildx) resolves the COPY to
+    // the arch-suffixed binary we staged, instead of the Dockerfile default.
+    cmd.args(["--build-arg", &format!("TARGETARCH={docker_arch}")]);
     cmd.args(["--label", LABEL_AGENT]);
     cmd.args(["--label", &format!("crosslink-binary-hash={binary_hash}")]);
     if force {


### PR DESCRIPTION
Fixes #75.

The working `kickoff --container` dispatch path (established on #55) had no reachable agent image, for two independent reasons — both fixed here.

## `crosslink container build` was broken (COPY name mismatch)

`build()` staged the binary as `crosslink`, but `resources/container/Dockerfile` `COPY`s `crosslink-${TARGETARCH}`, so every invocation failed:

```
COPY --chown=agent crosslink-amd64 /usr/local/bin/crosslink
ERROR: "/crosslink-amd64": not found
```

Now it stages `crosslink-<arch>` and passes `--build-arg TARGETARCH=<arch>` so a plain `docker build` resolves the COPY. Because the command packages the *installed* binary (no source tree to cross-compile from), it can only produce a runnable image on a Linux host — so on macOS/Windows it now fails fast with a clear message pointing at the CI workflow / `just build-image` (which cross-compile a static musl binary), instead of the cryptic docker error:

```
`crosslink container build` packages the installed crosslink binary, which must be a
Linux binary to run in the agent image — but this host is `macos`. Build on a Linux
host, or use the CI workflow (.github/workflows/container-image.yml) or `just build-image`...
```

## The default agent image was unpublished

`DEFAULT_AGENT_IMAGE = "ghcr.io/dollspace-gay/crosslink-agent:latest"` is not published, so `kickoff run --container` couldn't pull it. The `container-image.yml` workflow builds+publishes correctly (musl per-arch, `crosslink-<arch>` staging) — but `IMAGE_NAME` was hardcoded to the dollspace org, so a fork couldn't publish its own. This makes it `${{ github.repository_owner }}/crosslink-agent` (unchanged on dollspace-gay), and adds a `workflow_dispatch` trigger so any fork can publish a working agent image on-demand. Successor to forecast-bio/crosslink#576 for the new org.

## Testing

- `cargo build`, `cargo clippy -- -D warnings -W clippy::unwrap_used -W clippy::expect_used`, `cargo fmt --check` clean; full suite green.
- `crosslink container build` on macOS now emits the clear guard message (verified) rather than the COPY error; on a Linux host it stages `crosslink-<arch>` matching the Dockerfile.

Authored by Claude Code on behalf of @magnificentlycursed.

Generated with [Claude Code](https://claude.com/claude-code)
