### PR TITLE
feat(kickoff): effort/budget dispatch dials (gh#61, Slice 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Per-dispatch reasoning/spend dials on the kickoff path (gh#61).
+  `crosslink kickoff run` and `crosslink kickoff plan` accept
+  `--effort <low|medium|high|xhigh|max>` and `--budget-usd <amount>`, emitted
+  as `claude --effort` / `claude --max-budget-usd` immediately after `--model`
+  on both the local (tmux) and container launch paths. `--effort` is validated
+  fail-closed by clap; omitting both flags reproduces the previous invocation
+  byte-for-byte. The resolved `model`, `effort`, and `budget_usd` are recorded
+  in `.kickoff-metadata.json` so a run record captures what the dispatch was
+  actually given. `crosslink swarm config` gains the same two flags: swarm now
+  sources `model`/`effort`/`budget_usd` from its budget config instead of
+  hardcoding `opus` at launch, and the spend ceiling applies per dispatched
+  agent (a wave of N agents can spend up to N x the amount).
 - `crosslink migrate hub-v3 --remigrate-from-v2` - regenerates the v3 genesis
   from the current `crosslink/hub` (v2) tip and force-pushes it, superseding a
   stale remote v3 hub. The discoverable recovery path when a v2-only binary

--- a/crosslink/src/commands/kickoff/launch.rs
+++ b/crosslink/src/commands/kickoff/launch.rs
@@ -154,6 +154,31 @@ pub(super) fn permission_flag(permission_mode: Option<&str>, skip_permissions: b
     }
 }
 
+/// Resolve the per-dispatch reasoning/spend dials into a command-line fragment
+/// (each flag with a leading space, or empty). Shared by the local (tmux) and
+/// container launch paths so they cannot drift the way the permission flag once
+/// did (gh#61, mirroring the GH#59 fix for [`permission_flag`]).
+///
+/// Emits `--effort <level>` then `--max-budget-usd <amount>`, both values
+/// shell-escaped because both end up inside a `bash -c` string. Either dial
+/// being `None` (or empty) omits its flag entirely, so a launch that sets
+/// neither reproduces the previous invocation byte-for-byte.
+pub(super) fn dial_flags(effort: Option<&str>, budget_usd: Option<&str>) -> String {
+    use crate::utils::shell_escape_arg;
+    use std::fmt::Write as _;
+
+    let mut flags = String::new();
+    if let Some(level) = effort.filter(|v| !v.is_empty()) {
+        // INTENTIONAL: writing to a String is infallible — the Result is only
+        // there to satisfy the fmt::Write trait.
+        let _ = write!(flags, " --effort {}", shell_escape_arg(level));
+    }
+    if let Some(amount) = budget_usd.filter(|v| !v.is_empty()) {
+        let _ = write!(flags, " --max-budget-usd {}", shell_escape_arg(amount));
+    }
+    flags
+}
+
 /// Build the shell command string for launching a claude agent.
 ///
 /// `claude_config_dir` is a caller-side environment variable that must be
