### PR TITLE
backport: bring PR #44 into develop

### DIFF
--- a/crosslink/resources/claude/commands/kickoff.md
+++ b/crosslink/resources/claude/commands/kickoff.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash(crosslink *), Bash(which *), Bash(tmux *)
-description: Create a worktree and launch a background claude agent in tmux to implement a feature
+description: Create a worktree and launch a background agent in tmux to implement a feature
 argument-hint: <feature description> [--issue <id>] [--verify local|ci|thorough] [--container docker|podman]
 ---
 
@@ -9,8 +9,7 @@ argument-hint: <feature description> [--issue <id>] [--verify local|ci|thorough]
 - Current repo root: !`git rev-parse --show-toplevel`
 - Current branch: !`git branch --show-current`
 - tmux available: !`which tmux`
-- claude available: !`which claude`
-- gh available: !`which gh`
+- agent binary available: !`which $(crosslink config get agent.binary 2>/dev/null || echo claude)`
 
 ## Your task
 
@@ -26,7 +25,7 @@ The user may pass these flags after the feature description:
   - `thorough`: Everything in `ci` plus a structured adversarial self-review.
 - `--issue <id>`: Use an existing crosslink issue instead of creating a new one.
 - `--container <runtime>`: Use `docker` or `podman` instead of local tmux. Default: `none`.
-- `--model <model>`: LLM model to use. Default: `opus`.
+- `--model <model>`: LLM model to use (provider/model format, e.g. `opencode-go/deepseek-v4-flash`, `google-vertex/gemini-3.1-pro-preview`). Default: from `hook-config.json` or `opus`.
 - `--timeout <duration>`: Max runtime (e.g. `1h`, `30m`). Default: `1h`.
 - All other text is the feature description.
 
@@ -34,7 +33,7 @@ The user may pass these flags after the feature description:
 
 ### Steps
 
-1. **Validate prerequisites**: Check that `tmux` and `claude` are available (for local mode). If `--verify ci` or `--verify thorough`, check that `gh` is available. If missing, tell the user what to install and stop.
+1. **Validate prerequisites**: Check that `tmux` and the configured agent binary are available (for local mode). If `--verify ci` or `--verify thorough`, check that `gh` is available. If missing, tell the user what to install and stop.
 
 2. **Build the crosslink kickoff command**: Map parsed arguments to CLI flags:
 
@@ -59,6 +58,25 @@ Add `--issue <id>` if the user specified one. Add `--dry-run` if the user asked 
 4. **Report**: The CLI prints the summary. Relay it to the user. Remind them to:
    - Approve trust: `tmux attach -t <session-name>`
    - Check status: `crosslink kickoff status <agent-id>` or `/check <session-name>`
+
+## Configuration
+
+The agent binary and default model are configured via `hook-config.json`:
+
+```jsonc
+{
+    "agent": {
+        "binary": "opencode"
+    },
+    "sentinel": {
+        "default_agent": {
+            "model": "opencode-go/deepseek-v4-flash"
+        }
+    }
+}
+```
+
+When a non-Claude binary is configured, the wrapper automatically omits Anthropic-specific environment variables (`CLAUDE_CONFIG_DIR`, `CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`) and credential mounts (`~/.claude`).
 
 ## Constraints
 

--- a/crosslink/src/commands/kickoff/launch.rs
+++ b/crosslink/src/commands/kickoff/launch.rs
@@ -40,12 +40,6 @@ pub(super) fn read_sandbox_command(crosslink_dir: &Path) -> Option<String> {
         .map(ToString::to_string)
 }
 
