### PR TITLE
feat(kickoff): prompt-injection seam — template interpolation (gh#62, Slice 2)

### DIFF
--- a/crosslink/resources/claude/commands/kickoff.md
+++ b/crosslink/resources/claude/commands/kickoff.md
@@ -27,6 +27,7 @@ The user may pass these flags after the feature description:
 - `--container <runtime>`: Use `docker` or `podman` instead of local tmux. Default: `none`.
 - `--model <model>`: LLM model to use (provider/model format, e.g. `opencode-go/deepseek-v4-flash`, `google-vertex/gemini-3.1-pro-preview`). Default: from `hook-config.json` or `opus`.
 - `--timeout <duration>`: Max runtime (e.g. `1h`, `30m`). Default: `1h`.
+- `--template <path>`: Interpolate the built prompt into a template file rather than using the built-in prompt directly (gh#62). See **Prompt templates** below.
 - All other text is the feature description.
 
 **Parsing**: Split ARGUMENTS on whitespace. Extract recognized `--flag value` pairs. Everything remaining is the feature description.
@@ -77,6 +78,35 @@ The agent binary and default model are configured via `hook-config.json`:
 ```
 
 When a non-Claude binary is configured, the wrapper automatically omits Anthropic-specific environment variables (`CLAUDE_CONFIG_DIR`, `CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`) and credential mounts (`~/.claude`).
+
+### Prompt templates (gh#62)
+
+By default `kickoff run`/`plan` build a self-contained prompt. To wrap or extend it, supply a template whose body is *interpolated* (not replaced): the built prompt and its dispatch context are substituted into the placeholders the template references.
+
+Sources, highest precedence first:
+
+1. `--template <path>` — a per-invocation template file (dispatch-scoped, so parallel dispatches never race on one global path).
+2. `agent.kickoff_template` in `hook-config.json` — a repo-global default (path resolved relative to the crosslink directory).
+3. None — the built-in prompt is used unchanged.
+
+`agent.no_template: true` skips the prompt entirely and overrides both.
+
+Placeholders (Decision D2):
+
+| Placeholder | Value |
+| --- | --- |
+| `{{built_prompt}}` | The full built-in prompt |
+| `{{issue_id}}` | Issue number (`0` for a plan with no `--issue`) |
+| `{{branch}}` | Feature branch (empty in plan mode) |
+| `{{description}}` | Feature description (empty in plan mode) |
+| `{{model}}` | `--model` value |
+| `{{effort}}` | `--effort` value (empty if unset) |
+| `{{doc_path}}` | Design-doc path (empty if none) |
+| `{{allowed_tools}}` | Comma-joined allowed-tools list (empty in plan mode) |
+
+A template with no placeholders is used verbatim (wholesale replacement), so existing `agent.kickoff_template` files keep working unchanged. The assembled prompt is still written to `KICKOFF.md` as the run's audit record.
+
+**Swarm:** drop a per-phase template at `<crosslink-dir>/swarm-templates/<phase-slug>.md`; every agent launched for that phase uses it (overriding the repo-global config) while still rendering its own `{{description}}`.
 
 ## Constraints
 

--- a/crosslink/src/commands/kickoff/mod.rs
+++ b/crosslink/src/commands/kickoff/mod.rs
@@ -66,6 +66,7 @@ pub fn dispatch(
             permission_mode,
             effort,
             budget_usd,
+            template,
         } => {
             let parsed_doc = if let Some(ref path) = doc {
                 let content = std::fs::read_to_string(path)
@@ -95,6 +96,7 @@ pub fn dispatch(
                 permission_mode: permission_mode.as_deref(),
                 effort: effort.as_deref(),
                 budget_usd: budget_usd.as_deref(),
+                template: template.as_deref(),
                 agent_binary: crate::utils::read_agent_binary(crosslink_dir),
             };
             // The pipeline "running" row is now written from inside `run()`
@@ -119,6 +121,7 @@ pub fn dispatch(
             permission_mode,
             effort,
             budget_usd,
+            template,
         } => {
             let content = std::fs::read_to_string(&doc)
                 .with_context(|| format!("Failed to read design doc: {}", doc.display()))?;
@@ -138,6 +141,7 @@ pub fn dispatch(
                 permission_mode: permission_mode.as_deref(),
                 effort: effort.as_deref(),
                 budget_usd: budget_usd.as_deref(),
+                template: template.as_deref(),
                 agent_binary: crate::utils::read_agent_binary(crosslink_dir),
             };
             plan(crosslink_dir, db, &plan_opts)
@@ -254,8 +258,10 @@ fn dispatch_launch(
             // gh#61: the unified `kickoff [doc] --plan/--run` entry point does
             // not expose the dispatch dials — they live on `kickoff run` /
             // `kickoff plan`. Unset here reproduces the previous invocation.
+            // gh#62: likewise no per-invocation template on this entry point.
             effort: None,
             budget_usd: None,
+            template: None,
             agent_binary: crate::utils::read_agent_binary(crosslink_dir),
         };
         return plan(crosslink_dir, db, &plan_opts);
@@ -299,9 +305,10 @@ fn dispatch_launch(
             doc_path: doc.as_ref().map(|p| p.to_str().unwrap_or("unknown")),
             skip_permissions,
             permission_mode,
-            // See the --plan branch above: dials are not exposed here.
+            // See the --plan branch above: dials and template are not exposed here.
             effort: None,
             budget_usd: None,
+            template: None,
             agent_binary: crate::utils::read_agent_binary(crosslink_dir),
         };
         // mark_running is now invoked from inside run() with the real identity.
@@ -351,9 +358,11 @@ fn dispatch_launch(
                 skip_permissions: false,
                 permission_mode: None,
                 // The wizard collects model/timeout/verify only; dials stay
-                // unset so an interactive launch is unchanged (gh#61).
+                // unset so an interactive launch is unchanged (gh#61). No
+                // per-invocation template on the wizard path either (gh#62).
                 effort: None,
                 budget_usd: None,
+                template: None,
                 agent_binary: crate::utils::read_agent_binary(crosslink_dir),
             };
             plan(crosslink_dir, db, &plan_opts)
@@ -394,9 +403,10 @@ fn dispatch_launch(
                 doc_path: doc_path_str.as_deref(),
                 skip_permissions: false,
                 permission_mode: None,
-                // See the wizard's Plan branch: dials stay unset here.
+                // See the wizard's Plan branch: dials and template stay unset here.
                 effort: None,
                 budget_usd: None,
+                template: None,
                 agent_binary: crate::utils::read_agent_binary(crosslink_dir),
             };
             run(crosslink_dir, db, writer, &opts)?;

--- a/crosslink/src/commands/kickoff/plan.rs
+++ b/crosslink/src/commands/kickoff/plan.rs
@@ -8,6 +8,7 @@ use crate::identity::AgentConfig;
 
 use super::helpers::*;
 use super::launch::*;
+use super::prompt::{interpolate_template, TemplateContext};
 use super::types::*;
 
 /// Build the allowed tools string for plan mode (read-only analysis).
@@ -172,9 +173,30 @@ pub fn plan(crosslink_dir: &Path, db: &Database, opts: &PlanOpts) -> Result<()> 
         None
     };
 
-    // 3. Build prompt (with plan copy instruction if doc_path is known)
+    // 3. Build prompt (with plan copy instruction if doc_path is known). When a
+    //    template is configured (`--template` or `agent.kickoff_template`),
+    //    interpolate the plan prompt into it (gh#62, REQ-6). Plan mode has no
+    //    feature branch, feature description, or tool set, so `{{branch}}`,
+    //    `{{description}}`, and `{{allowed_tools}}` render empty; a plan without
+    //    `--issue` renders `{{issue_id}}` as `0`.
     let plan_copy_target = opts.doc_path.map(super::pipeline::plan_path_for_doc);
-    let prompt = build_plan_prompt(opts.doc, issue_id, plan_copy_target.as_deref());
+    let built = build_plan_prompt(opts.doc, issue_id, plan_copy_target.as_deref());
+    let prompt = match crate::utils::resolve_kickoff_template(crosslink_dir, opts.template) {
+        Some(template) => {
+            let ctx = TemplateContext {
+                built_prompt: &built,
+                issue_id: issue_id.unwrap_or(0),
+                branch: "",
+                description: "",
+                model: opts.model,
+                effort: opts.effort,
+                doc_path: opts.doc_path.and_then(|p| p.to_str()),
+                allowed_tools: "",
+            };
+            interpolate_template(&template, &ctx)
+        }
+        None => built,
+    };
 
     // Dry run: print what would happen and exit BEFORE any side effect —
     // no worktree, no branch, no sentinel, no PlanRecord (gh#19). The

--- a/crosslink/src/commands/kickoff/prompt.rs
+++ b/crosslink/src/commands/kickoff/prompt.rs
@@ -182,6 +182,45 @@ Then:
 "#
 }
 
+/// Placeholder values for kickoff-template interpolation (gh#62, REQ-5;
+/// Decision D2). Each field maps to one `{{token}}` substituted by
+/// [`interpolate_template`].
+pub(crate) struct TemplateContext<'a> {
+    /// The fully built prompt ([`build_prompt`] / `build_plan_prompt` output).
+    pub built_prompt: &'a str,
+    pub issue_id: i64,
+    pub branch: &'a str,
+    pub description: &'a str,
+    pub model: &'a str,
+    /// `--effort` value, or `None` to render `{{effort}}` empty.
+    pub effort: Option<&'a str>,
+    /// Design-doc path, or `None` to render `{{doc_path}}` empty.
+    pub doc_path: Option<&'a str>,
+    /// Comma-joined allowed-tools list.
+    pub allowed_tools: &'a str,
+}
+
+/// Interpolate the Decision-D2 placeholder set into a template body (gh#62,
+/// REQ-5). Each `{{token}}` is replaced by its value; an unset optional
+/// (`{{effort}}`/`{{doc_path}}`) renders as the empty string; tokens the
+/// template does not mention are left untouched. `{{built_prompt}}` is
+/// substituted last so a built prompt that happens to contain a `{{token}}`
+/// sequence is inserted verbatim rather than re-scanned. A template containing
+/// no placeholders is returned unchanged — byte-identical to the pre-gh#62
+/// full-replacement behaviour, so existing `agent.kickoff_template` users see
+/// no change (REQ-5 backward-compat).
+pub(crate) fn interpolate_template(template: &str, ctx: &TemplateContext) -> String {
+    template
+        .replace("{{issue_id}}", &ctx.issue_id.to_string())
+        .replace("{{branch}}", ctx.branch)
+        .replace("{{description}}", ctx.description)
+        .replace("{{model}}", ctx.model)
+        .replace("{{effort}}", ctx.effort.unwrap_or(""))
+        .replace("{{doc_path}}", ctx.doc_path.unwrap_or(""))
+        .replace("{{allowed_tools}}", ctx.allowed_tools)
+        .replace("{{built_prompt}}", ctx.built_prompt)
+}
+
 /// Build the KICKOFF.md prompt for the agent.
 pub(crate) fn build_prompt(
     opts: &KickoffOpts,

--- a/crosslink/src/commands/kickoff/run.rs
+++ b/crosslink/src/commands/kickoff/run.rs
@@ -105,13 +105,34 @@ pub fn run(
         .allowed_tools
         .extend(read_kickoff_allowed_tools(crosslink_dir));
 
-    // 5. Build the prompt — check for custom template or no_template first
+    // 5. Build the prompt. `no_template` still short-circuits to an empty
+    //    prompt. Otherwise build the prompt and, when a template is configured
+    //    (the `--template` flag or `agent.kickoff_template`), interpolate the
+    //    Decision-D2 placeholder set into it rather than replacing the built
+    //    prompt wholesale (gh#62, REQ-5). A placeholder-free template
+    //    interpolates to itself, so this is byte-identical to the previous
+    //    full-replacement behaviour for existing template users.
     let prompt = if crate::utils::read_no_template(crosslink_dir) {
         String::new()
-    } else if let Some(custom) = crate::utils::read_kickoff_template(crosslink_dir) {
-        custom
     } else {
-        build_prompt(opts, issue_id, &branch_name, &conventions)
+        let built = build_prompt(opts, issue_id, &branch_name, &conventions);
+        match crate::utils::resolve_kickoff_template(crosslink_dir, opts.template) {
+            Some(template) => {
+                let allowed_tools = conventions.allowed_tools.join(",");
+                let ctx = TemplateContext {
+                    built_prompt: &built,
+                    issue_id,
+                    branch: &branch_name,
+                    description: opts.description,
+                    model: opts.model,
+                    effort: opts.effort,
+                    doc_path: opts.doc_path,
+                    allowed_tools: &allowed_tools,
+                };
+                interpolate_template(&template, &ctx)
+            }
+            None => built,
+        }
     };
 
     // Dry run: print the prompt and the would-be worktree/branch/agent, then

--- a/crosslink/src/commands/kickoff/tests.rs
+++ b/crosslink/src/commands/kickoff/tests.rs
@@ -148,6 +148,7 @@ fn test_build_prompt_contains_essentials() {
         permission_mode: None,
         effort: None,
         budget_usd: None,
+        template: None,
         agent_binary: "claude".to_string(),
     };
     let prompt = build_prompt(&opts, 42, "feature/add-retry-logic", &conventions);
@@ -184,6 +185,7 @@ fn test_build_prompt_ci_verification() {
         permission_mode: None,
         effort: None,
         budget_usd: None,
+        template: None,
         agent_binary: "claude".to_string(),
     };
     let prompt = build_prompt(&opts, 1, "feature/test-ci", &conventions);
@@ -217,6 +219,7 @@ fn test_build_prompt_thorough_verification() {
         permission_mode: None,
         effort: None,
         budget_usd: None,
+        template: None,
         agent_binary: "claude".to_string(),
     };
     let prompt = build_prompt(&opts, 1, "feature/test-thorough", &conventions);
@@ -899,6 +902,7 @@ fn test_build_prompt_local_has_no_ci_or_adversarial() {
         permission_mode: None,
         effort: None,
         budget_usd: None,
+        template: None,
         agent_binary: "claude".to_string(),
     };
     let prompt = build_prompt(&opts, 1, "feature/test-local", &conventions);
@@ -932,6 +936,7 @@ fn test_build_prompt_contains_blocked_actions() {
         permission_mode: None,
         effort: None,
         budget_usd: None,
+        template: None,
         agent_binary: "claude".to_string(),
     };
     let prompt = build_prompt(&opts, 1, "feature/test", &conventions);
@@ -966,6 +971,7 @@ fn test_build_prompt_embeds_issue_id_in_instructions() {
         permission_mode: None,
         effort: None,
         budget_usd: None,
+        template: None,
         agent_binary: "claude".to_string(),
     };
     let prompt = build_prompt(&opts, 999, "feature/test-refs", &conventions);
@@ -1000,6 +1006,7 @@ fn test_build_prompt_empty_conventions_uses_generic_instructions() {
         permission_mode: None,
         effort: None,
         budget_usd: None,
+        template: None,
         agent_binary: "claude".to_string(),
     };
     let prompt = build_prompt(&opts, 1, "feature/test-generic", &conventions);
@@ -1046,6 +1053,7 @@ fn test_build_prompt_with_design_doc() {
         permission_mode: None,
         effort: None,
         budget_usd: None,
+        template: None,
         agent_binary: "claude".to_string(),
     };
     let prompt = build_prompt(&opts, 1, "feature/batch-retry", &conventions);
@@ -1195,6 +1203,7 @@ fn test_build_prompt_with_design_doc_open_questions() {
         permission_mode: None,
         effort: None,
         budget_usd: None,
+        template: None,
         agent_binary: "claude".to_string(),
     };
     let prompt = build_prompt(&opts, 1, "feature/auth", &conventions);
@@ -1370,6 +1379,7 @@ fn test_build_prompt_with_criteria_includes_validation() {
         permission_mode: None,
         effort: None,
         budget_usd: None,
+        template: None,
         agent_binary: "claude".to_string(),
     };
     let prompt = build_prompt(&opts, 1, "feature/test", &conventions);
@@ -1414,6 +1424,7 @@ fn test_build_prompt_without_criteria_no_validation() {
         permission_mode: None,
         effort: None,
         budget_usd: None,
+        template: None,
         agent_binary: "claude".to_string(),
     };
     let prompt = build_prompt(&opts, 1, "feature/test", &conventions);
@@ -1455,6 +1466,7 @@ fn test_build_prompt_validation_ordering() {
         permission_mode: None,
         effort: None,
         budget_usd: None,
+        template: None,
         agent_binary: "claude".to_string(),
     };
     let prompt = build_prompt(&opts, 1, "feature/test", &conventions);
@@ -2569,6 +2581,7 @@ fn test_build_prompt_contains_report_json_schema() {
         permission_mode: None,
         effort: None,
         budget_usd: None,
+        template: None,
         agent_binary: "claude".to_string(),
     };
     let prompt = build_prompt(&opts, 1, "feature/test", &conventions);
@@ -2620,6 +2633,7 @@ fn test_build_prompt_contains_validation_section() {
         permission_mode: None,
         effort: None,
         budget_usd: None,
+        template: None,
         agent_binary: "claude".to_string(),
     };
     let prompt = build_prompt(&opts, 1, "feature/validated", &conventions);
@@ -3314,6 +3328,7 @@ fn dialed_opts<'a>(
         permission_mode: None,
         effort,
         budget_usd: budget,
+        template: None,
         agent_binary: "claude".to_string(),
     }
 }
@@ -3368,4 +3383,151 @@ fn test_kickoff_metadata_deserializes_legacy_file() {
     assert_eq!(parsed.model, None);
     assert_eq!(parsed.effort, None);
     assert_eq!(parsed.budget_usd, None);
+}
+
+// =====================================================================
+// gh#62 (REQ-5, Decision D2): kickoff prompt-injection seam interpolation.
+// =====================================================================
+
+// AC-6: every D2 placeholder is replaced with its value.
+#[test]
+fn test_interpolate_template_substitutes_all_placeholders() {
+    let ctx = TemplateContext {
+        built_prompt: "BUILT-BODY",
+        issue_id: 42,
+        branch: "feature/add-x",
+        description: "add x",
+        model: "opus",
+        effort: Some("high"),
+        doc_path: Some(".design/x.md"),
+        allowed_tools: "Read,Write",
+    };
+    let template = "issue={{issue_id}} branch={{branch}} desc={{description}} model={{model}} effort={{effort}} doc={{doc_path}} tools={{allowed_tools}} | {{built_prompt}}";
+    assert_eq!(
+        interpolate_template(template, &ctx),
+        "issue=42 branch=feature/add-x desc=add x model=opus effort=high doc=.design/x.md tools=Read,Write | BUILT-BODY"
+    );
+}
+
+// AC-6: an unset optional (`{{effort}}`/`{{doc_path}}`) renders empty rather
+// than leaving the literal token behind.
+#[test]
+fn test_interpolate_template_unset_optionals_render_empty() {
+    let ctx = TemplateContext {
+        built_prompt: "B",
+        issue_id: 1,
+        branch: "br",
+        description: "d",
+        model: "opus",
+        effort: None,
+        doc_path: None,
+        allowed_tools: "",
+    };
+    assert_eq!(
+        interpolate_template("[{{effort}}][{{doc_path}}][{{allowed_tools}}]", &ctx),
+        "[][][]"
+    );
+}
+
+// REQ-5 backward-compat: a placeholder-free template is returned verbatim —
+// byte-identical to the pre-gh#62 full-replacement behaviour.
+#[test]
+fn test_interpolate_template_without_placeholders_is_unchanged() {
+    let ctx = TemplateContext {
+        built_prompt: "IGNORED",
+        issue_id: 7,
+        branch: "b",
+        description: "d",
+        model: "m",
+        effort: Some("low"),
+        doc_path: None,
+        allowed_tools: "",
+    };
+    let body = "A fixed prompt with no tokens.";
+    assert_eq!(interpolate_template(body, &ctx), body);
+}
+
+// `{{built_prompt}}` is substituted last, so a built prompt that itself
+// contains a `{{token}}` sequence is inserted verbatim, not re-scanned.
+#[test]
+fn test_interpolate_template_built_prompt_substituted_last() {
+    let ctx = TemplateContext {
+        built_prompt: "contains {{issue_id}} literally",
+        issue_id: 99,
+        branch: "b",
+        description: "d",
+        model: "m",
+        effort: None,
+        doc_path: None,
+        allowed_tools: "",
+    };
+    assert_eq!(
+        interpolate_template("id={{issue_id}} body={{built_prompt}}", &ctx),
+        "id=99 body=contains {{issue_id}} literally"
+    );
+}
+
+// AC-8 property: the same template rendered for two agents yields each agent's
+// own `{{description}}` — the per-agent differentiation swarm per-phase relies
+// on (a full swarm launch needs docker/agent and is not CI-runnable).
+#[test]
+fn test_interpolate_template_preserves_per_agent_description() {
+    let render = |desc: &str| {
+        let ctx = TemplateContext {
+            built_prompt: "",
+            issue_id: 1,
+            branch: "",
+            description: desc,
+            model: "opus",
+            effort: None,
+            doc_path: None,
+            allowed_tools: "",
+        };
+        interpolate_template("AGENT: {{description}}", &ctx)
+    };
+    assert_eq!(render("build the API"), "AGENT: build the API");
+    assert_eq!(render("wire the UI"), "AGENT: wire the UI");
+}
+
+// AC-7: an explicit `--template` path wins over the `agent.kickoff_template`
+// config; with only config set, the config path is used.
+#[test]
+fn test_resolve_kickoff_template_flag_wins_else_config() {
+    let dir = tempfile::tempdir().unwrap();
+    let crosslink_dir = dir.path();
+
+    // Config template referenced from hook-config.json (path relative to
+    // crosslink_dir, matching read_kickoff_template's resolution).
+    std::fs::write(crosslink_dir.join("config-template.md"), "CONFIG-BODY").unwrap();
+    std::fs::write(
+        crosslink_dir.join("hook-config.json"),
+        r#"{"agent":{"kickoff_template":"config-template.md"}}"#,
+    )
+    .unwrap();
+
+    // Explicit --template file.
+    let flag_path = crosslink_dir.join("flag-template.md");
+    std::fs::write(&flag_path, "FLAG-BODY").unwrap();
+
+    // Flag wins over config.
+    assert_eq!(
+        crate::utils::resolve_kickoff_template(crosslink_dir, Some(flag_path.as_path())).as_deref(),
+        Some("FLAG-BODY")
+    );
+    // No flag -> config fallback.
+    assert_eq!(
+        crate::utils::resolve_kickoff_template(crosslink_dir, None).as_deref(),
+        Some("CONFIG-BODY")
+    );
+}
+
+// AC-7: with neither a flag nor config template, resolution is None so the
+// caller falls back to the built-in prompt.
+#[test]
+fn test_resolve_kickoff_template_none_without_flag_or_config() {
+    let dir = tempfile::tempdir().unwrap();
+    assert_eq!(
+        crate::utils::resolve_kickoff_template(dir.path(), None),
+        None
+    );
 }

--- a/crosslink/src/commands/kickoff/types.rs
+++ b/crosslink/src/commands/kickoff/types.rs
@@ -146,6 +146,12 @@ pub struct KickoffOpts<'a> {
     /// spend ceiling for unattended dispatch. Per-session: under swarm each
     /// dispatched agent receives this cap (Decision D1). `None` emits no flag.
     pub budget_usd: Option<&'a str>,
+    /// Optional prompt template path (gh#62, REQ-6). When set (via `--template`
+    /// or a per-phase swarm template), it takes precedence over the
+    /// `agent.kickoff_template` config; its body is interpolated with the D2
+    /// placeholder set rather than replacing the built prompt wholesale.
+    /// `None` falls back to the config setting, then the built-in prompt.
+    pub template: Option<&'a Path>,
     /// Agent binary to launch (read from hook-config.json `agent.binary`,
     /// default "claude"). Allows pointing kickoff at a different agent CLI.
     pub agent_binary: String,
@@ -283,6 +289,10 @@ pub struct PlanOpts<'a> {
     /// Optional claude `--max-budget-usd <amount>` (gh#61). See
     /// [`KickoffOpts::budget_usd`].
     pub budget_usd: Option<&'a str>,
+    /// Optional prompt template path (gh#62, REQ-6). See
+    /// [`KickoffOpts::template`]; for plan mode the `{{branch}}`,
+    /// `{{description}}`, and `{{allowed_tools}}` placeholders render empty.
+    pub template: Option<&'a Path>,
     /// Agent binary to launch (read from hook-config.json `agent.binary`,
     /// default "claude").
     pub agent_binary: String,

--- a/crosslink/src/commands/sentinel/engine.rs
+++ b/crosslink/src/commands/sentinel/engine.rs
@@ -488,9 +488,11 @@ fn spawn_agent(
         skip_permissions: true,
         permission_mode: None,
         // Sentinel dispatch carries no reasoning/spend dials (gh#61) — the
-        // scope's model is the only dial it configures.
+        // scope's model is the only dial it configures. No template either
+        // (gh#62): sentinel agents use the built-in prompt.
         effort: None,
         budget_usd: None,
+        template: None,
         agent_binary: crate::utils::read_agent_binary(crosslink_dir),
     };
 

--- a/crosslink/src/commands/swarm/lifecycle.rs
+++ b/crosslink/src/commands/swarm/lifecycle.rs
@@ -2,7 +2,7 @@
 // resume, launch, gate, checkpoint.
 
 use anyhow::{bail, Context, Result};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use super::io::*;
 use super::status::{probe_agent_status, resolve_agents};
@@ -707,6 +707,22 @@ pub(super) fn resolve_dispatch_dials(config: Option<&BudgetConfig>) -> DispatchD
     }
 }
 
+/// Resolve a per-phase prompt template for swarm dispatch (gh#62, REQ-7).
+///
+/// Looks for `<crosslink_dir>/swarm-templates/<phase_slug>.md`. When present it
+/// is handed to every agent launched for that phase as its `--template`, so it
+/// takes precedence over the repo-global `agent.kickoff_template` while each
+/// agent still renders its own `{{description}}`. Absent, the phase falls back
+/// to the config template or the built-in prompt. Keyed by phase slug so
+/// different phases in a wave can inject different templates rather than the
+/// single repo-global template applying uniformly (AC-8).
+pub(super) fn resolve_phase_template(crosslink_dir: &Path, phase_slug: &str) -> Option<PathBuf> {
+    let candidate = crosslink_dir
+        .join("swarm-templates")
+        .join(format!("{phase_slug}.md"));
+    candidate.is_file().then_some(candidate)
+}
+
 /// Launch all planned agents for a phase via `kickoff run`.
 pub fn launch(
     crosslink_dir: &Path,
@@ -753,6 +769,10 @@ pub fn launch(
         .and_then(|ctx| read_hub_json::<BudgetConfig>(&sync, &ctx.budget_path()).ok());
     let dials = resolve_dispatch_dials(budget_config.as_ref());
 
+    // gh#62 (REQ-7): a per-phase template, if present, applies to every agent in
+    // this phase and takes precedence over the repo-global config template.
+    let phase_template = resolve_phase_template(crosslink_dir, phase_slug);
+
     if !quiet {
         println!(
             "Launching {} agent{} for {}...",
@@ -786,6 +806,7 @@ pub fn launch(
             permission_mode: None,
             effort: dials.effort.as_deref(),
             budget_usd: dials.budget_usd.as_deref(),
+            template: phase_template.as_deref(),
             agent_binary: crate::utils::read_agent_binary(crosslink_dir),
         };
 

--- a/crosslink/src/commands/swarm/mod.rs
+++ b/crosslink/src/commands/swarm/mod.rs
@@ -678,6 +678,26 @@ mod tests {
         assert_eq!(dials.budget_usd, None);
     }
 
+    // gh#62 (REQ-7, AC-8): a per-phase template file keyed by phase slug is
+    // picked up for that phase and is absent for phases with no file, so a
+    // wave can inject different templates per phase instead of one uniformly.
+    #[test]
+    fn test_resolve_phase_template_keyed_by_phase_slug() {
+        let dir = tempfile::tempdir().unwrap();
+        let crosslink_dir = dir.path();
+        let templates = crosslink_dir.join("swarm-templates");
+        std::fs::create_dir_all(&templates).unwrap();
+        std::fs::write(templates.join("build-api.md"), "{{built_prompt}}").unwrap();
+
+        // Present for the matching phase slug.
+        assert_eq!(
+            resolve_phase_template(crosslink_dir, "build-api").as_deref(),
+            Some(templates.join("build-api.md").as_path())
+        );
+        // Absent for a phase with no template file.
+        assert_eq!(resolve_phase_template(crosslink_dir, "ship-ui"), None);
+    }
+
     #[test]
     fn test_cost_log_serde_roundtrip() {
         let mut estimates = std::collections::HashMap::new();

--- a/crosslink/src/main.rs
+++ b/crosslink/src/main.rs
@@ -1725,6 +1725,15 @@ enum KickoffCommands {
         /// this cap, so a wave of N agents can spend up to N x amount.
         #[arg(long, value_name = "AMOUNT")]
         budget_usd: Option<String>,
+        /// Prompt template file interpolated with the built prompt (gh#62).
+        ///
+        /// The file's body has the placeholders `{{built_prompt}}`,
+        /// `{{issue_id}}`, `{{branch}}`, `{{description}}`, `{{model}}`,
+        /// `{{effort}}`, `{{doc_path}}`, and `{{allowed_tools}}` substituted;
+        /// a file with no placeholders replaces the prompt wholesale. Takes
+        /// precedence over the `agent.kickoff_template` config setting.
+        #[arg(long, value_name = "PATH")]
+        template: Option<PathBuf>,
     },
     /// Check status of a running kickoff agent (no args = pipeline overview)
     Status {
@@ -1802,6 +1811,14 @@ enum KickoffCommands {
         /// Spend ceiling in USD for the dispatched claude session (gh#61).
         #[arg(long, value_name = "AMOUNT")]
         budget_usd: Option<String>,
+        /// Prompt template file interpolated with the plan prompt (gh#62).
+        ///
+        /// Same placeholders as `kickoff run --template`; plan mode has no
+        /// feature branch/description/tool set, so `{{branch}}`,
+        /// `{{description}}`, and `{{allowed_tools}}` render empty. Takes
+        /// precedence over the `agent.kickoff_template` config setting.
+        #[arg(long, value_name = "PATH")]
+        template: Option<PathBuf>,
     },
     /// Display a gap report from a previous plan analysis
     ShowPlan {

--- a/crosslink/src/utils.rs
+++ b/crosslink/src/utils.rs
@@ -42,6 +42,26 @@ pub fn read_kickoff_template(crosslink_dir: &Path) -> Option<String> {
         .filter(|s| !s.is_empty())
 }
 
+/// Resolve the kickoff prompt template content, flag-first (gh#62, REQ-6).
+///
+/// An explicit `--template <path>` (`override_path`) wins over the
+/// `agent.kickoff_template` config setting, so a template is dispatch-scoped
+/// and parallel dispatches do not race on the single repo-global config path.
+/// The override path is read as given (resolved against the caller's cwd); the
+/// config path resolves relative to `crosslink_dir` (see
+/// [`read_kickoff_template`]). Returns the template body, or `None` when
+/// neither source is set / the file is empty or unreadable — in which case the
+/// caller falls back to the built-in prompt. (AC-7)
+pub fn resolve_kickoff_template(
+    crosslink_dir: &Path,
+    override_path: Option<&Path>,
+) -> Option<String> {
+    if let Some(path) = override_path {
+        return std::fs::read_to_string(path).ok().filter(|s| !s.is_empty());
+    }
+    read_kickoff_template(crosslink_dir)
+}
+
 /// Read the `agent.no_template` setting from `hook-config.json`.
 ///
 /// Returns `true` when `agent.no_template` is set to `true`, indicating the

--- a/crosslink/tests/cli_integration.rs
+++ b/crosslink/tests/cli_integration.rs
@@ -2869,6 +2869,58 @@ fn test_kickoff_dry_run_prints_prompt_and_metadata() {
     assert!(stdout.contains("Agent:"));
 }
 
+// gh#62 (REQ-5/REQ-6, AC-9): `kickoff run --template` interpolates the built
+// prompt into the template file and prints the assembled result — the same
+// content that would be written to KICKOFF.md — proving the flag flows through
+// the CLI into the run.rs step-5 seam.
+#[test]
+fn test_kickoff_run_template_interpolates_prompt() {
+    let dir = test_dir();
+    init_git_and_crosslink(dir.path());
+
+    let template_path = dir.path().join("tmpl.md");
+    std::fs::write(
+        &template_path,
+        "TEMPLATE-START desc={{description}} model={{model}} MARKER\n{{built_prompt}}\nTEMPLATE-END",
+    )
+    .unwrap();
+
+    let (success, stdout, stderr) = run_crosslink(
+        dir.path(),
+        &[
+            "kickoff",
+            "run",
+            "--dry-run",
+            "--model",
+            "sonnet",
+            "--template",
+            template_path.to_str().unwrap(),
+            "add retry logic",
+        ],
+    );
+    assert!(success, "kickoff run --template failed: stderr={stderr}");
+
+    // The template wrapper is present with its scalar placeholders substituted.
+    assert!(
+        stdout.contains("TEMPLATE-START desc=add retry logic model=sonnet MARKER"),
+        "template placeholders not interpolated: {stdout}"
+    );
+    assert!(
+        stdout.contains("TEMPLATE-END"),
+        "template tail missing: {stdout}"
+    );
+    // built_prompt was expanded to the real built prompt.
+    assert!(
+        stdout.contains("KICKOFF: add retry logic"),
+        "built_prompt placeholder not expanded to the built prompt: {stdout}"
+    );
+    // No raw placeholder token survived interpolation.
+    assert!(
+        !stdout.contains("description}}") && !stdout.contains("built_prompt}}"),
+        "raw template tokens leaked into output: {stdout}"
+    );
+}
+
 #[test]
 fn test_kickoff_dry_run_is_side_effect_free_and_prints_prompt() {
     let dir = test_dir();


### PR DESCRIPTION
Implements #62 — **Slice 2** of the `dispatch-dials-and-injection-seam` design: the kickoff **prompt-injection seam**. This evolves the template mechanism #78 (gh#43) landed on `develop` from *wholesale replacement* into *interpolation*, so a consumer (the immediate one is vsdd, epic magnificentlycursed/crosslink#2, requirements R4/R5) can wrap crosslink's tool-maintained prompt and echo the dispatch dials into its own injected manifest instead of discarding the built prompt entirely.

## Background

#78 added `agent.kickoff_template` (a hook-config path whose file **replaces** the built prompt) and `agent.no_template`. That's the mechanism Slice 2 was gated on (design Decision D3). Slice 2 turns replacement into interpolation and makes the template dispatch-scoped.

## What this adds

**Interpolation seam (REQ-5).** At `run.rs` step 5 (and the analogous `plan.rs` seam), the built prompt is always computed, then — when a template is configured — the template body is interpolated rather than used raw. The Decision-D2 placeholder set:

`{{built_prompt}}` `{{issue_id}}` `{{branch}}` `{{description}}` `{{model}}` `{{effort}}` `{{doc_path}}` `{{allowed_tools}}`

`{{built_prompt}}` is substituted last (a built prompt that itself contains a `{{token}}` is inserted verbatim, not re-scanned); an unset optional (`{{effort}}`/`{{doc_path}}`) renders empty. The `{{effort}}` placeholder is why this PR **stacks on #77** (feat/61) — it reads `KickoffOpts.effort`, a Slice 1 field not yet on `develop`.

**`--template <path>` (REQ-6).** `kickoff run`/`plan` gain the flag, threaded through `KickoffOpts`/`PlanOpts`. Resolution is **flag-else-config** (`resolve_kickoff_template`): an explicit `--template` wins over `agent.kickoff_template`, so a template is dispatch-scoped and parallel dispatches don't race on the single repo-global config path.

**Swarm per-phase templates (REQ-7).** `swarm/lifecycle.rs` resolves a per-phase template at `<crosslink-dir>/swarm-templates/<phase-slug>.md` and sets it as each agent's `--template`, so a wave can inject different templates per phase (overriding the global config) while every agent still renders its own `{{description}}`.

**Audit record preserved (REQ-8).** The fully-assembled (post-interpolation) prompt is still written to `KICKOFF.md`.

## Backward compatibility

A template with **no** placeholders interpolates to itself — byte-identical to #78's full-replacement behaviour, so existing `agent.kickoff_template` users are unaffected. `agent.no_template: true` still wins over any template (empty prompt).

## Decisions worth flagging

- **Plan mode is included** (REQ-6 says `run`/`plan`). Plan honors `--template` and the config fallback identically to run; plan has no feature branch / description / tool set, so `{{branch}}`, `{{description}}`, `{{allowed_tools}}` render empty and a plan without `--issue` renders `{{issue_id}}` as `0`. This is a deliberate behavior extension (a configured `agent.kickoff_template` now also wraps the plan prompt) — documented in `resources/claude/commands/kickoff.md`.
- **Per-phase templates are convention-based** (a file keyed by phase slug), not a new config schema — matching REQ-7's "per-phase template files keyed by phase name."

## Testing

- Unit (`kickoff/tests.rs`): `interpolate_template` — full placeholder substitution, empty-optional rendering, placeholder-free passthrough (backward compat), built-prompt-substituted-last, and per-agent `{{description}}` differentiation (AC-6, AC-8 property). `resolve_kickoff_template` — flag-wins-else-config and neither→None (AC-7).
- Unit (`swarm/mod.rs`): `resolve_phase_template` keyed by phase slug, present/absent (REQ-7).
- Integration (`cli_integration.rs`): `kickoff run --dry-run --template` interpolates end-to-end through the CLI and prints the assembled prompt — the same content written to `KICKOFF.md` (REQ-5/REQ-6/AC-9). A full swarm launch needs docker/agent and isn't CI-runnable; its constituent logic is unit-tested.
- `cargo build`, `cargo fmt --all -- --check`, `cargo clippy -- -D warnings -W clippy::unwrap_used -W clippy::expect_used`, and the full suite green (bin 2845, integration 199, proptest 37).

## Stacking / dependency

Was stacked on `feat/61-effort-budget-dispatch-dials` (#77, Slice 1) for the `{{effort}}` placeholder. **#77 is now merged to `develop`**, so this PR's diff is exactly the Slice 2 commit and it applies cleanly (`MERGEABLE`).

Authored by Claude Code on behalf of @magnificentlycursed.

Generated with [Claude Code](https://claude.com/claude-code)