@@ -194,6 +219,8 @@ pub(super) fn build_agent_command(
     skip_permissions: bool,
     claude_config_dir: Option<&str>,
     permission_mode: Option<&str>,
+    effort: Option<&str>,
+    budget_usd: Option<&str>,
 ) -> String {
     use crate::utils::shell_escape_arg;
 
@@ -222,8 +249,11 @@ pub(super) fn build_agent_command(
     let escaped_model = shell_escape_arg(model);
     let escaped_tools = shell_escape_arg(allowed_tools);
     let escaped_kickoff = shell_escape_arg(kickoff_file);
+    // gh#61: the dispatch dials sit immediately after `--model` so the
+    // reasoning/spend posture reads alongside the model it applies to.
+    let dials = dial_flags(effort, budget_usd);
     let claude_cmd = format!(
-        "env -u CLAUDECODE {env_assignment}claude{skip_flag} --model {escaped_model} --allowedTools {escaped_tools} -- \"$(cat {escaped_kickoff})\""
+        "env -u CLAUDECODE {env_assignment}claude{skip_flag} --model {escaped_model}{dials} --allowedTools {escaped_tools} -- \"$(cat {escaped_kickoff})\""
     );
     let launch = sandbox_command.map_or_else(
         || format!("{timeout_cmd} {timeout_secs}s {claude_cmd}"),
@@ -598,6 +628,8 @@ pub(super) fn launch_local(
     crosslink_dir: &Path,
     skip_permissions: bool,
     permission_mode: Option<&str>,
+    effort: Option<&str>,
+    budget_usd: Option<&str>,
 ) -> Result<()> {
     // Create the tmux session
     let output = Command::new("tmux")
@@ -635,6 +667,8 @@ pub(super) fn launch_local(
         skip_permissions,
         claude_config_dir.as_deref(),
         permission_mode,
+        effort,
+        budget_usd,
     );
 
     // Write initial status sentinel BEFORE sending the command.
@@ -694,6 +728,8 @@ pub(super) fn launch_container(
     protected_doc_rel: Option<&Path>,
     skip_permissions: bool,
     permission_mode: Option<&str>,
+    effort: Option<&str>,
+    budget_usd: Option<&str>,
 ) -> Result<String> {
     let runtime_cmd = match runtime {
         ContainerMode::Docker => "docker",
@@ -805,11 +841,14 @@ pub(super) fn launch_container(
     // and `container start` use — without it claude prompts for every tool and
     // the headless container agent blocks forever (a GH#55 stall cause).
     let skip_flag = permission_flag(permission_mode, skip_permissions);
+    // gh#61: same dial fragment the local path emits, in the same position
+    // (immediately after `--model`), so both launch paths dispatch identically.
+    let dials = dial_flags(effort, budget_usd);
     args.push(image.to_string());
     args.push("bash".to_string());
     args.push("-c".to_string());
     args.push(format!(
-        "cd /workspaces/repo && timeout {timeout_secs}s claude{skip_flag} --model {model} --allowedTools '{allowed_tools}' -- \"$(cat KICKOFF.md)\"; if [ $? -eq 124 ]; then printf 'TIMEOUT\\n' > /workspaces/repo/.kickoff-status; fi"
+        "cd /workspaces/repo && timeout {timeout_secs}s claude{skip_flag} --model {model}{dials} --allowedTools '{allowed_tools}' -- \"$(cat KICKOFF.md)\"; if [ $? -eq 124 ]; then printf 'TIMEOUT\\n' > /workspaces/repo/.kickoff-status; fi"
     ));
 
     let output = Command::new(runtime_cmd)

--- a/crosslink/src/commands/kickoff/mod.rs
+++ b/crosslink/src/commands/kickoff/mod.rs
@@ -17,7 +17,7 @@ mod tests;
 // Re-export public types used by external callers (swarm, main, etc.)
 pub use types::{
     ContainerMode, KickoffOpts, KickoffReport, PlanOpts, ReportFormat, VerifyLevel,
-    DEFAULT_AGENT_IMAGE,
+    DEFAULT_AGENT_IMAGE, EFFORT_LEVELS,
 };
 
 // Re-export parse functions (used by dispatch and swarm)
@@ -64,6 +64,8 @@ pub fn dispatch(
             doc,
             skip_permissions,
             permission_mode,
+            effort,
+            budget_usd,
         } => {
             let parsed_doc = if let Some(ref path) = doc {
                 let content = std::fs::read_to_string(path)
@@ -91,6 +93,8 @@ pub fn dispatch(
                 doc_path: doc.as_ref().map(|p| p.to_str().unwrap_or("unknown")),
                 skip_permissions,
                 permission_mode: permission_mode.as_deref(),
+                effort: effort.as_deref(),
+                budget_usd: budget_usd.as_deref(),
             };
             // The pipeline "running" row is now written from inside `run()`
             // once the real worktree + agent identity exist (GH#614) — no more
@@ -112,6 +116,8 @@ pub fn dispatch(
             dry_run,
             skip_permissions,
             permission_mode,
+            effort,
+            budget_usd,
         } => {
             let content = std::fs::read_to_string(&doc)
                 .with_context(|| format!("Failed to read design doc: {}", doc.display()))?;
@@ -129,6 +135,8 @@ pub fn dispatch(
                 quiet,
                 skip_permissions,
                 permission_mode: permission_mode.as_deref(),
+                effort: effort.as_deref(),
+                budget_usd: budget_usd.as_deref(),
             };
             plan(crosslink_dir, db, &plan_opts)
         }
@@ -241,6 +249,11 @@ fn dispatch_launch(
             quiet,
             skip_permissions,
             permission_mode,
+            // gh#61: the unified `kickoff [doc] --plan/--run` entry point does
+            // not expose the dispatch dials — they live on `kickoff run` /
+            // `kickoff plan`. Unset here reproduces the previous invocation.
+            effort: None,
+            budget_usd: None,
         };
         return plan(crosslink_dir, db, &plan_opts);
     }
@@ -283,6 +296,9 @@ fn dispatch_launch(
             doc_path: doc.as_ref().map(|p| p.to_str().unwrap_or("unknown")),
             skip_permissions,
             permission_mode,
+            // See the --plan branch above: dials are not exposed here.
+            effort: None,
+            budget_usd: None,
         };
         // mark_running is now invoked from inside run() with the real identity.
         run(crosslink_dir, db, writer, &opts)?;
@@ -330,6 +346,10 @@ fn dispatch_launch(
                 // dialog, so plan mode keeps the fail-closed default (gh#66).
                 skip_permissions: false,
                 permission_mode: None,
+                // The wizard collects model/timeout/verify only; dials stay
+                // unset so an interactive launch is unchanged (gh#61).
+                effort: None,
+                budget_usd: None,
             };
             plan(crosslink_dir, db, &plan_opts)
         }
@@ -369,6 +389,9 @@ fn dispatch_launch(
                 doc_path: doc_path_str.as_deref(),
                 skip_permissions: false,
                 permission_mode: None,
+                // See the wizard's Plan branch: dials stay unset here.
+                effort: None,
+                budget_usd: None,
             };
             run(crosslink_dir, db, writer, &opts)?;
             Ok(())

--- a/crosslink/src/commands/kickoff/plan.rs
+++ b/crosslink/src/commands/kickoff/plan.rs
@@ -251,6 +251,8 @@ pub fn plan(crosslink_dir: &Path, db: &Database, opts: &PlanOpts) -> Result<()> 
         opts.skip_permissions,
         claude_config_dir.as_deref(),
         opts.permission_mode,
+        opts.effort,
+        opts.budget_usd,
     );
 
     let output = Command::new("tmux")

--- a/crosslink/src/commands/kickoff/run.rs
+++ b/crosslink/src/commands/kickoff/run.rs
@@ -147,12 +147,12 @@ pub fn run(
         }
     }
 
-    // 6c. Write launch metadata (timeout + start time) for status tracking
+    // 6c. Write launch metadata (timeout + start time) for status tracking,
+    //     plus the dispatch dials (model/effort/budget) so the run record
+    //     captures what reasoning and spend posture the agent was given
+    //     (gh#61). Dials absent from the launch stay absent from the JSON.
     {
-        let metadata = KickoffMetadata {
-            started_at: chrono::Utc::now().to_rfc3339(),
-            timeout_secs: opts.timeout.as_secs(),
-        };
+        let metadata = KickoffMetadata::for_launch(opts, chrono::Utc::now().to_rfc3339());
         let json = serde_json::to_string_pretty(&metadata)
             .context("Failed to serialize kickoff metadata")?;
         std::fs::write(worktree_dir.join(".kickoff-metadata.json"), &json)
@@ -219,6 +219,8 @@ pub fn run(
                 crosslink_dir,
                 opts.skip_permissions,
                 opts.permission_mode,
+                opts.effort,
+                opts.budget_usd,
             )?;
 
             // Persist the actual session name so kickoff list can find it
@@ -258,6 +260,8 @@ pub fn run(
                 protected_doc_rel.as_deref(),
                 opts.skip_permissions,
                 opts.permission_mode,
+                opts.effort,
+                opts.budget_usd,
             )?;
 
             if opts.quiet {

--- a/crosslink/src/commands/kickoff/tests.rs
+++ b/crosslink/src/commands/kickoff/tests.rs
@@ -146,6 +146,8 @@ fn test_build_prompt_contains_essentials() {
         doc_path: None,
         skip_permissions: false,
         permission_mode: None,
+        effort: None,
+        budget_usd: None,
     };
     let prompt = build_prompt(&opts, 42, "feature/add-retry-logic", &conventions);
 
@@ -179,6 +181,8 @@ fn test_build_prompt_ci_verification() {
         doc_path: None,
         skip_permissions: false,
         permission_mode: None,
+        effort: None,
+        budget_usd: None,
     };
     let prompt = build_prompt(&opts, 1, "feature/test-ci", &conventions);
 
@@ -209,6 +213,8 @@ fn test_build_prompt_thorough_verification() {
         doc_path: None,
         skip_permissions: false,
         permission_mode: None,
+        effort: None,
+        budget_usd: None,
     };
     let prompt = build_prompt(&opts, 1, "feature/test-thorough", &conventions);
 
@@ -889,6 +895,8 @@ fn test_build_prompt_local_has_no_ci_or_adversarial() {
         doc_path: None,
         skip_permissions: false,
         permission_mode: None,
+        effort: None,
+        budget_usd: None,
     };
     let prompt = build_prompt(&opts, 1, "feature/test-local", &conventions);
 
@@ -919,6 +927,8 @@ fn test_build_prompt_contains_blocked_actions() {
         doc_path: None,
         skip_permissions: false,
         permission_mode: None,
+        effort: None,
+        budget_usd: None,
     };
     let prompt = build_prompt(&opts, 1, "feature/test", &conventions);
 
@@ -950,6 +960,8 @@ fn test_build_prompt_embeds_issue_id_in_instructions() {
         doc_path: None,
         skip_permissions: false,
         permission_mode: None,
+        effort: None,
+        budget_usd: None,
     };
     let prompt = build_prompt(&opts, 999, "feature/test-refs", &conventions);
 
@@ -981,6 +993,8 @@ fn test_build_prompt_empty_conventions_uses_generic_instructions() {
         doc_path: None,
         skip_permissions: false,
         permission_mode: None,
+        effort: None,
+        budget_usd: None,
     };
     let prompt = build_prompt(&opts, 1, "feature/test-generic", &conventions);
 
@@ -1024,6 +1038,8 @@ fn test_build_prompt_with_design_doc() {
         doc_path: None,
         skip_permissions: false,
         permission_mode: None,
+        effort: None,
+        budget_usd: None,
     };
     let prompt = build_prompt(&opts, 1, "feature/batch-retry", &conventions);
 
@@ -1170,6 +1186,8 @@ fn test_build_prompt_with_design_doc_open_questions() {
         doc_path: None,
         skip_permissions: false,
         permission_mode: None,
+        effort: None,
+        budget_usd: None,
     };
     let prompt = build_prompt(&opts, 1, "feature/auth", &conventions);
 
@@ -1342,6 +1360,8 @@ fn test_build_prompt_with_criteria_includes_validation() {
         doc_path: None,
         skip_permissions: false,
         permission_mode: None,
+        effort: None,
+        budget_usd: None,
     };
     let prompt = build_prompt(&opts, 1, "feature/test", &conventions);
     assert!(prompt.contains("Spec Validation"));
@@ -1383,6 +1403,8 @@ fn test_build_prompt_without_criteria_no_validation() {
         doc_path: None,
         skip_permissions: false,
         permission_mode: None,
+        effort: None,
+        budget_usd: None,
     };
     let prompt = build_prompt(&opts, 1, "feature/test", &conventions);
     assert!(!prompt.contains("Spec Validation"));
@@ -1421,6 +1443,8 @@ fn test_build_prompt_validation_ordering() {
         doc_path: None,
         skip_permissions: false,
         permission_mode: None,
+        effort: None,
+        budget_usd: None,
     };
     let prompt = build_prompt(&opts, 1, "feature/test", &conventions);
     let test_pos = prompt.find("Run tests").expect("should have test section");
@@ -1767,6 +1791,8 @@ fn test_build_agent_command_without_sandbox() {
         false,
         None,
         None,
+        None,
+        None,
     );
     assert_eq!(
         cmd,
@@ -1787,6 +1813,8 @@ fn test_build_agent_command_with_sandbox() {
         false,
         None,
         None,
+        None,
+        None,
     );
     assert!(cmd.starts_with("timeout 3600s bwrap --bind '/tmp/my-worktree' /workspace --"));
     assert!(cmd.contains("env -u CLAUDECODE claude"));
@@ -1803,6 +1831,8 @@ fn test_build_agent_command_with_skip_permissions() {
         None,
         Path::new("/tmp/worktree"),
         true,
+        None,
+        None,
         None,
         None,
     );
@@ -1828,6 +1858,8 @@ fn test_build_agent_command_with_permission_mode_auto() {
         false,
         None,
         Some("auto"),
+        None,
+        None,
     );
     assert!(
         cmd.contains("--permission-mode 'auto'"),
@@ -1856,6 +1888,8 @@ fn test_build_agent_command_permission_mode_wins_over_skip_permissions() {
         true,
         None,
         Some("acceptEdits"),
+        None,
+        None,
     );
     assert!(
         cmd.contains("--permission-mode 'acceptEdits'"),
@@ -1882,6 +1916,8 @@ fn test_build_agent_command_empty_permission_mode_treated_as_none() {
         true,
         None,
         Some(""),
+        None,
+        None,
     );
     assert!(
         !cmd.contains("--permission-mode"),
@@ -1904,6 +1940,8 @@ fn test_build_agent_command_plan_kickoff() {
         None,
         Path::new("/tmp/worktree"),
         false,
+        None,
+        None,
         None,
         None,
     );
@@ -1929,6 +1967,8 @@ fn test_build_agent_command_propagates_claude_config_dir() {
         false,
         Some("/Users/me/.claude-work"),
         None,
+        None,
+        None,
     );
     assert_eq!(
         cmd,
@@ -1951,6 +1991,8 @@ fn test_build_agent_command_omits_empty_claude_config_dir() {
         false,
         Some(""),
         None,
+        None,
+        None,
     );
     assert!(!cmd.contains("CLAUDE_CONFIG_DIR="));
     assert!(cmd.starts_with("timeout 3600s env -u CLAUDECODE claude"));
@@ -1972,6 +2014,8 @@ fn test_build_agent_command_escapes_claude_config_dir_with_quotes() {
         false,
         Some("/weird/it's-a-path"),
         None,
+        None,
+        None,
     );
     assert!(cmd.contains("CLAUDE_CONFIG_DIR='/weird/it'\\''s-a-path'"));
 }
@@ -1991,6 +2035,8 @@ fn test_build_agent_command_with_sandbox_includes_claude_config_dir() {
         Path::new("/tmp/my-worktree"),
         false,
         Some("/Users/me/.claude-work"),
+        None,
+        None,
         None,
     );
     assert!(cmd.contains(
@@ -2085,6 +2131,8 @@ fn test_build_agent_command_env_var_actually_reaches_claude() {
         false,
         Some("/expected/value"),
         None,
+        None,
+        None,
     );
 
     let output = run_built_command_in_bash(&cmd, tmp.path(), tmp.path());
@@ -2137,6 +2185,8 @@ fn test_build_agent_command_env_var_reaches_claude_through_sandbox() {
         false,
         Some("/sandbox-passthrough/value"),
         None,
+        None,
+        None,
     );
 
     let output = run_built_command_in_bash(&cmd, tmp.path(), tmp.path());
@@ -2178,6 +2228,8 @@ fn test_build_agent_command_omitted_env_var_does_not_break_launch() {
         None,
         tmp.path(),
         false,
+        None,
+        None,
         None,
         None,
     );
@@ -2456,6 +2508,8 @@ fn test_build_prompt_contains_report_json_schema() {
         doc_path: Some("test.md"),
         skip_permissions: false,
         permission_mode: None,
+        effort: None,
+        budget_usd: None,
     };
     let prompt = build_prompt(&opts, 1, "feature/test", &conventions);
 
@@ -2504,6 +2558,8 @@ fn test_build_prompt_contains_validation_section() {
         doc_path: Some("test.md"),
         skip_permissions: false,
         permission_mode: None,
+        effort: None,
+        budget_usd: None,
     };
     let prompt = build_prompt(&opts, 1, "feature/validated", &conventions);
 
@@ -3011,4 +3067,242 @@ fn test_permission_flag_postures() {
     );
     // Neither → no flag (claude prompts per tool — the GH#55 container stall).
     assert_eq!(permission_flag(None, false), "");
+}
+
+// ============================================================================
+// gh#61 (REQ-1/REQ-2): per-dispatch reasoning/spend dials.
+// ============================================================================
+
+// The dial fragment both launch paths share. Values are shell-escaped because
+// they land inside a `bash -c` string, exactly like `--model 'opus'`.
+#[test]
+fn test_dial_flags_postures() {
+    assert_eq!(dial_flags(Some("high"), None), " --effort 'high'");
+    assert_eq!(dial_flags(None, Some("5.00")), " --max-budget-usd '5.00'");
+    assert_eq!(
+        dial_flags(Some("max"), Some("12.5")),
+        " --effort 'max' --max-budget-usd '12.5'"
+    );
+    // Neither dial → no tokens, so an un-dialed launch is byte-identical to
+    // the pre-gh#61 invocation.
+    assert_eq!(dial_flags(None, None), "");
+    // Empty strings are treated as unset rather than emitting `--effort ''`.
+    assert_eq!(dial_flags(Some(""), Some("")), "");
+}
+
+// AC-1: effort = Some("high") emits ` --effort high` positioned after --model.
+#[test]
+fn test_build_agent_command_with_effort() {
+    let cmd = build_agent_command(
+        "timeout",
+        3600,
+        "opus",
+        "Read,Write",
+        "KICKOFF.md",
+        None,
+        Path::new("/tmp/worktree"),
+        false,
+        None,
+        None,
+        Some("high"),
+        None,
+    );
+    assert!(
+        cmd.contains("--effort 'high'"),
+        "effort=high should emit --effort, got: {cmd}"
+    );
+    assert!(
+        cmd.contains("--model 'opus' --effort 'high' --allowedTools"),
+        "--effort must sit immediately after --model, got: {cmd}"
+    );
+    assert!(
+        !cmd.contains("--max-budget-usd"),
+        "budget_usd=None must not emit a budget flag, got: {cmd}"
+    );
+}
+
+// AC-1 (negative): effort = None produces no --effort token at all.
+#[test]
+fn test_build_agent_command_without_effort_omits_flag() {
+    let cmd = build_agent_command(
+        "timeout",
+        3600,
+        "opus",
+        "Read,Write",
+        "KICKOFF.md",
+        None,
+        Path::new("/tmp/worktree"),
+        false,
+        None,
+        None,
+        None,
+        None,
+    );
+    assert!(
+        !cmd.contains("--effort"),
+        "effort=None must not emit --effort, got: {cmd}"
+    );
+    // Byte-for-byte identical to the pre-gh#61 command (REQ-2's guarantee).
+    assert_eq!(
+        cmd,
+        "timeout 3600s env -u CLAUDECODE claude --model 'opus' --allowedTools 'Read,Write' -- \"$(cat 'KICKOFF.md')\"; if [ $? -eq 124 ]; then printf 'TIMEOUT\\n' > '/tmp/worktree/.kickoff-status'; fi"
+    );
+}
+
+// AC-2: budget_usd = Some("5.00") emits ` --max-budget-usd 5.00`.
+#[test]
+fn test_build_agent_command_with_budget_usd() {
+    let cmd = build_agent_command(
+        "timeout",
+        3600,
+        "opus",
+        "Read,Write",
+        "KICKOFF.md",
+        None,
+        Path::new("/tmp/worktree"),
+        false,
+        None,
+        None,
+        None,
+        Some("5.00"),
+    );
+    assert!(
+        cmd.contains("--max-budget-usd '5.00'"),
+        "budget_usd should emit --max-budget-usd, got: {cmd}"
+    );
+    assert!(
+        cmd.contains("--model 'opus' --max-budget-usd '5.00' --allowedTools"),
+        "the budget dial must sit after --model, got: {cmd}"
+    );
+    assert!(
+        !cmd.contains("--effort"),
+        "effort=None must not emit --effort, got: {cmd}"
+    );
+}
+
+// Both dials together, in a full command string — the ordering claude sees.
+#[test]
+fn test_build_agent_command_with_both_dials() {
+    let cmd = build_agent_command(
+        "timeout",
+        3600,
+        "opus",
+        "Read,Write",
+        "KICKOFF.md",
+        None,
+        Path::new("/tmp/worktree"),
+        true,
+        None,
+        None,
+        Some("xhigh"),
+        Some("5"),
+    );
+    assert_eq!(
+        cmd,
+        "timeout 3600s env -u CLAUDECODE claude --dangerously-skip-permissions --model 'opus' --effort 'xhigh' --max-budget-usd '5' --allowedTools 'Read,Write' -- \"$(cat 'KICKOFF.md')\"; if [ $? -eq 124 ]; then printf 'TIMEOUT\\n' > '/tmp/worktree/.kickoff-status'; fi"
+    );
+}
+
+// A dial value carrying shell metacharacters must not escape its quoting.
+#[test]
+fn test_build_agent_command_escapes_dial_values() {
+    let cmd = build_agent_command(
+        "timeout",
+        3600,
+        "opus",
+        "Read,Write",
+        "KICKOFF.md",
+        None,
+        Path::new("/tmp/worktree"),
+        false,
+        None,
+        None,
+        Some("high'; rm -rf /"),
+        None,
+    );
+    assert!(
+        cmd.contains("--effort 'high'\\''; rm -rf /'"),
+        "dial values must be shell-escaped, got: {cmd}"
+    );
+}
+
+// ============================================================================
+// gh#61 (REQ-3): the dispatch dials are recorded in .kickoff-metadata.json.
+// ============================================================================
+
+fn dialed_opts<'a>(
+    model: &'a str,
+    effort: Option<&'a str>,
+    budget: Option<&'a str>,
+) -> KickoffOpts<'a> {
+    KickoffOpts {
+        description: "add retry logic",
+        issue: None,
+        container: ContainerMode::None,
+        verify: VerifyLevel::Local,
+        model,
+        image: "",
+        timeout: Duration::from_secs(3600),
+        dry_run: false,
+        branch: None,
+        quiet: false,
+        design_doc: None,
+        doc_path: None,
+        skip_permissions: false,
+        permission_mode: None,
+        effort,
+        budget_usd: budget,
+    }
+}
+
+// AC-4: a `--effort high --budget-usd 5 --model opus` launch writes metadata
+// that round-trips through serde with all three dials intact.
+#[test]
+fn test_kickoff_metadata_records_dispatch_dials() {
+    let opts = dialed_opts("opus", Some("high"), Some("5"));
+    let metadata = KickoffMetadata::for_launch(&opts, "2026-08-02T00:00:00+00:00".to_string());
+
+    let json = serde_json::to_string_pretty(&metadata).unwrap();
+    let parsed: KickoffMetadata = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(parsed.effort.as_deref(), Some("high"));
+    assert_eq!(parsed.budget_usd.as_deref(), Some("5"));
+    assert_eq!(parsed.model.as_deref(), Some("opus"));
+    assert_eq!(parsed.timeout_secs, 3600);
+    assert_eq!(parsed.started_at, "2026-08-02T00:00:00+00:00");
+}
+
+// An un-dialed launch records no dial keys at all, so the file stays the shape
+// downstream readers already expect.
+#[test]
+fn test_kickoff_metadata_omits_unset_dials() {
+    let opts = dialed_opts("sonnet", None, None);
+    let metadata = KickoffMetadata::for_launch(&opts, "2026-08-02T00:00:00+00:00".to_string());
+
+    let json = serde_json::to_string(&metadata).unwrap();
+    assert!(
+        !json.contains("effort"),
+        "unset effort must be omitted: {json}"
+    );
+    assert!(
+        !json.contains("budget_usd"),
+        "unset budget_usd must be omitted: {json}"
+    );
+    assert!(
+        json.contains("\"model\":\"sonnet\""),
+        "model is always recorded: {json}"
+    );
+}
+
+// Metadata written before gh#61 (no dial keys) must still deserialize — the
+// timeout checks in `is_timed_out` read every agent's file, including ones
+// launched by an older binary.
+#[test]
+fn test_kickoff_metadata_deserializes_legacy_file() {
+    let legacy = r#"{"started_at":"2026-08-02T00:00:00+00:00","timeout_secs":1800}"#;
+    let parsed: KickoffMetadata = serde_json::from_str(legacy).unwrap();
+    assert_eq!(parsed.timeout_secs, 1800);
+    assert_eq!(parsed.model, None);
+    assert_eq!(parsed.effort, None);
+    assert_eq!(parsed.budget_usd, None);
 }

--- a/crosslink/src/commands/kickoff/types.rs
+++ b/crosslink/src/commands/kickoff/types.rs
@@ -10,6 +10,15 @@ use std::time::Duration;
 /// swarm, and CLI default values.
 pub const DEFAULT_AGENT_IMAGE: &str = "ghcr.io/dollspace-gay/crosslink-agent:latest";
 
+/// Reasoning-effort levels accepted by `claude --effort` (gh#61).
+///
+/// Single source of truth for the clap `PossibleValuesParser` on
+/// `kickoff run` / `kickoff plan` and for any non-clap caller that needs
+/// to validate a configured level (e.g. swarm config). Keeping the list
+/// here means the CLI's fail-closed value error and the dispatch path can
+/// never drift apart.
+pub const EFFORT_LEVELS: [&str; 5] = ["low", "medium", "high", "xhigh", "max"];
+
 /// Container runtime for agent execution.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ContainerMode {
@@ -52,13 +61,45 @@ pub struct CriteriaFile {
 /// Metadata written at agent launch (`.kickoff-metadata.json`).
 ///
 /// Records the timeout and start time so that `status` / `list` can detect
-/// agents that have exceeded their time budget.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// agents that have exceeded their time budget, plus the dispatch dials the
+/// agent was launched with (gh#61) so the run record answers "what reasoning
+/// effort / spend ceiling / model did this dispatch actually get?".
+///
+/// The dial fields are optional and `skip_serializing_if = "Option::is_none"`:
+/// a metadata file written before this field set existed still deserializes,
+/// and a launch that passes no dials produces the same JSON it always did.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct KickoffMetadata {
     /// ISO-8601 UTC timestamp of when the agent was launched.
     pub started_at: String,
     /// Timeout in seconds (matches `--timeout` flag).
     pub timeout_secs: u64,
+    /// Resolved model the agent was dispatched with (matches `--model`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    /// Reasoning effort the agent was dispatched with (matches `--effort`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effort: Option<String>,
+    /// Per-session spend ceiling in USD (matches `--budget-usd`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub budget_usd: Option<String>,
+}
+
+impl KickoffMetadata {
+    /// Build the launch record for a dispatch, capturing its dials.
+    ///
+    /// Keeps the `.kickoff-metadata.json` shape derived from exactly one place
+    /// so the run-record oracle and the launch path cannot disagree about what
+    /// a dispatch was given (gh#61, REQ-3).
+    pub fn for_launch(opts: &KickoffOpts, started_at: String) -> Self {
+        Self {
+            started_at,
+            timeout_secs: opts.timeout.as_secs(),
+            model: Some(opts.model.to_string()),
+            effort: opts.effort.map(ToString::to_string),
+            budget_usd: opts.budget_usd.map(ToString::to_string),
+        }
+    }
 }
 
 /// Breadcrumb written at launch when `--doc <path>` is supplied
@@ -97,6 +138,14 @@ pub struct KickoffOpts<'a> {
     /// with the finer-grained mode (acceptEdits/auto/bypassPermissions/
     /// default/dontAsk/plan). CLI marks the flags as mutually exclusive.
     pub permission_mode: Option<&'a str>,
+    /// Optional claude `--effort <level>` (gh#61). One of [`EFFORT_LEVELS`];
+    /// the CLI validates the value fail-closed. `None` reproduces today's
+    /// invocation with no `--effort` token.
+    pub effort: Option<&'a str>,
+    /// Optional claude `--max-budget-usd <amount>` (gh#61) — a fail-closed
+    /// spend ceiling for unattended dispatch. Per-session: under swarm each
+    /// dispatched agent receives this cap (Decision D1). `None` emits no flag.
+    pub budget_usd: Option<&'a str>,
 }
 
 /// A single criterion verdict in the validation report.
@@ -226,6 +275,11 @@ pub struct PlanOpts<'a> {
     /// Pass `--permission-mode <mode>`. Mutually exclusive with
     /// `skip_permissions`; does not itself clear the trust dialog.
     pub permission_mode: Option<&'a str>,
+    /// Optional claude `--effort <level>` (gh#61). See [`KickoffOpts::effort`].
+    pub effort: Option<&'a str>,
+    /// Optional claude `--max-budget-usd <amount>` (gh#61). See
+    /// [`KickoffOpts::budget_usd`].
+    pub budget_usd: Option<&'a str>,
 }
 
 /// Detect project conventions from the repo root.

--- a/crosslink/src/commands/sentinel/engine.rs
+++ b/crosslink/src/commands/sentinel/engine.rs
@@ -450,6 +450,10 @@ fn spawn_agent(
         doc_path: None,
         skip_permissions: true,
         permission_mode: None,
+        // Sentinel dispatch carries no reasoning/spend dials (gh#61) — the
+        // scope's model is the only dial it configures.
+        effort: None,
+        budget_usd: None,
     };
 
     run(crosslink_dir, db, writer, &opts)

--- a/crosslink/src/commands/swarm/budget.rs
+++ b/crosslink/src/commands/swarm/budget.rs
@@ -17,7 +17,17 @@ use crate::sync::SyncManager;
 // ---------------------------------------------------------------------------
 
 /// Set budget parameters for the swarm.
-pub fn config_budget(crosslink_dir: &Path, budget_window: &str, model: &str) -> Result<()> {
+///
+/// `effort` / `budget_usd` are the per-dispatch dials every agent this swarm
+/// launches will carry (gh#61). `None` leaves the corresponding claude flag
+/// off, which is the pre-gh#61 behaviour.
+pub fn config_budget(
+    crosslink_dir: &Path,
+    budget_window: &str,
+    model: &str,
+    effort: Option<&str>,
+    budget_usd: Option<&str>,
+) -> Result<()> {
     let sync = SyncManager::new(crosslink_dir)?;
     if !sync.is_initialized() {
         bail!("Hub cache not initialized. Run `crosslink sync` first.");
@@ -28,6 +38,19 @@ pub fn config_budget(crosslink_dir: &Path, budget_window: &str, model: &str) -> 
     let config = BudgetConfig {
         budget_window_s,
         model: model.to_string(),
+        effort: effort.map(ToString::to_string),
+        budget_usd: budget_usd.map(ToString::to_string),
+    };
+
+    // Dials appear in both the hub commit message and the confirmation line so
+    // the audit trail records what a swarm's agents will be dispatched with.
+    let dial_summary = match (effort, budget_usd) {
+        (None, None) => String::new(),
+        (e, b) => format!(
+            ", effort={}, budget_usd={}",
+            e.unwrap_or("unset"),
+            b.unwrap_or("unset")
+        ),
     };
 
     let ctx = resolve_swarm(&sync)?;
@@ -36,13 +59,14 @@ pub fn config_budget(crosslink_dir: &Path, budget_window: &str, model: &str) -> 
     commit_hub_files(
         &sync,
         &[&budget_path],
-        &format!("swarm: set budget {budget_window}  model={model}"),
+        &format!("swarm: set budget {budget_window}  model={model}{dial_summary}"),
     )?;
 
     println!(
-        "Budget configured: {} window, model={}",
+        "Budget configured: {} window, model={}{}",
         kickoff::format_duration(budget_window_s),
-        model
+        model,
+        dial_summary
     );
 
     Ok(())

--- a/crosslink/src/commands/swarm/lifecycle.rs
+++ b/crosslink/src/commands/swarm/lifecycle.rs
@@ -673,6 +673,40 @@ pub fn resume(crosslink_dir: &Path) -> Result<()> {
 // swarm launch
 // ---------------------------------------------------------------------------
 
+/// The dispatch dials a swarm wave launches its agents with.
+///
+/// Owned strings: `KickoffOpts` borrows its `model`/`effort`/`budget_usd`, so
+/// the resolved dials must outlive the per-agent opts built in the launch loop.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct DispatchDials {
+    pub model: String,
+    pub effort: Option<String>,
+    pub budget_usd: Option<String>,
+}
+
+/// Resolve the dials swarm dispatches its agents with (gh#61, REQ-4).
+///
+/// `config` is the swarm's `budget.json` when one has been written. A swarm
+/// with no budget config falls back to [`BudgetConfig::default`] — the
+/// documented swarm default (#521) — rather than a model literal pinned in the
+/// launch loop, so `swarm config --model sonnet` actually changes what gets
+/// dispatched. Empty strings are treated as unset: a config that round-tripped
+/// through an editor with `"effort": ""` must not emit `--effort ''`.
+pub(super) fn resolve_dispatch_dials(config: Option<&BudgetConfig>) -> DispatchDials {
+    let fallback = BudgetConfig::default();
+    let cfg = config.unwrap_or(&fallback);
+    let model = if cfg.model.trim().is_empty() {
+        fallback.model.clone()
+    } else {
+        cfg.model.clone()
+    };
+    DispatchDials {
+        model,
+        effort: cfg.effort.clone().filter(|v| !v.is_empty()),
+        budget_usd: cfg.budget_usd.clone().filter(|v| !v.is_empty()),
+    }
+}
+
 /// Launch all planned agents for a phase via `kickoff run`.
 pub fn launch(
     crosslink_dir: &Path,
@@ -710,6 +744,15 @@ pub fn launch(
 
     let now = chrono::Utc::now().to_rfc3339();
 
+    // gh#61 (REQ-4): source the dispatch dials from swarm config instead of
+    // pinning a model literal in the launch loop. Reading `budget.json` is
+    // best-effort — a swarm that never ran `swarm config` still launches, on
+    // the documented defaults.
+    let budget_config: Option<BudgetConfig> = resolve_swarm(&sync)
+        .ok()
+        .and_then(|ctx| read_hub_json::<BudgetConfig>(&sync, &ctx.budget_path()).ok());
+    let dials = resolve_dispatch_dials(budget_config.as_ref());
+
     if !quiet {
         println!(
             "Launching {} agent{} for {}...",
@@ -731,7 +774,7 @@ pub fn launch(
             issue: issue_id,
             container: ContainerMode::None,
             verify: VerifyLevel::Local,
-            model: "opus",
+            model: &dials.model,
             image: kickoff::DEFAULT_AGENT_IMAGE,
             timeout: std::time::Duration::from_secs(3600),
             dry_run: false,
@@ -741,6 +784,8 @@ pub fn launch(
             doc_path: None,
             skip_permissions: false,
             permission_mode: None,
+            effort: dials.effort.as_deref(),
+            budget_usd: dials.budget_usd.as_deref(),
         };
 
         match kickoff::run(crosslink_dir, db, writer, &opts) {

--- a/crosslink/src/commands/swarm/mod.rs
+++ b/crosslink/src/commands/swarm/mod.rs
@@ -614,10 +614,68 @@ mod tests {
         let config = BudgetConfig {
             budget_window_s: 18000,
             model: "opus".to_string(),
+            effort: Some("high".to_string()),
+            budget_usd: Some("5.00".to_string()),
         };
         let json = serde_json::to_string(&config).unwrap();
         let parsed: BudgetConfig = serde_json::from_str(&json).unwrap();
         assert_eq!(config, parsed);
+    }
+
+    // A budget.json written before gh#61 has no dial keys — it must still
+    // parse, or every pre-existing swarm loses its budget window.
+    #[test]
+    fn test_budget_config_deserializes_legacy_file() {
+        let legacy = r#"{"budget_window_s":18000,"model":"sonnet"}"#;
+        let parsed: BudgetConfig = serde_json::from_str(legacy).unwrap();
+        assert_eq!(parsed.model, "sonnet");
+        assert_eq!(parsed.effort, None);
+        assert_eq!(parsed.budget_usd, None);
+    }
+
+    // ------------------------------------------------------------------
+    // gh#61 (REQ-4 / AC-5): swarm dispatch dials come from swarm config.
+    // ------------------------------------------------------------------
+
+    // The configured model/effort/budget reach the dials the launch loop
+    // hands to KickoffOpts — no `"opus"` literal pinned in lifecycle.rs.
+    #[test]
+    fn test_resolve_dispatch_dials_uses_swarm_config() {
+        let config = BudgetConfig {
+            budget_window_s: 18000,
+            model: "sonnet".to_string(),
+            effort: Some("high".to_string()),
+            budget_usd: Some("5.00".to_string()),
+        };
+        let dials = resolve_dispatch_dials(Some(&config));
+        assert_eq!(dials.model, "sonnet");
+        assert_eq!(dials.effort.as_deref(), Some("high"));
+        assert_eq!(dials.budget_usd.as_deref(), Some("5.00"));
+    }
+
+    // No budget.json yet: fall back to the documented swarm defaults (#521)
+    // rather than failing to launch.
+    #[test]
+    fn test_resolve_dispatch_dials_defaults_without_config() {
+        let dials = resolve_dispatch_dials(None);
+        assert_eq!(dials.model, BudgetConfig::default().model);
+        assert_eq!(dials.effort, None);
+        assert_eq!(dials.budget_usd, None);
+    }
+
+    // Empty strings in a hand-edited config are unset, not empty flags.
+    #[test]
+    fn test_resolve_dispatch_dials_treats_empty_as_unset() {
+        let config = BudgetConfig {
+            budget_window_s: 18000,
+            model: String::new(),
+            effort: Some(String::new()),
+            budget_usd: Some(String::new()),
+        };
+        let dials = resolve_dispatch_dials(Some(&config));
+        assert_eq!(dials.model, BudgetConfig::default().model);
+        assert_eq!(dials.effort, None);
+        assert_eq!(dials.budget_usd, None);
     }
 
     #[test]

--- a/crosslink/src/commands/swarm/types.rs
+++ b/crosslink/src/commands/swarm/types.rs
@@ -129,18 +129,32 @@ pub struct TestResult {
 }
 
 /// Budget configuration stored at `swarm/budget.json` on the hub branch.
+///
+/// Doubles as swarm's dispatch configuration: `model` is both the model cost
+/// estimates are computed against and the model agents are launched with, and
+/// the optional dials are threaded into every dispatched agent (gh#61).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BudgetConfig {
     pub budget_window_s: u64,
     pub model: String,
+    /// Reasoning effort for dispatched agents (`claude --effort`). `None`
+    /// dispatches without the flag.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effort: Option<String>,
+    /// Per-agent spend ceiling in USD (`claude --max-budget-usd`). Applied to
+    /// each dispatched session, not divided across a wave (Decision D1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub budget_usd: Option<String>,
 }
 
-/// Default: 5-hour window, opus model (#521).
+/// Default: 5-hour window, opus model (#521), no dials.
 impl Default for BudgetConfig {
     fn default() -> Self {
         Self {
             budget_window_s: 18000,
             model: "opus".to_string(),
+            effort: None,
+            budget_usd: None,
         }
     }
 }

--- a/crosslink/src/main.rs
+++ b/crosslink/src/main.rs
@@ -1706,6 +1706,25 @@ enum KickoffCommands {
             conflicts_with = "skip_permissions"
         )]
         permission_mode: Option<String>,
+        /// Reasoning effort for the dispatched claude session (gh#61).
+        ///
+        /// Emitted as `claude --effort <level>` right after `--model`.
+        /// Omitting it reproduces the previous invocation exactly.
+        #[arg(
+            long,
+            value_name = "LEVEL",
+            value_parser = clap::builder::PossibleValuesParser::new(
+                commands::kickoff::EFFORT_LEVELS,
+            )
+        )]
+        effort: Option<String>,
+        /// Spend ceiling in USD for the dispatched claude session (gh#61).
+        ///
+        /// Emitted as `claude --max-budget-usd <amount>` — a fail-closed cap
+        /// for unattended dispatch. Per-session: under swarm each agent gets
+        /// this cap, so a wave of N agents can spend up to N x amount.
+        #[arg(long, value_name = "AMOUNT")]
+        budget_usd: Option<String>,
     },
     /// Check status of a running kickoff agent (no args = pipeline overview)
     Status {
@@ -1769,6 +1788,20 @@ enum KickoffCommands {
             conflicts_with = "skip_permissions"
         )]
         permission_mode: Option<String>,
+        /// Reasoning effort for the dispatched claude session (gh#61).
+        ///
+        /// Same levels and placement as `kickoff run --effort`.
+        #[arg(
+            long,
+            value_name = "LEVEL",
+            value_parser = clap::builder::PossibleValuesParser::new(
+                commands::kickoff::EFFORT_LEVELS,
+            )
+        )]
+        effort: Option<String>,
+        /// Spend ceiling in USD for the dispatched claude session (gh#61).
+        #[arg(long, value_name = "AMOUNT")]
+        budget_usd: Option<String>,
     },
     /// Display a gap report from a previous plan analysis
     ShowPlan {
@@ -1969,14 +2002,30 @@ enum SwarmCommands {
         #[arg(long)]
         force: bool,
     },
-    /// Set budget parameters (window duration, model)
+    /// Set budget parameters (window duration, model, dispatch dials)
     Config {
         /// Budget time window (e.g. "5h", "3h30m")
         #[arg(long, value_name = "DURATION")]
         budget_window: String,
-        /// Model to estimate costs for
+        /// Model to estimate costs for — also the model swarm dispatches
+        /// its agents with (gh#61)
         #[arg(long, default_value = "opus")]
         model: String,
+        /// Reasoning effort for every agent swarm dispatches (gh#61)
+        #[arg(
+            long,
+            value_name = "LEVEL",
+            value_parser = clap::builder::PossibleValuesParser::new(
+                commands::kickoff::EFFORT_LEVELS,
+            )
+        )]
+        effort: Option<String>,
+        /// Per-agent spend ceiling in USD for swarm dispatch (gh#61).
+        ///
+        /// Applied to each dispatched session, so a wave of N agents can
+        /// spend up to N x this amount.
+        #[arg(long, value_name = "AMOUNT")]
+        budget_usd: Option<String>,
     },
     /// Estimate wall-clock cost for a phase
     Estimate {
@@ -3306,7 +3355,15 @@ fn main() -> Result<()> {
                 SwarmCommands::Config {
                     budget_window,
                     model,
-                } => commands::swarm::config_budget(&crosslink_dir, &budget_window, &model),
+                    effort,
+                    budget_usd,
+                } => commands::swarm::config_budget(
+                    &crosslink_dir,
+                    &budget_window,
+                    &model,
+                    effort.as_deref(),
+                    budget_usd.as_deref(),
+                ),
                 SwarmCommands::Estimate { phase } => {
                     commands::swarm::estimate(&crosslink_dir, &phase)
                 }

--- a/crosslink/tests/cli_integration.rs
+++ b/crosslink/tests/cli_integration.rs
@@ -3898,3 +3898,64 @@ fn test_kickoff_plan_permission_flags_are_exposed_and_conflict() {
         "expected a clap conflict error naming the two flags, got: {err}"
     );
 }
+
+// gh#61 (AC-3): `kickoff run --effort <bogus>` is rejected at the clap layer
+// with a value error naming the allowed set, so a typo'd dial fails closed
+// instead of silently dispatching an un-dialed agent. Mirrors the gh#66
+// conflict test — verified at the CLI layer, no tmux involved.
+#[test]
+fn test_kickoff_run_rejects_unknown_effort_level() {
+    let dir = test_dir();
+    init_git_and_crosslink(dir.path());
+    let (success, _out, err) = run_crosslink(
+        dir.path(),
+        &["kickoff", "run", "some feature", "--effort", "bogus"],
+    );
+    assert!(!success, "an unknown --effort level must be rejected");
+    let e = err.to_lowercase();
+    assert!(
+        e.contains("invalid value") || e.contains("possible values"),
+        "expected a clap value error, got: {err}"
+    );
+    for level in ["low", "medium", "high", "xhigh", "max"] {
+        assert!(
+            err.contains(level),
+            "the error must name the allowed level '{level}', got: {err}"
+        );
+    }
+}
+
+// The same fail-closed validation on `kickoff plan`, which gained the dials
+// alongside `kickoff run`.
+#[test]
+fn test_kickoff_plan_rejects_unknown_effort_level() {
+    let dir = test_dir();
+    init_git_and_crosslink(dir.path());
+    let (success, _out, err) = run_crosslink(
+        dir.path(),
+        &["kickoff", "plan", "does-not-matter.md", "--effort", "bogus"],
+    );
+    assert!(!success, "an unknown --effort level must be rejected");
+    let e = err.to_lowercase();
+    assert!(
+        e.contains("invalid value") || e.contains("possible values"),
+        "expected a clap value error, got: {err}"
+    );
+}
+
+// A valid level parses (the failure below comes from the missing design doc,
+// not from the dial) — guards against the value parser rejecting its own set.
+#[test]
+fn test_kickoff_plan_accepts_valid_effort_level() {
+    let dir = test_dir();
+    init_git_and_crosslink(dir.path());
+    let (_success, _out, err) = run_crosslink(
+        dir.path(),
+        &["kickoff", "plan", "does-not-matter.md", "--effort", "xhigh"],
+    );
+    let e = err.to_lowercase();
+    assert!(
+        !e.contains("invalid value"),
+        "'xhigh' is a valid effort level, got: {err}"
+    );
+}

--- a/docs_src/guides/kickoff.qmd
+++ b/docs_src/guides/kickoff.qmd
@@ -238,6 +238,37 @@ If you find yourself passing `--skip-permissions` on every kickoff, that's a sig
 
 &nbsp;
 
+### Dispatch dials: reasoning effort and spend ceiling
+
+Two optional per-launch dials sit alongside `--model` on `kickoff run` and `kickoff plan`:
+
+```bash
+crosslink kickoff run "add batch retry logic" --model opus --effort high --budget-usd 5
+```
+
+- **`--effort <low|medium|high|xhigh|max>`** -- how much reasoning the dispatched session spends per turn. Invalid levels are rejected before anything is created, so a typo fails the launch rather than silently dispatching an un-dialed agent.
+- **`--budget-usd <amount>`** -- a spend ceiling for the session. It is a *per-session* cap: under swarm each dispatched agent gets the given cap, so a wave of N agents can spend up to N times the amount.
+
+Both are optional; omitting them launches exactly as before. Whatever you set is recorded in the worktree's `.kickoff-metadata.json` alongside the resolved model, so the run record answers what the dispatch was actually given:
+
+```json
+{
+  "started_at": "2026-08-02T05:44:02Z",
+  "timeout_secs": 3600,
+  "model": "opus",
+  "effort": "high",
+  "budget_usd": "5"
+}
+```
+
+For swarm, the dials are configured once and apply to every agent the swarm launches:
+
+```bash
+crosslink swarm config --budget-window 5h --model sonnet --effort high --budget-usd 5
+```
+
+&nbsp;
+
 ---
 
 ## Managing kickoffs


### PR DESCRIPTION
Implements #61 — **Slice 1** of the `dispatch-dials-and-injection-seam` design. This is a new capability, not a fix: it adds first-class *dispatch dials* to the kickoff/swarm launch path.

## Motivation

crosslink can dispatch an agent (`kickoff run`/`plan`, and swarm waves), but it can neither **set** nor **record** the two knobs that most shape a dispatch's cost and quality: the model's **reasoning effort** and its **spend ceiling**. Model is settable (`--model`) but effort and budget are not, and none of the three are captured in the run record. For any harness that dispatches through crosslink under a fail-closed discipline (the immediate consumer is vsdd, tracked in the epic magnificentlycursed/crosslink#2, requirement R4/R5), that's a gap in both directions: it can't command the dials, and it can't verify from the transcript what a dispatch was actually dialed with. Slice 1 closes both.

`claude` already exposes the underlying controls — `--effort <low|medium|high|xhigh|max>` and `--max-budget-usd <amount>` — so this is about threading them through crosslink's dispatch surface and persisting them, not inventing a mechanism.

## Design

This is the first of two slices from the design doc (stored as the `dispatch-dials-and-injection-seam` knowledge page). Slice 1 is the **dials** (this PR); Slice 2 is the **#62 prompt-injection seam**, which is gated on the `kickoff_template` mechanism reaching develop and is **out of scope here**. The two slices were designed together because they share `KickoffOpts` and the swarm launch path, but they ship independently.

## What this adds

**CLI surface**
- `crosslink kickoff run` and `crosslink kickoff plan` gain `--effort <low|medium|high|xhigh|max>` and `--budget-usd <amount>`. Both are optional; omitting them reproduces today's invocation byte-for-byte.
- `crosslink swarm config` gains the same two dials, applied to **every agent** the swarm dispatches (see Decision D1 below).
- `--effort` is validated against the `EFFORT_LEVELS` set; `--budget-usd` takes a dollar amount.

**Emission** — the dials thread through `KickoffOpts`/`PlanOpts` into `build_agent_command`, emitted immediately after the existing `--model`:
- `--effort high` → `claude … --model <m> --effort high …`
- `--budget-usd 5` → `claude … --max-budget-usd 5 …` (a fail-closed spend cap)

on **both** the local (tmux) and the container command paths, each value shell-escaped.

**Recording (the R5 half)** — `KickoffMetadata` (written to `.kickoff-metadata.json` at launch) now carries `model`, `effort`, and `budget_usd`, populated via `KickoffMetadata::for_launch(opts, started_at)`. This is the point of the feature for a conformance consumer: the run record now answers "what effort / spend ceiling / model did this dispatch actually get?" — previously unrecorded on the kickoff path.

**Swarm** — `swarm/lifecycle.rs` no longer hardcodes `model: "opus"`; it threads `model`/`effort`/`budget_usd` from swarm config into the per-agent `KickoffOpts`. Every `KickoffOpts` construction site is updated, including the sentinel auto-dispatch (which carries no dials — `effort: None`, `budget_usd: None`).

## Decisions

- **D1 — `--budget-usd` is a per-agent cap.** `claude --max-budget-usd` bounds a single session's spend, so under swarm the cap applies **per dispatched agent** (total wave spend up to N×amount). This matches the flag's per-session semantics, needs no division policy, and can't starve a mid-wave agent. A hard wave-level ceiling is deliberately not attempted.
- **Effort levels** mirror the claude CLI's set exactly (`low|medium|high|xhigh|max`) rather than inventing an abstraction.

## Out of scope

- Slice 2 — the #62 injection seam (prompt interpolation, `--template`, swarm per-phase composition). Gated on `kickoff_template` reaching develop; separate PR.
- No change to model selection/defaults beyond de-hardcoding swarm's `"opus"`.

## Testing

- Unit tests: flag parsing, the `EFFORT_LEVELS` validation set, `--effort`/`--budget-usd` command-string emission (present/absent), and `KickoffMetadata` serde round-trip capturing the dials.
- CLI-integration tests for the flags on `run`/`plan`.
- `docs_src/guides/kickoff.qmd` documents the dials.
- `cargo build`, `cargo clippy -- -D warnings -W clippy::unwrap_used -W clippy::expect_used`, `cargo fmt --check`, and the full suite green (bin 2870, integration 198, smoke 159).

## Provenance

Implemented by a **containerized kickoff agent** running in `ghcr.io/magnificentlycursed/crosslink-agent` — the `kickoff --container` dispatch path (which, per #55, runs headlessly without a trust stall because a detached container has no TTY), made usable by #75 (PR #76: fixed `crosslink container build` and made the image fork-publishable). The agent produced the implementation; it was reviewed and re-verified on the host, then rebased onto a clean develop for this PR. In other words, this feature was built by dispatching an agent through the very surface it extends.

Authored by Claude Code on behalf of @magnificentlycursed.

Generated with [Claude Code](https://claude.com/claude-code)