-/// Read the `agent.binary` setting from hook-config.json, if configured.
-///
-/// Returns the configured binary name, or `"claude"` when the key is absent,
-/// empty, or the file cannot be parsed. This lets projects point kickoff at a
-/// different agent CLI (e.g. `opencode`, `codex`) without code changes.
-
 pub(super) fn read_watchdog_config(crosslink_dir: &Path) -> WatchdogConfig {
     let config_path = crosslink_dir.join("hook-config.json");
     let Ok(content) = std::fs::read_to_string(&config_path) else {

--- a/crosslink/src/commands/kickoff/launch.rs
+++ b/crosslink/src/commands/kickoff/launch.rs
@@ -40,6 +40,12 @@ pub(super) fn read_sandbox_command(crosslink_dir: &Path) -> Option<String> {
         .map(ToString::to_string)
 }
 
+/// Read the `agent.binary` setting from hook-config.json, if configured.
+///
+/// Returns the configured binary name, or `"claude"` when the key is absent,
+/// empty, or the file cannot be parsed. This lets projects point kickoff at a
+/// different agent CLI (e.g. `opencode`, `codex`) without code changes.
+
 pub(super) fn read_watchdog_config(crosslink_dir: &Path) -> WatchdogConfig {
     let config_path = crosslink_dir.join("hook-config.json");
     let Ok(content) = std::fs::read_to_string(&config_path) else {
@@ -184,6 +190,7 @@ pub(super) fn permission_flag(permission_mode: Option<&str>, skip_permissions: b
 /// When `claude_config_dir` is `None`, the assignment is omitted.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn build_agent_command(
+    agent_binary: &str,
     timeout_cmd: &str,
     timeout_secs: u64,
     model: &str,
@@ -215,15 +222,22 @@ pub(super) fn build_agent_command(
     // effect regardless of what wraps the resulting command (timeout, sandbox
     // wrappers, etc.). `env` accepts `KEY=val` between options and the
     // command, mutating only the environment passed to the exec'd process.
-    let env_assignment = claude_config_dir
-        .filter(|v| !v.is_empty())
-        .map(|v| format!("CLAUDE_CONFIG_DIR={} ", shell_escape_arg(v)))
-        .unwrap_or_default();
+    // This is claude-specific (it is claude's config dir), so only emit it
+    // when the configured agent binary is `claude` — other agents have no use
+    // for it and would receive a meaningless env var.
+    let env_assignment = if agent_binary == "claude" {
+        claude_config_dir
+            .filter(|v| !v.is_empty())
+            .map(|v| format!("CLAUDE_CONFIG_DIR={} ", shell_escape_arg(v)))
+            .unwrap_or_default()
+    } else {
+        String::new()
+    };
     let escaped_model = shell_escape_arg(model);
     let escaped_tools = shell_escape_arg(allowed_tools);
     let escaped_kickoff = shell_escape_arg(kickoff_file);
     let claude_cmd = format!(
-        "env -u CLAUDECODE {env_assignment}claude{skip_flag} --model {escaped_model} --allowedTools {escaped_tools} -- \"$(cat {escaped_kickoff})\""
+        "env -u CLAUDECODE {env_assignment}{agent_binary}{skip_flag} --model {escaped_model} --allowedTools {escaped_tools} -- \"$(cat {escaped_kickoff})\""
     );
     let launch = sandbox_command.map_or_else(
         || format!("{timeout_cmd} {timeout_secs}s {claude_cmd}"),
@@ -250,6 +264,7 @@ pub(super) fn preflight_check(
     crosslink_dir: &Path,
 ) -> Result<PreflightResult> {
     let platform = detect_platform();
+    let agent_binary = crate::utils::read_agent_binary(crosslink_dir);
     let mut missing: Vec<String> = Vec::new();
 
     // timeout (or gtimeout on macOS) — always required for agent timeout
@@ -275,9 +290,10 @@ pub(super) fn preflight_check(
         }
     }
 
-    // claude CLI — required for local mode
-    if *container == ContainerMode::None && !command_available("claude") {
-        missing.push(install_hint("claude", &platform));
+    // Agent CLI — required for local mode. The binary name comes from
+    // hook-config.json's `agent.binary` (default "claude").
+    if *container == ContainerMode::None && !command_available(&agent_binary) {
+        missing.push(install_hint(&agent_binary, &platform));
     }
 
     // gh — required for CI/thorough verification
@@ -588,6 +604,7 @@ pub(super) fn exclude_kickoff_files(worktree_dir: &Path) -> Result<()> {
 /// Launch the agent as a local tmux process.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn launch_local(
+    agent_binary: &str,
     worktree_dir: &Path,
     session_name: &str,
     model: &str,
@@ -625,6 +642,7 @@ pub(super) fn launch_local(
 
     // Build the claude command (with optional sandbox wrapping)
     let cmd = build_agent_command(
+        agent_binary,
         timeout_cmd,
         timeout.as_secs(),
         model,
@@ -684,6 +702,7 @@ pub(super) fn launch_local(
 #[allow(clippy::too_many_arguments)]
 pub(super) fn launch_container(
     runtime: &ContainerMode,
+    agent_binary: &str,
     worktree_dir: &Path,
     host_repo_root: &Path,
     image: &str,
@@ -708,10 +727,6 @@ pub(super) fn launch_container(
 
     let timeout_secs = timeout.as_secs();
     let container_name = format!("crosslink-agent-{agent_id}");
-
-    // Resolve host auth path for credential mounting
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
-    let host_auth = format!("{home}/.claude");
 
     // Get host UID/GID for remapping (skip on Windows — Docker Desktop handles user mapping)
     let uid_gid = if cfg!(target_os = "windows") {
@@ -739,13 +754,21 @@ pub(super) fn launch_container(
         // Mount the worktree as workspace
         "-v".to_string(),
         format!("{}:/workspaces/repo", worktree_dir.to_string_lossy()),
-        // Mount credentials read-only
-        "-v".to_string(),
-        format!("{}:/host-auth:ro", host_auth),
         // Environment
         "-e".to_string(),
         format!("AGENT_ID={}", agent_id),
     ];
+
+    // Mount claude credentials read-only and forward Anthropic auth env vars
+    // only when the configured agent is claude. Other agents have no use for
+    // `~/.claude` auth or the Anthropic/Claude OAuth tokens.
+    if agent_binary == "claude" {
+        // Resolve host auth path for credential mounting
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
+        let host_auth = format!("{home}/.claude");
+        args.push("-v".to_string());
+        args.push(format!("{host_auth}:/host-auth:ro"));
+    }
 
     // Bind-mount the main repo's `.git/` at its host absolute path. The
     // worktree's `.git` is a single file containing an absolute
@@ -778,10 +801,13 @@ pub(super) fn launch_container(
     // the parent process env, so tokens don't appear in `ps`. macOS hosts
     // — where the Keychain holds the OAuth credential rather than
     // `~/.claude/.credentials.json` — rely on this passthrough. See GH#580.
-    for var in ["CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_API_KEY"] {
-        if std::env::var(var).is_ok_and(|v| !v.is_empty()) {
-            args.push("-e".to_string());
-            args.push(var.to_string());
+    // Only relevant when the configured agent is claude.
+    if agent_binary == "claude" {
+        for var in ["CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_API_KEY"] {
+            if std::env::var(var).is_ok_and(|v| !v.is_empty()) {
+                args.push("-e".to_string());
+                args.push(var.to_string());
+            }
         }
     }
 
@@ -809,7 +835,7 @@ pub(super) fn launch_container(
     args.push("bash".to_string());
     args.push("-c".to_string());
     args.push(format!(
-        "cd /workspaces/repo && timeout {timeout_secs}s claude{skip_flag} --model {model} --allowedTools '{allowed_tools}' -- \"$(cat KICKOFF.md)\"; if [ $? -eq 124 ]; then printf 'TIMEOUT\\n' > /workspaces/repo/.kickoff-status; fi"
+        "cd /workspaces/repo && timeout {timeout_secs}s {agent_binary}{skip_flag} --model {model} --allowedTools '{allowed_tools}' -- \"$(cat KICKOFF.md)\"; if [ $? -eq 124 ]; then printf 'TIMEOUT\\n' > /workspaces/repo/.kickoff-status; fi"
     ));
 
     let output = Command::new(runtime_cmd)

--- a/crosslink/src/commands/kickoff/launch.rs
+++ b/crosslink/src/commands/kickoff/launch.rs
@@ -236,15 +236,20 @@ pub(super) fn build_agent_command(
     let escaped_model = shell_escape_arg(model);
     let escaped_tools = shell_escape_arg(allowed_tools);
     let escaped_kickoff = shell_escape_arg(kickoff_file);
-    let claude_cmd = format!(
-        "env -u CLAUDECODE {env_assignment}{agent_binary}{skip_flag} --model {escaped_model} --allowedTools {escaped_tools} -- \"$(cat {escaped_kickoff})\""
-    );
+    let agent_cmd = if agent_binary == "claude" {
+        format!(
+            "env -u CLAUDECODE {env_assignment}{agent_binary}{skip_flag} --model {escaped_model} --allowedTools {escaped_tools} -- \"$(cat {escaped_kickoff})\""
+        )
+    } else {
+        // Non-Claude agents: pipe the prompt via stdin, no --model/--allowedTools flags
+        format!("env -u CLAUDECODE {agent_binary} < {escaped_kickoff}")
+    };
     let launch = sandbox_command.map_or_else(
-        || format!("{timeout_cmd} {timeout_secs}s {claude_cmd}"),
+        || format!("{timeout_cmd} {timeout_secs}s {agent_cmd}"),
         |cmd| {
             let escaped_worktree = shell_escape_arg(&worktree_dir.to_string_lossy());
             let expanded = cmd.replace("{{worktree}}", &escaped_worktree);
-            format!("{timeout_cmd} {timeout_secs}s {expanded} {claude_cmd}")
+            format!("{timeout_cmd} {timeout_secs}s {expanded} {agent_cmd}")
         },
     );
     // gh#60: persist the TIMEOUT sentinel at kill time. GNU timeout exits
@@ -834,9 +839,16 @@ pub(super) fn launch_container(
     args.push(image.to_string());
     args.push("bash".to_string());
     args.push("-c".to_string());
-    args.push(format!(
-        "cd /workspaces/repo && timeout {timeout_secs}s {agent_binary}{skip_flag} --model {model} --allowedTools '{allowed_tools}' -- \"$(cat KICKOFF.md)\"; if [ $? -eq 124 ]; then printf 'TIMEOUT\\n' > /workspaces/repo/.kickoff-status; fi"
-    ));
+    if agent_binary == "claude" {
+        args.push(format!(
+            "cd /workspaces/repo && timeout {timeout_secs}s {agent_binary}{skip_flag} --model {model} --allowedTools '{allowed_tools}' -- \"$(cat KICKOFF.md)\"; if [ $? -eq 124 ]; then printf 'TIMEOUT\\n' > /workspaces/repo/.kickoff-status; fi"
+        ));
+    } else {
+        // Non-Claude agents: pipe the prompt via stdin
+        args.push(format!(
+            "cd /workspaces/repo && timeout {timeout_secs}s {agent_binary} < KICKOFF.md; if [ $? -eq 124 ]; then printf 'TIMEOUT\\n' > /workspaces/repo/.kickoff-status; fi"
+        ));
+    }
 
     let output = Command::new(runtime_cmd)
         .args(&args)

--- a/crosslink/src/commands/kickoff/mod.rs
+++ b/crosslink/src/commands/kickoff/mod.rs
@@ -91,6 +91,7 @@ pub fn dispatch(
                 doc_path: doc.as_ref().map(|p| p.to_str().unwrap_or("unknown")),
                 skip_permissions,
                 permission_mode: permission_mode.as_deref(),
+                agent_binary: crate::utils::read_agent_binary(crosslink_dir),
             };
             // The pipeline "running" row is now written from inside `run()`
             // once the real worktree + agent identity exist (GH#614) — no more
@@ -129,6 +130,7 @@ pub fn dispatch(
                 quiet,
                 skip_permissions,
                 permission_mode: permission_mode.as_deref(),
+                agent_binary: crate::utils::read_agent_binary(crosslink_dir),
             };
             plan(crosslink_dir, db, &plan_opts)
         }
@@ -241,6 +243,7 @@ fn dispatch_launch(
             quiet,
             skip_permissions,
             permission_mode,
+            agent_binary: crate::utils::read_agent_binary(crosslink_dir),
         };
         return plan(crosslink_dir, db, &plan_opts);
     }
@@ -283,6 +286,7 @@ fn dispatch_launch(
             doc_path: doc.as_ref().map(|p| p.to_str().unwrap_or("unknown")),
             skip_permissions,
             permission_mode,
+            agent_binary: crate::utils::read_agent_binary(crosslink_dir),
         };
         // mark_running is now invoked from inside run() with the real identity.
         run(crosslink_dir, db, writer, &opts)?;
@@ -330,6 +334,7 @@ fn dispatch_launch(
                 // dialog, so plan mode keeps the fail-closed default (gh#66).
                 skip_permissions: false,
                 permission_mode: None,
+                agent_binary: crate::utils::read_agent_binary(crosslink_dir),
             };
             plan(crosslink_dir, db, &plan_opts)
         }
@@ -369,6 +374,7 @@ fn dispatch_launch(
                 doc_path: doc_path_str.as_deref(),
                 skip_permissions: false,
                 permission_mode: None,
+                agent_binary: crate::utils::read_agent_binary(crosslink_dir),
             };
             run(crosslink_dir, db, writer, &opts)?;
             Ok(())

--- a/crosslink/src/commands/kickoff/plan.rs
+++ b/crosslink/src/commands/kickoff/plan.rs
@@ -238,6 +238,7 @@ pub fn plan(crosslink_dir: &Path, db: &Database, opts: &PlanOpts) -> Result<()> 
 
     // Plan mode reads PLAN_KICKOFF.md instead of KICKOFF.md
     let cmd = build_agent_command(
+        &opts.agent_binary,
         preflight.timeout_cmd,
         opts.timeout.as_secs(),
         opts.model,

--- a/crosslink/src/commands/kickoff/run.rs
+++ b/crosslink/src/commands/kickoff/run.rs
@@ -105,8 +105,14 @@ pub fn run(
         .allowed_tools
         .extend(read_kickoff_allowed_tools(crosslink_dir));
 
-    // 5. Build the prompt
-    let prompt = build_prompt(opts, issue_id, &branch_name, &conventions);
+    // 5. Build the prompt — check for custom template or no_template first
+    let prompt = if crate::utils::read_no_template(crosslink_dir) {
+        String::new()
+    } else if let Some(custom) = crate::utils::read_kickoff_template(crosslink_dir) {
+        custom
+    } else {
+        build_prompt(opts, issue_id, &branch_name, &conventions)
+    };
 
     // Dry run: print the prompt and the would-be worktree/branch/agent, then
     // exit BEFORE creating the worktree, branch, or any sentinel file (gh#19).

--- a/crosslink/src/commands/kickoff/run.rs
+++ b/crosslink/src/commands/kickoff/run.rs
@@ -209,6 +209,7 @@ pub fn run(
             }
 
             launch_local(
+                &opts.agent_binary,
                 &worktree_dir,
                 &session_name,
                 opts.model,
@@ -248,6 +249,7 @@ pub fn run(
         mode @ (ContainerMode::Docker | ContainerMode::Podman) => {
             let container_id = launch_container(
                 mode,
+                &opts.agent_binary,
                 &worktree_dir,
                 &root,
                 opts.image,

--- a/crosslink/src/commands/kickoff/tests.rs
+++ b/crosslink/src/commands/kickoff/tests.rs
@@ -146,6 +146,7 @@ fn test_build_prompt_contains_essentials() {
         doc_path: None,
         skip_permissions: false,
         permission_mode: None,
+        agent_binary: "claude".to_string(),
     };
     let prompt = build_prompt(&opts, 42, "feature/add-retry-logic", &conventions);
 
@@ -179,6 +180,7 @@ fn test_build_prompt_ci_verification() {
         doc_path: None,
         skip_permissions: false,
         permission_mode: None,
+        agent_binary: "claude".to_string(),
     };
     let prompt = build_prompt(&opts, 1, "feature/test-ci", &conventions);
 
@@ -209,6 +211,7 @@ fn test_build_prompt_thorough_verification() {
         doc_path: None,
         skip_permissions: false,
         permission_mode: None,
+        agent_binary: "claude".to_string(),
     };
     let prompt = build_prompt(&opts, 1, "feature/test-thorough", &conventions);
 
@@ -889,6 +892,7 @@ fn test_build_prompt_local_has_no_ci_or_adversarial() {
         doc_path: None,
         skip_permissions: false,
         permission_mode: None,
+        agent_binary: "claude".to_string(),
     };
     let prompt = build_prompt(&opts, 1, "feature/test-local", &conventions);
 
@@ -919,6 +923,7 @@ fn test_build_prompt_contains_blocked_actions() {
         doc_path: None,
         skip_permissions: false,
         permission_mode: None,
+        agent_binary: "claude".to_string(),
     };
     let prompt = build_prompt(&opts, 1, "feature/test", &conventions);
 
@@ -950,6 +955,7 @@ fn test_build_prompt_embeds_issue_id_in_instructions() {
         doc_path: None,
         skip_permissions: false,
         permission_mode: None,
+        agent_binary: "claude".to_string(),
     };
     let prompt = build_prompt(&opts, 999, "feature/test-refs", &conventions);
 
@@ -981,6 +987,7 @@ fn test_build_prompt_empty_conventions_uses_generic_instructions() {
         doc_path: None,
         skip_permissions: false,
         permission_mode: None,
+        agent_binary: "claude".to_string(),
     };
     let prompt = build_prompt(&opts, 1, "feature/test-generic", &conventions);
 
@@ -1024,6 +1031,7 @@ fn test_build_prompt_with_design_doc() {
         doc_path: None,
         skip_permissions: false,
         permission_mode: None,
+        agent_binary: "claude".to_string(),
     };
     let prompt = build_prompt(&opts, 1, "feature/batch-retry", &conventions);
 
@@ -1170,6 +1178,7 @@ fn test_build_prompt_with_design_doc_open_questions() {
         doc_path: None,
         skip_permissions: false,
         permission_mode: None,
+        agent_binary: "claude".to_string(),
     };
     let prompt = build_prompt(&opts, 1, "feature/auth", &conventions);
 
@@ -1342,6 +1351,7 @@ fn test_build_prompt_with_criteria_includes_validation() {
         doc_path: None,
         skip_permissions: false,
         permission_mode: None,
+        agent_binary: "claude".to_string(),
     };
     let prompt = build_prompt(&opts, 1, "feature/test", &conventions);
     assert!(prompt.contains("Spec Validation"));
@@ -1383,6 +1393,7 @@ fn test_build_prompt_without_criteria_no_validation() {
         doc_path: None,
         skip_permissions: false,
         permission_mode: None,
+        agent_binary: "claude".to_string(),
     };
     let prompt = build_prompt(&opts, 1, "feature/test", &conventions);
     assert!(!prompt.contains("Spec Validation"));
@@ -1421,6 +1432,7 @@ fn test_build_prompt_validation_ordering() {
         doc_path: None,
         skip_permissions: false,
         permission_mode: None,
+        agent_binary: "claude".to_string(),
     };
     let prompt = build_prompt(&opts, 1, "feature/test", &conventions);
     let test_pos = prompt.find("Run tests").expect("should have test section");
@@ -1757,6 +1769,7 @@ fn test_preflight_check_missing_command_includes_hint() {
 #[test]
 fn test_build_agent_command_without_sandbox() {
     let cmd = build_agent_command(
+        "claude",
         "timeout",
         3600,
         "opus",
@@ -1777,6 +1790,7 @@ fn test_build_agent_command_without_sandbox() {
 #[test]
 fn test_build_agent_command_with_sandbox() {
     let cmd = build_agent_command(
+        "claude",
         "timeout",
         3600,
         "opus",
@@ -1795,6 +1809,7 @@ fn test_build_agent_command_with_sandbox() {
 #[test]
 fn test_build_agent_command_with_skip_permissions() {
     let cmd = build_agent_command(
+        "claude",
         "timeout",
         3600,
         "opus",
@@ -1818,6 +1833,7 @@ fn test_build_agent_command_with_permission_mode_auto() {
     // GH#603: --permission-mode <mode> emits claude's --permission-mode flag
     // with the value shell-escaped.
     let cmd = build_agent_command(
+        "claude",
         "timeout",
         3600,
         "opus",
@@ -1846,6 +1862,7 @@ fn test_build_agent_command_permission_mode_wins_over_skip_permissions() {
     // permission_mode takes precedence and skip_permissions's
     // --dangerously-skip-permissions is suppressed.
     let cmd = build_agent_command(
+        "claude",
         "timeout",
         3600,
         "opus",
@@ -1872,6 +1889,7 @@ fn test_build_agent_command_empty_permission_mode_treated_as_none() {
     // An empty string should be treated the same as None — falling back
     // to skip_permissions resolution (or no flag).
     let cmd = build_agent_command(
+        "claude",
         "timeout",
         3600,
         "opus",
@@ -1896,6 +1914,7 @@ fn test_build_agent_command_empty_permission_mode_treated_as_none() {
 #[test]
 fn test_build_agent_command_plan_kickoff() {
     let cmd = build_agent_command(
+        "claude",
         "gtimeout",
         1800,
         "sonnet",
@@ -1919,6 +1938,7 @@ fn test_build_agent_command_propagates_claude_config_dir() {
     // rather than emitting it as a shell prefix — see build_agent_command
     // docstring for why.
     let cmd = build_agent_command(
+        "claude",
         "timeout",
         3600,
         "opus",
@@ -1941,6 +1961,7 @@ fn test_build_agent_command_omits_empty_claude_config_dir() {
     // An empty string should be treated the same as None — propagating an
     // empty value would just confuse claude's lookup logic.
     let cmd = build_agent_command(
+        "claude",
         "timeout",
         3600,
         "opus",
@@ -1962,6 +1983,7 @@ fn test_build_agent_command_escapes_claude_config_dir_with_quotes() {
     // parses correctly. shell_escape_arg wraps in single quotes and replaces
     // embedded single quotes with '\''.
     let cmd = build_agent_command(
+        "claude",
         "timeout",
         3600,
         "opus",
@@ -1982,6 +2004,7 @@ fn test_build_agent_command_with_sandbox_includes_claude_config_dir() {
     // boundary so the sandboxed claude process inherits the variable, not
     // the sandbox wrapper itself. Folded into env(1)'s argv per GH#587.
     let cmd = build_agent_command(
+        "claude",
         "timeout",
         3600,
         "opus",
@@ -2075,6 +2098,7 @@ fn test_build_agent_command_env_var_actually_reaches_claude() {
     std::fs::write(tmp.path().join("KICKOFF.md"), "noop").unwrap();
 
     let cmd = build_agent_command(
+        "claude",
         timeout_cmd,
         3600,
         "opus",
@@ -2127,6 +2151,7 @@ fn test_build_agent_command_env_var_reaches_claude_through_sandbox() {
     std::fs::set_permissions(&sandbox, std::fs::Permissions::from_mode(0o755)).unwrap();
 
     let cmd = build_agent_command(
+        "claude",
         timeout_cmd,
         3600,
         "opus",
@@ -2170,6 +2195,7 @@ fn test_build_agent_command_omitted_env_var_does_not_break_launch() {
     std::fs::write(tmp.path().join("KICKOFF.md"), "noop").unwrap();
 
     let cmd = build_agent_command(
+        "claude",
         timeout_cmd,
         3600,
         "opus",
@@ -2202,6 +2228,42 @@ fn test_read_sandbox_command_not_configured() {
     let dir = tempfile::tempdir().unwrap();
     std::fs::write(dir.path().join("hook-config.json"), "{}").unwrap();
     assert!(read_sandbox_command(dir.path()).is_none());
+}
+
+#[test]
+fn test_read_agent_binary_defaults_to_claude() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("hook-config.json"), "{}").unwrap();
+    assert_eq!(crate::utils::read_agent_binary(dir.path()), "claude");
+}
+
+#[test]
+fn test_read_agent_binary_configured() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("hook-config.json"),
+        r#"{"agent": {"binary": "opencode"}}"#,
+    )
+    .unwrap();
+    assert_eq!(crate::utils::read_agent_binary(dir.path()), "opencode");
+}
+
+#[test]
+fn test_read_agent_binary_empty_string_ignored() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("hook-config.json"),
+        r#"{"agent": {"binary": ""}}"#,
+    )
+    .unwrap();
+    assert_eq!(crate::utils::read_agent_binary(dir.path()), "claude");
+}
+
+#[test]
+fn test_read_agent_binary_missing_file_defaults_to_claude() {
+    let dir = tempfile::tempdir().unwrap();
+    // No hook-config.json present at all.
+    assert_eq!(crate::utils::read_agent_binary(dir.path()), "claude");
 }
 
 #[test]
@@ -2456,6 +2518,7 @@ fn test_build_prompt_contains_report_json_schema() {
         doc_path: Some("test.md"),
         skip_permissions: false,
         permission_mode: None,
+        agent_binary: "claude".to_string(),
     };
     let prompt = build_prompt(&opts, 1, "feature/test", &conventions);
 
@@ -2504,6 +2567,7 @@ fn test_build_prompt_contains_validation_section() {
         doc_path: Some("test.md"),
         skip_permissions: false,
         permission_mode: None,
+        agent_binary: "claude".to_string(),
     };
     let prompt = build_prompt(&opts, 1, "feature/validated", &conventions);
 

--- a/crosslink/src/commands/kickoff/types.rs
+++ b/crosslink/src/commands/kickoff/types.rs
@@ -97,6 +97,9 @@ pub struct KickoffOpts<'a> {
     /// with the finer-grained mode (acceptEdits/auto/bypassPermissions/
     /// default/dontAsk/plan). CLI marks the flags as mutually exclusive.
     pub permission_mode: Option<&'a str>,
+    /// Agent binary to launch (read from hook-config.json `agent.binary`,
+    /// default "claude"). Allows pointing kickoff at a different agent CLI.
+    pub agent_binary: String,
 }
 
 /// A single criterion verdict in the validation report.
@@ -226,6 +229,9 @@ pub struct PlanOpts<'a> {
     /// Pass `--permission-mode <mode>`. Mutually exclusive with
     /// `skip_permissions`; does not itself clear the trust dialog.
     pub permission_mode: Option<&'a str>,
+    /// Agent binary to launch (read from hook-config.json `agent.binary`,
+    /// default "claude").
+    pub agent_binary: String,
 }
 
 /// Detect project conventions from the repo root.

--- a/crosslink/src/commands/sentinel/collect.rs
+++ b/crosslink/src/commands/sentinel/collect.rs
@@ -3,8 +3,10 @@ use std::path::Path;
 use std::process::Command;
 
 use crate::db::Database;
+use crate::shared_writer::SharedWriter;
 
 use super::config::SentinelConfig;
+use super::engine;
 use super::seen_set::gh_comment_already_posted;
 
 /// Statistics from a result collection pass.
@@ -38,10 +40,14 @@ struct TemplateContext<'a> {
 /// Poll completed agents, read findings, post results to GitHub, update records.
 ///
 /// Runs every sentinel cycle (after dispatch phase in oneshot, every cycle in watch).
+///
+/// `writer` is used to file triage issues (e.g. when an agent exhausts all
+/// retry attempts) on the hub branch when available.
 pub fn collect_completed(
     db: &Database,
     crosslink_dir: &Path,
     config: Option<&SentinelConfig>,
+    writer: Option<&SharedWriter>,
 ) -> Result<CollectStats> {
     let pending = db.get_pending_dispatches()?;
     let mut stats = CollectStats::default();
@@ -106,6 +112,37 @@ pub fn collect_completed(
                 tracing::debug!("sentinel #{} already posted to GH#{}", dispatch.id, gh_num);
             } else if let Err(e) = post_gh_comment(gh_num, &comment_body) {
                 tracing::warn!("failed to post results to GH#{gh_num}: {e}");
+            }
+        }
+
+        // If the agent exhausted all retry attempts, file a high-priority
+        // triage issue BEFORE recording the exhausted outcome so a human is
+        // alerted. Done prior to `update_dispatch_outcome` so the issue
+        // reference is captured in the same cycle as the terminal state.
+        if outcome == "exhausted" {
+            let reference = &dispatch.signal_ref;
+            let title = format!(
+                "Agent exhausted after all attempts: {}",
+                dispatch.signal_title
+            );
+            let description = format!(
+                "Sentinel agent `{}` exhausted all retry attempts for signal `{}` \
+                 (attempt {}). Findings recorded by the agent:\n\n{}",
+                dispatch.agent_id.as_deref().unwrap_or("unknown"),
+                reference,
+                dispatch.attempt_number,
+                findings,
+            );
+            if let Err(e) = engine::create_triage_issue(
+                db,
+                writer,
+                reference,
+                &title,
+                &description,
+                "high",
+                &["agent-exhausted", "sentinel"],
+            ) {
+                tracing::warn!("failed to file agent-exhausted triage issue: {e}");
             }
         }
 

--- a/crosslink/src/commands/sentinel/dispatch.rs
+++ b/crosslink/src/commands/sentinel/dispatch.rs
@@ -58,22 +58,21 @@ pub fn triage(
     // the self-tuning recommendation and the per-decision default. It is
     // applied to `scope.model` before the New/Escalate branch and bypasses
     // `tuning.model_for_label`.
-    let model_override = model_override.map(String::from);
-
     let (model, attempt) = match decision {
         SignalDecision::New => {
-            let model = if let Some(ov) = &model_override {
-                ov.clone()
-            } else {
-                // Check if self-tuning recommends a different model for this label
-                tuning
-                    .and_then(|t| t.model_for_label(label))
-                    .map_or_else(|| config.default_agent.model.clone(), String::from)
-            };
+            let model = model_override.map_or_else(
+                || {
+                    // Check if self-tuning recommends a different model for this label
+                    tuning
+                        .and_then(|t| t.model_for_label(label))
+                        .map_or_else(|| config.default_agent.model.clone(), String::from)
+                },
+                String::from,
+            );
             (model, 1u32)
         }
         SignalDecision::Escalate => (
-            model_override.unwrap_or_else(|| config.escalation.model.clone()),
+            model_override.map_or_else(|| config.escalation.model.clone(), String::from),
             2u32,
         ),
         SignalDecision::Skip(reason) => {

--- a/crosslink/src/commands/sentinel/dispatch.rs
+++ b/crosslink/src/commands/sentinel/dispatch.rs
@@ -46,6 +46,7 @@ pub fn triage(
     decision: &SignalDecision,
     config: &SentinelConfig,
     tuning: Option<&super::tuning::TuningOverride>,
+    model_override: Option<&str>,
 ) -> Disposition {
     let label = signal
         .metadata
@@ -53,15 +54,28 @@ pub fn triage(
         .and_then(|v| v.as_str())
         .unwrap_or("");
 
+    // An explicit model override (e.g. `--model`) takes precedence over both
+    // the self-tuning recommendation and the per-decision default. It is
+    // applied to `scope.model` before the New/Escalate branch and bypasses
+    // `tuning.model_for_label`.
+    let model_override = model_override.map(String::from);
+
     let (model, attempt) = match decision {
         SignalDecision::New => {
-            // Check if self-tuning recommends a different model for this label
-            let model = tuning
-                .and_then(|t| t.model_for_label(label))
-                .map_or_else(|| config.default_agent.model.clone(), String::from);
+            let model = if let Some(ov) = &model_override {
+                ov.clone()
+            } else {
+                // Check if self-tuning recommends a different model for this label
+                tuning
+                    .and_then(|t| t.model_for_label(label))
+                    .map_or_else(|| config.default_agent.model.clone(), String::from)
+            };
             (model, 1u32)
         }
-        SignalDecision::Escalate => (config.escalation.model.clone(), 2u32),
+        SignalDecision::Escalate => (
+            model_override.unwrap_or_else(|| config.escalation.model.clone()),
+            2u32,
+        ),
         SignalDecision::Skip(reason) => {
             return Disposition::Skip {
                 reason: reason.to_string(),

--- a/crosslink/src/commands/sentinel/engine.rs
+++ b/crosslink/src/commands/sentinel/engine.rs
@@ -22,26 +22,32 @@ pub struct CycleStats {
     pub deferred: u32,
 }
 
+/// Per-cycle behavior shared by polled and webhook-driven dispatches.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct CycleOptions<'a> {
+    pub quiet: bool,
+    pub model_override: Option<&'a str>,
+}
+
 /// Run a single sentinel cycle: poll sources, triage, dispatch, collect.
-pub fn run_oneshot(
+pub(super) fn run_oneshot(
     crosslink_dir: &Path,
     db: &Database,
     writer: Option<&SharedWriter>,
     config: &SentinelConfig,
     dry_run: bool,
     label_filter: Option<&str>,
-    quiet: bool,
-    model_override: Option<&str>,
+    options: CycleOptions<'_>,
 ) -> Result<CycleStats> {
     if !config.enabled {
-        if !quiet {
+        if !options.quiet {
             println!("sentinel is disabled");
         }
         return Ok(CycleStats::default());
     }
 
     if dry_run {
-        return Ok(run_dry(config, quiet));
+        return Ok(run_dry(config, options.quiet));
     }
 
     // Poll all configured sources to gather signals
@@ -54,8 +60,7 @@ pub fn run_oneshot(
         config,
         &all_signals,
         "oneshot",
-        quiet,
-        model_override,
+        options,
     )
 }
 
@@ -125,15 +130,14 @@ fn poll_all_sources(
 ///
 /// Used by both `run_oneshot` (after polling sources) and `webhook` (for real-time
 /// events that arrive between polling cycles).
-pub fn process_signal_batch(
+pub(super) fn process_signal_batch(
     crosslink_dir: &Path,
     db: &Database,
     writer: Option<&SharedWriter>,
     config: &SentinelConfig,
     all_signals: &[Signal],
     mode: &str,
-    quiet: bool,
-    model_override: Option<&str>,
+    options: CycleOptions<'_>,
 ) -> Result<CycleStats> {
     let run_id = Uuid::new_v4().to_string();
     db.insert_sentinel_run(&run_id, mode)?;
@@ -150,7 +154,7 @@ pub fn process_signal_batch(
     } else {
         super::tuning::TuningOverride::none()
     };
-    if tuning.has_overrides() && !quiet {
+    if tuning.has_overrides() && !options.quiet {
         println!("  self-tuning: model overrides active based on historical data");
     }
 
@@ -164,7 +168,7 @@ pub fn process_signal_batch(
         // Layer 2: in-memory dedup
         let decision = seen.evaluate(&signal.reference, config);
         if let SignalDecision::Skip(reason) = &decision {
-            if !quiet {
+            if !options.quiet {
                 println!("  skip: {} ({})", signal.reference, reason);
             }
             stats.skipped += 1;
@@ -178,7 +182,7 @@ pub fn process_signal_batch(
             let full_label = format!("agent-todo: {label}");
             let db_decision = db_dedup_check(db, num, &full_label, config)?;
             if let SignalDecision::Skip(reason) = &db_decision {
-                if !quiet {
+                if !options.quiet {
                     println!("  skip: {} ({})", signal.reference, reason);
                 }
                 stats.skipped += 1;
@@ -189,7 +193,13 @@ pub fn process_signal_batch(
         }
 
         // 5. Triage
-        let mut disposition = triage(signal, &decision, config, Some(&tuning), model_override);
+        let mut disposition = triage(
+            signal,
+            &decision,
+            config,
+            Some(&tuning),
+            options.model_override,
+        );
 
         // 6. Capacity check: if triage decided to dispatch but we're at capacity,
         //    override to Defer so the signal is retried on the next cycle.
@@ -211,7 +221,7 @@ pub fn process_signal_batch(
                 scope,
                 attempt,
             } => {
-                if !quiet {
+                if !options.quiet {
                     println!(
                         "  dispatch: {} [{:?}] (attempt {}, model: {}, detected: {})",
                         signal.reference,
@@ -274,13 +284,13 @@ pub fn process_signal_batch(
                 }
             }
             super::dispatch::Disposition::Skip { reason } => {
-                if !quiet {
+                if !options.quiet {
                     println!("  skip: {} ({})", signal.reference, reason);
                 }
                 stats.skipped += 1;
             }
             super::dispatch::Disposition::Defer { reason } => {
-                if !quiet {
+                if !options.quiet {
                     println!("  defer: {} ({})", signal.reference, reason);
                 }
                 stats.deferred += 1;
@@ -296,7 +306,7 @@ pub fn process_signal_batch(
                         let _ = db.add_label(issue_id, l);
                     }
                 }
-                if !quiet {
+                if !options.quiet {
                     println!(
                         "  triage: {} (priority: {}, labels: {})",
                         signal.reference,
@@ -328,7 +338,7 @@ pub fn process_signal_batch(
         },
     )?;
 
-    if !quiet {
+    if !options.quiet {
         println!(
             "{} signal(s) found, {} dispatched, {} skipped, {} deferred, {} collected",
             stats.signals_found, stats.dispatched, stats.skipped, stats.deferred, stats.collected,

--- a/crosslink/src/commands/sentinel/engine.rs
+++ b/crosslink/src/commands/sentinel/engine.rs
@@ -31,6 +31,7 @@ pub fn run_oneshot(
     dry_run: bool,
     label_filter: Option<&str>,
     quiet: bool,
+    model_override: Option<&str>,
 ) -> Result<CycleStats> {
     if !config.enabled {
         if !quiet {
@@ -54,6 +55,7 @@ pub fn run_oneshot(
         &all_signals,
         "oneshot",
         quiet,
+        model_override,
     )
 }
 
@@ -131,6 +133,7 @@ pub fn process_signal_batch(
     all_signals: &[Signal],
     mode: &str,
     quiet: bool,
+    model_override: Option<&str>,
 ) -> Result<CycleStats> {
     let run_id = Uuid::new_v4().to_string();
     db.insert_sentinel_run(&run_id, mode)?;
@@ -186,7 +189,7 @@ pub fn process_signal_batch(
         }
 
         // 5. Triage
-        let mut disposition = triage(signal, &decision, config, Some(&tuning));
+        let mut disposition = triage(signal, &decision, config, Some(&tuning), model_override);
 
         // 6. Capacity check: if triage decided to dispatch but we're at capacity,
         //    override to Defer so the signal is retried on the next cycle.
@@ -307,7 +310,7 @@ pub fn process_signal_batch(
     }
 
     // 7. Collect results from previously completed agents
-    match collect::collect_completed(db, crosslink_dir, Some(config)) {
+    match collect::collect_completed(db, crosslink_dir, Some(config), writer) {
         Ok(collect_stats) => stats.collected = collect_stats.collected,
         Err(e) => tracing::warn!("result collection failed: {e}"),
     }
@@ -365,22 +368,46 @@ fn create_sentinel_issue(
         signal.reference,
         &signal.body[..signal.body.len().min(2000)]
     );
+    create_triage_issue(
+        db,
+        writer,
+        &signal.reference,
+        &signal.title,
+        &description,
+        "medium",
+        &["sentinel", "bug"],
+    )
+}
+
+/// Create a crosslink issue with an explicit reference, title, description,
+/// priority, and label set.
+///
+/// Shared by `create_sentinel_issue` (signal-driven issues) and the
+/// agent-exhaustion triage path in `collect.rs`. When a `SharedWriter` is
+/// available it is used so the issue is created on the hub branch; otherwise
+/// the local database is used directly.
+pub fn create_triage_issue(
+    db: &Database,
+    writer: Option<&SharedWriter>,
+    reference: &str,
+    title: &str,
+    description: &str,
+    priority: &str,
+    labels: &[&str],
+) -> Result<i64> {
     let issue_id = if let Some(w) = writer {
-        w.create_issue(db, &signal.title, Some(&description), "medium", None, None)?
+        w.create_issue(db, title, Some(description), priority, None, None)?
     } else {
-        db.create_issue(&signal.title, Some(&description), "medium")?
+        db.create_issue(title, Some(description), priority)?
     };
-    // Label the issue
-    let label_fn = |label: &str| -> Result<()> {
+    for label in labels {
         if let Some(w) = writer {
             w.add_label(db, issue_id, label)?;
         } else {
             db.add_label(issue_id, label)?;
         }
-        Ok(())
-    };
-    let _ = label_fn("sentinel");
-    let _ = label_fn("bug");
+    }
+    let _ = reference;
     Ok(issue_id)
 }
 
@@ -450,6 +477,7 @@ fn spawn_agent(
         doc_path: None,
         skip_permissions: true,
         permission_mode: None,
+        agent_binary: crate::utils::read_agent_binary(crosslink_dir),
     };
 
     run(crosslink_dir, db, writer, &opts)

--- a/crosslink/src/commands/sentinel/mod.rs
+++ b/crosslink/src/commands/sentinel/mod.rs
@@ -40,12 +40,16 @@ pub fn dispatch_cmd(
                 &config,
                 dry_run,
                 label.as_deref(),
-                quiet,
-                model.as_deref(),
+                engine::CycleOptions {
+                    quiet,
+                    model_override: model.as_deref(),
+                },
             )?;
             Ok(())
         }
-        SentinelCommands::Watch { interval, .. } => watch::start(crosslink_dir, interval, model),
+        SentinelCommands::Watch { interval, .. } => {
+            watch::start(crosslink_dir, interval, model.as_deref())
+        }
         SentinelCommands::Status => watch::status(crosslink_dir, db),
         SentinelCommands::History {
             limit,

--- a/crosslink/src/commands/sentinel/mod.rs
+++ b/crosslink/src/commands/sentinel/mod.rs
@@ -28,9 +28,10 @@ pub fn dispatch_cmd(
     writer: Option<&SharedWriter>,
     quiet: bool,
     json: bool,
+    model: Option<String>,
 ) -> Result<()> {
     match command {
-        SentinelCommands::Run { dry_run, label } => {
+        SentinelCommands::Run { dry_run, label, .. } => {
             let config = SentinelConfig::load(crosslink_dir)?;
             engine::run_oneshot(
                 crosslink_dir,
@@ -40,10 +41,11 @@ pub fn dispatch_cmd(
                 dry_run,
                 label.as_deref(),
                 quiet,
+                model.as_deref(),
             )?;
             Ok(())
         }
-        SentinelCommands::Watch { interval } => watch::start(crosslink_dir, interval),
+        SentinelCommands::Watch { interval, .. } => watch::start(crosslink_dir, interval, model),
         SentinelCommands::Status => watch::status(crosslink_dir, db),
         SentinelCommands::History {
             limit,
@@ -62,6 +64,8 @@ pub fn dispatch_cmd(
             let use_json = json || json_flag;
             patterns::detect_patterns(db, use_json)
         }
-        SentinelCommands::RunDaemon { dir, interval } => watch::run_watch_loop(&dir, interval),
+        SentinelCommands::RunDaemon { dir, interval, .. } => {
+            watch::run_watch_loop(&dir, interval, model)
+        }
     }
 }

--- a/crosslink/src/commands/sentinel/watch.rs
+++ b/crosslink/src/commands/sentinel/watch.rs
@@ -14,7 +14,7 @@ use super::config::SentinelConfig;
 use super::engine;
 
 /// Start the sentinel daemon as a background process.
-pub fn start(crosslink_dir: &Path, interval: u64) -> Result<()> {
+pub fn start(crosslink_dir: &Path, interval: u64, model: Option<String>) -> Result<()> {
     let pid_file = crosslink_dir.join("sentinel.pid");
     let log_file = crosslink_dir.join("sentinel.log");
 
@@ -37,13 +37,17 @@ pub fn start(crosslink_dir: &Path, interval: u64) -> Result<()> {
     let log_handle_err = log_handle
         .try_clone()
         .context("Failed to clone log file handle")?;
-    let child = Command::new(&exe)
-        .arg("sentinel")
+    let mut cmd = Command::new(&exe);
+    cmd.arg("sentinel")
         .arg("run-daemon")
         .arg("--dir")
         .arg(crosslink_dir)
         .arg("--interval")
-        .arg(interval.to_string())
+        .arg(interval.to_string());
+    if let Some(m) = &model {
+        cmd.arg("--model").arg(m);
+    }
+    let child = cmd
         .stdin(Stdio::null())
         .stdout(log_handle)
         .stderr(log_handle_err)
@@ -160,7 +164,11 @@ pub fn status(crosslink_dir: &Path, db: &Database) -> Result<()> {
 /// - Webhook events from the optional GitHub webhook server
 /// - SIGTERM/SIGINT shutdown signals
 /// - Stdin closure (zombie prevention when parent dies)
-pub fn run_watch_loop(crosslink_dir: &Path, interval_minutes: u64) -> Result<()> {
+pub fn run_watch_loop(
+    crosslink_dir: &Path,
+    interval_minutes: u64,
+    model: Option<String>,
+) -> Result<()> {
     let db_path = crosslink_dir.join("issues.db");
     if !db_path.exists() {
         anyhow::bail!(
@@ -184,6 +192,7 @@ pub fn run_watch_loop(crosslink_dir: &Path, interval_minutes: u64) -> Result<()>
         crosslink_dir.to_path_buf(),
         interval_minutes,
         config,
+        model,
     ))
 }
 
@@ -192,6 +201,7 @@ async fn async_watch_loop(
     crosslink_dir: PathBuf,
     interval_minutes: u64,
     config: SentinelConfig,
+    model: Option<String>,
 ) -> Result<()> {
     let interval = Duration::from_secs(interval_minutes * 60);
     let mut backoff_multiplier: u32 = 1;
@@ -304,8 +314,9 @@ async fn async_watch_loop(
             () = &mut sleep_until => {
                 let cycle_dir = crosslink_dir.clone();
                 let cycle_config = config.clone();
+                let cycle_model = model.clone();
                 let result = tokio::task::spawn_blocking(move || {
-                    run_polling_cycle(&cycle_dir, &cycle_config)
+                    run_polling_cycle(&cycle_dir, &cycle_config, cycle_model.as_deref())
                 })
                 .await
                 .context("polling cycle task panicked")?;
@@ -325,9 +336,15 @@ async fn async_watch_loop(
                 if let Some(event) = maybe_event {
                     let cycle_dir = crosslink_dir.clone();
                     let cycle_config = config.clone();
+                    let cycle_model = model.clone();
                     let signal = event.signal;
                     let result = tokio::task::spawn_blocking(move || {
-                        run_webhook_cycle(&cycle_dir, &cycle_config, signal)
+                        run_webhook_cycle(
+                            &cycle_dir,
+                            &cycle_config,
+                            signal,
+                            cycle_model.as_deref(),
+                        )
                     })
                     .await
                     .context("webhook cycle task panicked")?;
@@ -363,7 +380,11 @@ async fn recv_webhook(
 }
 
 /// Execute a single polling cycle (sync, called via `spawn_blocking`).
-fn run_polling_cycle(crosslink_dir: &Path, config: &SentinelConfig) -> Result<()> {
+fn run_polling_cycle(
+    crosslink_dir: &Path,
+    config: &SentinelConfig,
+    model_override: Option<&str>,
+) -> Result<()> {
     let db = Database::open(&crosslink_dir.join("issues.db"))?;
     let writer = crate::shared_writer::SharedWriter::new(crosslink_dir)
         .ok()
@@ -377,6 +398,7 @@ fn run_polling_cycle(crosslink_dir: &Path, config: &SentinelConfig) -> Result<()
         false, // not dry run
         None,  // no label filter
         true,  // quiet in daemon mode (output goes to log)
+        model_override,
     )?;
 
     if stats.signals_found > 0 || stats.collected > 0 {
@@ -399,6 +421,7 @@ fn run_webhook_cycle(
     crosslink_dir: &Path,
     config: &SentinelConfig,
     signal: super::sources::Signal,
+    model_override: Option<&str>,
 ) -> Result<()> {
     let db = Database::open(&crosslink_dir.join("issues.db"))?;
     let writer = crate::shared_writer::SharedWriter::new(crosslink_dir)
@@ -414,6 +437,7 @@ fn run_webhook_cycle(
         &[signal],
         "webhook",
         true, // quiet in daemon mode
+        model_override,
     )?;
 
     println!(

--- a/crosslink/src/commands/sentinel/watch.rs
+++ b/crosslink/src/commands/sentinel/watch.rs
@@ -14,7 +14,7 @@ use super::config::SentinelConfig;
 use super::engine;
 
 /// Start the sentinel daemon as a background process.
-pub fn start(crosslink_dir: &Path, interval: u64, model: Option<String>) -> Result<()> {
+pub fn start(crosslink_dir: &Path, interval: u64, model: Option<&str>) -> Result<()> {
     let pid_file = crosslink_dir.join("sentinel.pid");
     let log_file = crosslink_dir.join("sentinel.log");
 
@@ -44,7 +44,7 @@ pub fn start(crosslink_dir: &Path, interval: u64, model: Option<String>) -> Resu
         .arg(crosslink_dir)
         .arg("--interval")
         .arg(interval.to_string());
-    if let Some(m) = &model {
+    if let Some(m) = model {
         cmd.arg("--model").arg(m);
     }
     let child = cmd
@@ -397,8 +397,10 @@ fn run_polling_cycle(
         config,
         false, // not dry run
         None,  // no label filter
-        true,  // quiet in daemon mode (output goes to log)
-        model_override,
+        engine::CycleOptions {
+            quiet: true, // daemon output goes to the log
+            model_override,
+        },
     )?;
 
     if stats.signals_found > 0 || stats.collected > 0 {
@@ -436,8 +438,10 @@ fn run_webhook_cycle(
         config,
         &[signal],
         "webhook",
-        true, // quiet in daemon mode
-        model_override,
+        engine::CycleOptions {
+            quiet: true, // daemon output goes to the log
+            model_override,
+        },
     )?;
 
     println!(

--- a/crosslink/src/commands/swarm/lifecycle.rs
+++ b/crosslink/src/commands/swarm/lifecycle.rs
@@ -741,6 +741,7 @@ pub fn launch(
             doc_path: None,
             skip_permissions: false,
             permission_mode: None,
+            agent_binary: crate::utils::read_agent_binary(crosslink_dir),
         };
 
         match kickoff::run(crosslink_dir, db, writer, &opts) {

--- a/crosslink/src/main.rs
+++ b/crosslink/src/main.rs
@@ -2125,12 +2125,18 @@ pub enum SentinelCommands {
         /// Only process signals matching this label
         #[arg(long)]
         label: Option<String>,
+        /// Override the model used for dispatched agents
+        #[arg(long)]
+        model: Option<String>,
     },
     /// Start persistent sentinel daemon
     Watch {
         /// Poll interval in minutes
         #[arg(long, default_value = "10")]
         interval: u64,
+        /// Override the model used for dispatched agents
+        #[arg(long)]
+        model: Option<String>,
     },
     /// Show sentinel daemon status and in-flight agents
     Status,
@@ -2167,6 +2173,9 @@ pub enum SentinelCommands {
         dir: std::path::PathBuf,
         #[arg(long, default_value = "10")]
         interval: u64,
+        /// Override the model used for dispatched agents
+        #[arg(long)]
+        model: Option<String>,
     },
 }
 
@@ -3394,12 +3403,23 @@ fn main() -> Result<()> {
         }
         Commands::Sentinel { action } => {
             // RunDaemon is the internal loop entry point — dir is explicit, no auto-detection
-            if let SentinelCommands::RunDaemon { ref dir, interval } = action {
-                return commands::sentinel::watch::run_watch_loop(dir, interval);
+            if let SentinelCommands::RunDaemon {
+                ref dir,
+                interval,
+                ref model,
+            } = action
+            {
+                return commands::sentinel::watch::run_watch_loop(dir, interval, model.clone());
             }
             let crosslink_dir = find_crosslink_dir()?;
             let db = get_db()?;
             let writer = get_writer(&crosslink_dir);
+            let sentinel_model = match &action {
+                SentinelCommands::Run { model, .. } => model.clone(),
+                SentinelCommands::Watch { model, .. } => model.clone(),
+                SentinelCommands::RunDaemon { model, .. } => model.clone(),
+                _ => None,
+            };
             commands::sentinel::dispatch_cmd(
                 action,
                 &crosslink_dir,
@@ -3407,6 +3427,7 @@ fn main() -> Result<()> {
                 writer.as_ref(),
                 cli.quiet,
                 cli.json,
+                sentinel_model,
             )
         }
         Commands::Tui => {

--- a/crosslink/src/main.rs
+++ b/crosslink/src/main.rs
@@ -3415,9 +3415,9 @@ fn main() -> Result<()> {
             let db = get_db()?;
             let writer = get_writer(&crosslink_dir);
             let sentinel_model = match &action {
-                SentinelCommands::Run { model, .. } => model.clone(),
-                SentinelCommands::Watch { model, .. } => model.clone(),
-                SentinelCommands::RunDaemon { model, .. } => model.clone(),
+                SentinelCommands::Run { model, .. }
+                | SentinelCommands::Watch { model, .. }
+                | SentinelCommands::RunDaemon { model, .. } => model.clone(),
                 _ => None,
             };
             commands::sentinel::dispatch_cmd(

--- a/crosslink/src/orchestrator/decompose.rs
+++ b/crosslink/src/orchestrator/decompose.rs
@@ -80,20 +80,20 @@ fn build_user_prompt(document: &str) -> String {
 // Claude CLI invocation
 // ---------------------------------------------------------------------------
 
-/// Call the `claude` CLI to decompose a document.
+/// Call the agent CLI to decompose a document.
 ///
-/// This runs `claude -p <prompt> --output-format json` as a subprocess.
-/// The Claude CLI must be available on `$PATH`.
+/// This runs `<agent_binary> -p <prompt> --output-format json` as a subprocess.
+/// The agent CLI (default `claude`) must be available on `$PATH`.
 ///
 /// Returns the raw stdout as a string on success.
-async fn call_claude_cli(document: &str) -> Result<String> {
+async fn call_claude_cli(agent_binary: &str, document: &str) -> Result<String> {
     let system_prompt = build_system_prompt();
     let user_prompt = build_user_prompt(document);
 
-    // Combine into a single prompt since `claude -p` takes one prompt argument.
+    // Combine into a single prompt since `<agent> -p` takes one prompt argument.
     let full_prompt = format!("{system_prompt}\n\n---\n\n{user_prompt}");
 
-    let output = tokio::process::Command::new("claude")
+    let output = tokio::process::Command::new(agent_binary)
         .arg("-p")
         .arg(&full_prompt)
         .arg("--output-format")
@@ -340,6 +340,7 @@ pub fn list_plans(crosslink_dir: &Path) -> Result<Vec<String>> {
 /// plan storage fails.
 pub async fn decompose_document(
     crosslink_dir: &Path,
+    agent_binary: &str,
     document: &str,
     slug: Option<&str>,
 ) -> Result<OrchestratorPlan> {
@@ -350,7 +351,7 @@ pub async fn decompose_document(
     let effective_slug = slug.unwrap_or("untitled");
 
     // Call the LLM
-    let raw_response = call_claude_cli(document).await?;
+    let raw_response = call_claude_cli(agent_binary, document).await?;
 
     // Extract and parse JSON
     let json_str = extract_json_from_response(&raw_response)?;
@@ -840,7 +841,7 @@ mod tests {
     #[tokio::test]
     async fn test_decompose_document_empty_document_bails() {
         let dir = tempfile::tempdir().unwrap();
-        let result = decompose_document(dir.path(), "", None).await;
+        let result = decompose_document(dir.path(), "claude", "", None).await;
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
@@ -851,7 +852,7 @@ mod tests {
     #[tokio::test]
     async fn test_decompose_document_whitespace_only_bails() {
         let dir = tempfile::tempdir().unwrap();
-        let result = decompose_document(dir.path(), "   \n\t  ", Some("my-slug")).await;
+        let result = decompose_document(dir.path(), "claude", "   \n\t  ", Some("my-slug")).await;
         assert!(result.is_err());
         assert!(result
             .unwrap_err()

--- a/crosslink/src/server/handlers/orchestrator.rs
+++ b/crosslink/src/server/handlers/orchestrator.rs
@@ -67,9 +67,10 @@ pub async fn decompose_handler(
     // (default "claude") so decomposition can target a non-claude agent.
     let agent_binary = crate::utils::read_agent_binary(&state.crosslink_dir);
 
-    let plan = decompose::decompose_document(&state.crosslink_dir, &agent_binary, &body.document, slug)
-        .await
-        .map_err(|e| internal_error("decomposition failed", e))?;
+    let plan =
+        decompose::decompose_document(&state.crosslink_dir, &agent_binary, &body.document, slug)
+            .await
+            .map_err(|e| internal_error("decomposition failed", e))?;
 
     Ok(Json(plan))
 }

--- a/crosslink/src/server/handlers/orchestrator.rs
+++ b/crosslink/src/server/handlers/orchestrator.rs
@@ -63,7 +63,11 @@ pub async fn decompose_handler(
 
     let slug = body.slug.as_deref();
 
-    let plan = decompose::decompose_document(&state.crosslink_dir, &body.document, slug)
+    // Resolve the agent binary from hook-config.json's `agent.binary`
+    // (default "claude") so decomposition can target a non-claude agent.
+    let agent_binary = crate::utils::read_agent_binary(&state.crosslink_dir);
+
+    let plan = decompose::decompose_document(&state.crosslink_dir, &agent_binary, &body.document, slug)
         .await
         .map_err(|e| internal_error("decomposition failed", e))?;
 

--- a/crosslink/src/token_usage.rs
+++ b/crosslink/src/token_usage.rs
@@ -408,7 +408,14 @@ mod tests {
     fn test_pricing_config_anthropic_heuristic_still_works() {
         let cfg = PricingConfig::default();
         // With an empty config, Anthropic substring heuristics still apply.
-        let cost = estimate_cost_cfg("claude-sonnet-4-20250514", 1_000_000, 1_000_000, None, None, &cfg);
+        let cost = estimate_cost_cfg(
+            "claude-sonnet-4-20250514",
+            1_000_000,
+            1_000_000,
+            None,
+            None,
+            &cfg,
+        );
         assert!(cost.is_some());
         assert!((cost.unwrap() - 18.0).abs() < 0.001);
     }

--- a/crosslink/src/token_usage.rs
+++ b/crosslink/src/token_usage.rs
@@ -6,6 +6,8 @@
 //! - Extracting usage from kickoff report JSON
 
 use serde::Deserialize;
+use std::collections::HashMap;
+use std::path::Path;
 
 /// Raw token usage data as reported by the Claude API.
 #[derive(Debug, Clone, Deserialize)]
@@ -31,16 +33,80 @@ pub struct ParsedUsage {
     pub cost_estimate: Option<f64>,
 }
 
-/// Model pricing per million tokens (input, output).
+/// Model pricing per million tokens (input, output, cache read, cache creation).
 /// Based on publicly available Anthropic pricing as of 2025.
-struct ModelPricing {
-    input: f64,
-    output: f64,
-    cache_read: f64,
-    cache_creation: f64,
+///
+/// `Default` yields all-zero pricing; `Deserialize` tolerates missing cache
+/// fields (they default to `0.0`).
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct ModelPricing {
+    pub input: f64,
+    pub output: f64,
+    #[serde(default)]
+    pub cache_read: f64,
+    #[serde(default)]
+    pub cache_creation: f64,
 }
 
-fn get_pricing(model: &str) -> Option<ModelPricing> {
+/// Provider-agnostic pricing configuration.
+///
+/// Resolution for a given model name proceeds in this order:
+/// 1. exact match in `models`,
+/// 2. longest prefix match in `providers`,
+/// 3. the built-in Anthropic substring heuristics,
+/// 4. `default`,
+/// 5. `None`.
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct PricingConfig {
+    /// Exact model-name to pricing overrides.
+    #[serde(default)]
+    pub models: HashMap<String, ModelPricing>,
+    /// Provider prefix (e.g. `"gpt-"`) to pricing.
+    #[serde(default)]
+    pub providers: HashMap<String, ModelPricing>,
+    /// Fallback pricing applied when nothing else matches.
+    #[serde(default)]
+    pub default: Option<ModelPricing>,
+}
+
+/// Load the `pricing` section of `hook-config.json` from the given crosslink
+/// directory. Returns a default (empty) config if the file is missing, invalid,
+/// or lacks a `pricing` key.
+#[must_use]
+pub fn load_pricing_config(crosslink_dir: &Path) -> PricingConfig {
+    let config_path = crosslink_dir.join("hook-config.json");
+    let content = match std::fs::read_to_string(&config_path) {
+        Ok(c) => c,
+        Err(_) => return PricingConfig::default(),
+    };
+    let value: serde_json::Value = match serde_json::from_str(&content) {
+        Ok(v) => v,
+        Err(_) => return PricingConfig::default(),
+    };
+    match value.get("pricing") {
+        Some(pricing) => serde_json::from_value(pricing.clone()).unwrap_or_default(),
+        None => PricingConfig::default(),
+    }
+}
+
+fn get_pricing(model: &str, cfg: &PricingConfig) -> Option<ModelPricing> {
+    // 1) exact match in models
+    if let Some(p) = cfg.models.get(model) {
+        return Some(p.clone());
+    }
+    // 2) longest prefix match in providers
+    let mut best_prefix_len: usize = 0;
+    let mut best: Option<ModelPricing> = None;
+    for (prefix, pricing) in &cfg.providers {
+        if model.starts_with(prefix.as_str()) && prefix.len() > best_prefix_len {
+            best_prefix_len = prefix.len();
+            best = Some(pricing.clone());
+        }
+    }
+    if let Some(p) = best {
+        return Some(p);
+    }
+    // 3) existing Anthropic substring match (kept exactly as before)
     // Normalize model name for matching
     let m = model.to_lowercase();
     if m.contains("opus") {
@@ -65,20 +131,22 @@ fn get_pricing(model: &str) -> Option<ModelPricing> {
             cache_creation: 1.0,
         })
     } else {
-        None
+        // 4) default, 5) None
+        cfg.default.clone()
     }
 }
 
-/// Estimate cost in USD for a token usage record.
+/// Estimate cost in USD for a token usage record using the given pricing config.
 #[must_use]
-pub fn estimate_cost(
+pub fn estimate_cost_cfg(
     model: &str,
     input_tokens: i64,
     output_tokens: i64,
     cache_read_tokens: Option<i64>,
     cache_creation_tokens: Option<i64>,
+    cfg: &PricingConfig,
 ) -> Option<f64> {
-    let pricing = get_pricing(model)?;
+    let pricing = get_pricing(model, cfg)?;
     #[allow(clippy::cast_precision_loss)] // token counts are well within f64 mantissa range
     let input_cost = (input_tokens as f64 / 1_000_000.0) * pricing.input;
     #[allow(clippy::cast_precision_loss)]
@@ -92,20 +160,41 @@ pub fn estimate_cost(
     Some(input_cost + output_cost + cache_read_cost + cache_creation_cost)
 }
 
-/// Parse a raw Claude API usage block into a `ParsedUsage`.
+/// Estimate cost in USD for a token usage record using the default pricing config.
 #[must_use]
-pub fn parse_api_usage(
+pub fn estimate_cost(
+    model: &str,
+    input_tokens: i64,
+    output_tokens: i64,
+    cache_read_tokens: Option<i64>,
+    cache_creation_tokens: Option<i64>,
+) -> Option<f64> {
+    estimate_cost_cfg(
+        model,
+        input_tokens,
+        output_tokens,
+        cache_read_tokens,
+        cache_creation_tokens,
+        &PricingConfig::default(),
+    )
+}
+
+/// Parse a raw Claude API usage block into a `ParsedUsage` using the given pricing config.
+#[must_use]
+pub fn parse_api_usage_cfg(
     raw: &RawTokenUsage,
     agent_id: &str,
     session_id: Option<i64>,
     model: &str,
+    cfg: &PricingConfig,
 ) -> ParsedUsage {
-    let cost = estimate_cost(
+    let cost = estimate_cost_cfg(
         model,
         raw.input_tokens,
         raw.output_tokens,
         raw.cache_read_input_tokens,
         raw.cache_creation_input_tokens,
+        cfg,
     );
     ParsedUsage {
         agent_id: agent_id.to_string(),
@@ -117,6 +206,17 @@ pub fn parse_api_usage(
         model: model.to_string(),
         cost_estimate: cost,
     }
+}
+
+/// Parse a raw Claude API usage block into a `ParsedUsage` using the default pricing config.
+#[must_use]
+pub fn parse_api_usage(
+    raw: &RawTokenUsage,
+    agent_id: &str,
+    session_id: Option<i64>,
+    model: &str,
+) -> ParsedUsage {
+    parse_api_usage_cfg(raw, agent_id, session_id, model, &PricingConfig::default())
 }
 
 #[cfg(test)]
@@ -219,5 +319,131 @@ mod tests {
         let raw: RawTokenUsage = serde_json::from_str(json).unwrap();
         assert_eq!(raw.cache_read_input_tokens, Some(2000));
         assert_eq!(raw.cache_creation_input_tokens, Some(500));
+    }
+
+    #[test]
+    fn test_pricing_config_exact_model_match() {
+        let mut cfg = PricingConfig::default();
+        cfg.models.insert(
+            "gpt-4o".to_string(),
+            ModelPricing {
+                input: 5.0,
+                output: 15.0,
+                ..Default::default()
+            },
+        );
+        let cost = estimate_cost_cfg("gpt-4o", 1_000_000, 1_000_000, None, None, &cfg);
+        assert!(cost.is_some());
+        // 5.0 + 15.0 = 20.0
+        assert!((cost.unwrap() - 20.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_pricing_config_provider_prefix_match() {
+        let mut cfg = PricingConfig::default();
+        cfg.providers.insert(
+            "gpt-".to_string(),
+            ModelPricing {
+                input: 2.5,
+                output: 10.0,
+                ..Default::default()
+            },
+        );
+        let cost = estimate_cost_cfg("gpt-4o-mini", 1_000_000, 1_000_000, None, None, &cfg);
+        assert!(cost.is_some());
+        // 2.5 + 10.0 = 12.5
+        assert!((cost.unwrap() - 12.5).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_pricing_config_longest_prefix_wins() {
+        let mut cfg = PricingConfig::default();
+        cfg.providers.insert(
+            "gpt-".to_string(),
+            ModelPricing {
+                input: 2.5,
+                output: 10.0,
+                ..Default::default()
+            },
+        );
+        cfg.providers.insert(
+            "gpt-4o".to_string(),
+            ModelPricing {
+                input: 5.0,
+                output: 15.0,
+                ..Default::default()
+            },
+        );
+        // "gpt-4o-mini" matches both "gpt-" and "gpt-4o"; longest prefix wins.
+        let cost = estimate_cost_cfg("gpt-4o-mini", 1_000_000, 1_000_000, None, None, &cfg);
+        assert!(cost.is_some());
+        // 5.0 + 15.0 = 20.0 (from the longer "gpt-4o" prefix)
+        assert!((cost.unwrap() - 20.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_pricing_config_default_fallback() {
+        let mut cfg = PricingConfig::default();
+        cfg.default = Some(ModelPricing {
+            input: 1.0,
+            output: 2.0,
+            ..Default::default()
+        });
+        // Unknown model with no provider match falls back to default.
+        let cost = estimate_cost_cfg("some-unknown-model", 1_000_000, 1_000_000, None, None, &cfg);
+        assert!(cost.is_some());
+        // 1.0 + 2.0 = 3.0
+        assert!((cost.unwrap() - 3.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_pricing_config_none_when_no_match() {
+        let cfg = PricingConfig::default();
+        // No models, no providers, no default -> None.
+        let cost = estimate_cost_cfg("gpt-4o", 1_000_000, 1_000_000, None, None, &cfg);
+        assert!(cost.is_none());
+    }
+
+    #[test]
+    fn test_pricing_config_anthropic_heuristic_still_works() {
+        let cfg = PricingConfig::default();
+        // With an empty config, Anthropic substring heuristics still apply.
+        let cost = estimate_cost_cfg("claude-sonnet-4-20250514", 1_000_000, 1_000_000, None, None, &cfg);
+        assert!(cost.is_some());
+        assert!((cost.unwrap() - 18.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_load_pricing_config_missing_file() {
+        let dir = std::env::temp_dir().join("crosslink-nonexistent-dir-xyz");
+        let cfg = load_pricing_config(&dir);
+        assert!(cfg.models.is_empty());
+        assert!(cfg.providers.is_empty());
+        assert!(cfg.default.is_none());
+    }
+
+    #[test]
+    fn test_load_pricing_config_from_json() {
+        let tmp = std::env::temp_dir().join("crosslink-pricing-test");
+        std::fs::create_dir_all(&tmp).unwrap();
+        let json = r#"{
+            "pricing": {
+                "models": {
+                    "custom-model": { "input": 7.0, "output": 21.0 }
+                },
+                "providers": {
+                    "gemini-": { "input": 1.0, "output": 2.0 }
+                },
+                "default": { "input": 0.5, "output": 1.0 }
+            }
+        }"#;
+        std::fs::write(tmp.join("hook-config.json"), json).unwrap();
+        let cfg = load_pricing_config(&tmp);
+        assert!(cfg.models.contains_key("custom-model"));
+        assert!(cfg.providers.contains_key("gemini-"));
+        assert!(cfg.default.is_some());
+        let cost = estimate_cost_cfg("custom-model", 1_000_000, 1_000_000, None, None, &cfg);
+        assert!((cost.unwrap() - 28.0).abs() < 0.001);
+        std::fs::remove_dir_all(&tmp).ok();
     }
 }

--- a/crosslink/src/utils.rs
+++ b/crosslink/src/utils.rs
@@ -14,8 +14,7 @@ pub fn read_agent_binary(crosslink_dir: &Path) -> String {
         .and_then(|a| a.get("binary"))
         .and_then(|v| v.as_str())
         .filter(|s| !s.is_empty())
-        .map(|s| s.to_string())
-        .unwrap_or_else(|| "claude".to_string())
+        .map_or_else(|| "claude".to_string(), ToString::to_string)
 }
 
 /// Read the `agent.kickoff_template` setting from `hook-config.json`.
@@ -58,7 +57,7 @@ pub fn read_no_template(crosslink_dir: &Path) -> bool {
     parsed
         .get("agent")
         .and_then(|a| a.get("no_template"))
-        .and_then(|v| v.as_bool())
+        .and_then(serde_json::Value::as_bool)
         .unwrap_or(false)
 }
 

--- a/crosslink/src/utils.rs
+++ b/crosslink/src/utils.rs
@@ -2,6 +2,22 @@ use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+/// Resolve the agent binary from `hook-config.json`'s `agent.binary`
+/// (default "claude").
+pub fn read_agent_binary(crosslink_dir: &Path) -> String {
+    let config_path = crosslink_dir.join("hook-config.json");
+    let content = std::fs::read_to_string(&config_path).unwrap_or_default();
+    let parsed: serde_json::Value =
+        serde_json::from_str(&content).unwrap_or(serde_json::Value::Null);
+    parsed
+        .get("agent")
+        .and_then(|a| a.get("binary"))
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| "claude".to_string())
+}
+
 /// Resolve the main repository root when running inside a git worktree.
 ///
 /// Compares `git rev-parse --git-common-dir` with `--git-dir`. If they

--- a/crosslink/src/utils.rs
+++ b/crosslink/src/utils.rs
@@ -18,6 +18,50 @@ pub fn read_agent_binary(crosslink_dir: &Path) -> String {
         .unwrap_or_else(|| "claude".to_string())
 }
 
+/// Read the `agent.kickoff_template` setting from `hook-config.json`.
+///
+/// Returns the template file path when configured, or `None` when the key is
+/// absent, empty, or the file cannot be parsed. The path is resolved relative
+/// to the crosslink directory when it is not absolute.
+pub fn read_kickoff_template(crosslink_dir: &Path) -> Option<String> {
+    let config_path = crosslink_dir.join("hook-config.json");
+    let content = std::fs::read_to_string(&config_path).ok()?;
+    let parsed: serde_json::Value = serde_json::from_str(&content).ok()?;
+    let path = parsed
+        .get("agent")
+        .and_then(|a| a.get("kickoff_template"))
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())?;
+    let template_path = if std::path::Path::new(path).is_absolute() {
+        std::path::PathBuf::from(path)
+    } else {
+        crosslink_dir.join(path)
+    };
+    // Read and return the template content
+    std::fs::read_to_string(&template_path)
+        .ok()
+        .filter(|s| !s.is_empty())
+}
+
+/// Read the `agent.no_template` setting from `hook-config.json`.
+///
+/// Returns `true` when `agent.no_template` is set to `true`, indicating the
+/// built-in kickoff prompt should be skipped entirely. Defaults to `false`.
+pub fn read_no_template(crosslink_dir: &Path) -> bool {
+    let config_path = crosslink_dir.join("hook-config.json");
+    let Ok(content) = std::fs::read_to_string(&config_path) else {
+        return false;
+    };
+    let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&content) else {
+        return false;
+    };
+    parsed
+        .get("agent")
+        .and_then(|a| a.get("no_template"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+}
+
 /// Resolve the main repository root when running inside a git worktree.
 ///
 /// Compares `git rev-parse --git-common-dir` with `--git-dir`. If they


### PR DESCRIPTION
## What changed

- Backports all three commits from #44 onto the current `develop` tip.
- Adds configurable `agent.binary`, provider-aware token pricing, sentinel model overrides, and configurable/disabled kickoff templates.
- Reconciles #44 with newer `develop` kickoff behavior: `--permission-mode`, `--dangerously-skip-permissions`, container permission propagation, and timeout sentinels are all preserved.
- Fixes the rustfmt failure from #44 and the strict-Clippy findings that its failed formatting step prevented CI from reaching.

## Why

#44 was merged to `main`, but the feature belongs on `develop` as well. A direct branch merge would also pull unrelated `main`-only dependency changes, so this PR carries #44's exact three-commit feature set forward onto current `develop`.

## Impact

`develop` gains the model/provider-agnostic agent configuration and kickoff-template support without regressing its newer headless-agent permission and timeout protections.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings -W clippy::unwrap_used -W clippy::expect_used`
- `PROPTEST_CASES=10 cargo test --bin crosslink` (2,861 passed)
- `cargo test --test cli_integration` (195 passed)
