### PR TITLE
fix(reconcile): recover pre-generation v3 trust

### DIFF
--- a/crosslink/src/reconcile.rs
+++ b/crosslink/src/reconcile.rs
@@ -98,6 +98,8 @@ pub enum MigrationAction {
     ImportV2,
     RenameHiddenV3Refs,
     ResolveMixedSharedStore,
+    EstablishReconciliationGeneration,
+    ResumeReconciliation,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -180,12 +182,46 @@ pub fn check_repository(crosslink_dir: &Path) -> ReconcileReport {
         local_database,
         shared_store,
     };
-    let plan = plan_migration(&format);
+    let plan = plan_repository_reconciliation(&repository_root, crosslink_dir, &format);
     ReconcileReport {
         repository_root,
         format,
         plan,
     }
+}
+
+fn plan_repository_reconciliation(
+    repository_root: &Path,
+    crosslink_dir: &Path,
+    format: &RepositoryFormat,
+) -> MigrationPlan {
+    let mut plan = plan_migration(format);
+    if !matches!(format.shared_store, SharedStoreFormat::VisibleV3 { .. }) {
+        return plan;
+    }
+    if crosslink_dir.join("reconciliation-journal.json").exists() {
+        plan.actions.push(MigrationAction::ResumeReconciliation);
+    } else {
+        match publication::generation_id_at_ref(repository_root, publication::GENERATION_REF) {
+            Ok(Some(_)) => {}
+            Ok(None) => plan
+                .actions
+                .push(MigrationAction::EstablishReconciliationGeneration),
+            Err(error) => plan.blockers.push(format!(
+                "reconciliation generation is unreadable: {error:#}"
+            )),
+        }
+    }
+    plan.state = if plan.blockers.is_empty() {
+        if plan.actions.is_empty() {
+            ReadinessState::ReadyCurrent
+        } else {
+            ReadinessState::MigrationRequired
+        }
+    } else {
+        ReadinessState::BlockedCorrupt
+    };
+    plan
 }
 
 #[must_use]

--- a/crosslink/src/reconcile/migration.rs
+++ b/crosslink/src/reconcile/migration.rs
@@ -348,6 +348,7 @@ impl MigrationImporter<'_> {
         let targets = seed_v3_targets(
             self.cache_dir,
             materialized.path(),
+            signers.as_deref(),
             &genesis,
             &source_tip,
             generation_id,
@@ -382,6 +383,7 @@ impl MigrationImporter<'_> {
         let targets = seed_v3_targets(
             self.cache_dir,
             materialized.path(),
+            None,
             &genesis,
             &source_tip,
             generation_id,
@@ -525,15 +527,16 @@ impl HistoricalImporter for MigrationImporter<'_> {
         let current = reduce_v3_state(self.cache_dir, &current_targets)?;
         let (merged, changed) = merge_local_database_projection(&current, &local)?;
         anyhow::ensure!(changed, "local database contains no unshared state");
+        let signers = read_v3_allowed_signers(self.cache_dir, &current_targets)?;
         let targets = seed_v3_targets(
             self.cache_dir,
             materialized.path(),
+            signers.as_deref(),
             &merged,
             database_evidence.oid(),
             source.fingerprint(),
             Some(&current_targets),
         )?;
-        let signers = read_v3_allowed_signers(self.cache_dir, &current_targets)?;
         Ok(PreparedImport::new(
             targets,
             canonical_semantic(&merged, signers)?,
@@ -2354,6 +2357,7 @@ fn merge_agent_event_logs(agent_id: &str, left: &[u8], right: &[u8]) -> Result<V
 fn seed_v3_targets(
     repository: &Path,
     source_dir: &Path,
+    allowed_signers: Option<&[u8]>,
     genesis: &CheckpointState,
     source_tip: &str,
     generation_id: &str,
@@ -2458,18 +2462,9 @@ fn seed_v3_targets(
     };
     let hub_json =
         serde_json::to_vec_pretty(&meta).context("serializing reconciliation hub meta")?;
-    let signers_path = source_dir.join("trust").join("allowed_signers");
-    let signers = if signers_path.exists() {
-        Some(
-            std::fs::read(&signers_path)
-                .with_context(|| format!("failed to read {}", signers_path.display()))?,
-        )
-    } else {
-        None
-    };
     let mut files = vec![("hub.json", hub_json.as_slice())];
-    if let Some(bytes) = &signers {
-        files.push(("allowed_signers", bytes.as_slice()));
+    if let Some(bytes) = allowed_signers {
+        files.push(("allowed_signers", bytes));
     }
     let meta_ref = format!("{build_root}/meta");
     let meta_oid = hub_v3::commit_files_to_ref(
@@ -3560,6 +3555,75 @@ pub(crate) mod tests {
         assert_eq!(fs::read(&database_path).unwrap(), database_before);
         assert_eq!(fs::read(&wal_path).unwrap(), wal_before);
         assert_local_database_archive_contains(&cache_dir, local_uuid);
+        drop(database);
+    }
+
+    #[test]
+    fn pregeneration_v3_preserves_trust_and_imports_local_projection() {
+        let (_work, _remote, crosslink_dir, cache_dir) = setup_v2_hub();
+        let allowed_signers = b"alpha ssh-ed25519 AAAAPREGENERATION\n";
+        fs::write(
+            cache_dir.join("trust").join("allowed_signers"),
+            allowed_signers,
+        )
+        .unwrap();
+        run(&cache_dir, &["add", "trust"]);
+        run(&cache_dir, &["commit", "-m", "pin trust", "--no-gpg-sign"]);
+        run(&cache_dir, &["push", "origin", "crosslink/hub"]);
+        hub_v3(&crosslink_dir, false, false, false, false).unwrap();
+        run(
+            &cache_dir,
+            &["push", "origin", &format!(":{GENERATION_POINTER}")],
+        );
+        run(&cache_dir, &["update-ref", "-d", GENERATION_POINTER]);
+
+        let database = open_with_uncheckpointed_wal(&crosslink_dir.join("issues.db"));
+        let local_id = database
+            .create_issue("pregeneration local projection", None, "high")
+            .unwrap();
+        let local_uuid: Uuid = database
+            .get_issue_uuid_by_id(local_id)
+            .unwrap()
+            .parse()
+            .unwrap();
+        let check = crate::reconcile::check_repository(&crosslink_dir);
+        assert_eq!(
+            check.plan.state,
+            crate::reconcile::ReadinessState::MigrationRequired
+        );
+        assert!(check
+            .plan
+            .actions
+            .contains(&crate::reconcile::MigrationAction::EstablishReconciliationGeneration));
+
+        let first = activate_repository(&crosslink_dir).unwrap();
+        let RepositoryActivation::ReadyMigrated { generation_id } = first else {
+            panic!("expected migrated activation, got {first:?}");
+        };
+        let state = compaction::reduce(&RefHubSource::new(&cache_dir).unwrap())
+            .unwrap()
+            .state;
+        assert!(state.issues.contains_key(&local_uuid));
+        let source = RefHubSource::new(&cache_dir).unwrap();
+        assert_eq!(
+            fs::read(source.allowed_signers_file().unwrap().unwrap()).unwrap(),
+            allowed_signers
+        );
+        let projection =
+            crate::db::Database::open_read_only(&crosslink_dir.join("issues.db")).unwrap();
+        assert!(projection
+            .get_issue_id_by_uuid(&local_uuid.to_string())
+            .is_ok());
+        drop(projection);
+
+        let second = activate_repository(&crosslink_dir).unwrap();
+        assert_eq!(second, RepositoryActivation::ReadyCurrent { generation_id });
+        assert_eq!(
+            crate::reconcile::check_repository(&crosslink_dir)
+                .plan
+                .state,
+            crate::reconcile::ReadinessState::ReadyCurrent
+        );
         drop(database);
     }
 

--- a/crosslink/src/reconcile/publication.rs
+++ b/crosslink/src/reconcile/publication.rs
@@ -19,6 +19,7 @@ pub(crate) const GENERATION_REF: &str = "refs/heads/crosslink/reconciliation/cur
 const GENERATION_ROOT: &str = "refs/heads/crosslink/reconciliation/generations";
 const ARCHIVE_ROOT: &str = "refs/heads/crosslink/reconciliation/archives";
 const LOCAL_ROOT: &str = "refs/crosslink/reconciliation";
+const RECOVERY_ARCHIVE_DIR: &str = "reconciliation-journal-archive";
 const PROTOCOL_VERSION: u32 = 1;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -107,6 +108,22 @@ impl CanonicalSemantic {
 
     pub const fn value(&self) -> &Value {
         &self.value
+    }
+
+    fn differing_sections(&self, other: &Self) -> Vec<String> {
+        let (Some(left), Some(right)) = (self.value.as_object(), other.value.as_object()) else {
+            return (self.value != other.value)
+                .then(|| "root".to_string())
+                .into_iter()
+                .collect();
+        };
+        left.keys()
+            .chain(right.keys())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .filter(|section| left.get(*section) != right.get(*section))
+            .cloned()
+            .collect()
     }
 }
 
@@ -532,12 +549,12 @@ impl<'a, I: HistoricalImporter> RepositoryReconciler<'a, I> {
         journal: ReconciliationJournal,
         observed_format: &RepositoryFormat,
     ) -> Result<PublicationOutcome> {
+        let current = remote_ref_map(self.repository, self.remote, &[GENERATION_REF.to_string()])?;
         if !self.source_still_pinned(&journal.descriptor.source, observed_format)? {
             return Ok(PublicationOutcome::BlockedCorrupt {
                 reason: "historical source changed after reconciliation was prepared".to_string(),
             });
         }
-        let current = remote_ref_map(self.repository, self.remote, &[GENERATION_REF.to_string()])?;
         if let Some(remote_oid) = current.get(GENERATION_REF) {
             if remote_oid == &journal.descriptor_oid {
                 let fallback = journal.atomic_publication == Some(false);
@@ -548,16 +565,25 @@ impl<'a, I: HistoricalImporter> RepositoryReconciler<'a, I> {
         match journal.stage {
             JournalStage::IntentRecorded | JournalStage::Prepared => {
                 let targets = descriptor_target_oids(&journal.descriptor);
-                let target_semantic = self
-                    .importer
-                    .read_target_semantic(self.repository, &targets)
-                    .context("verifying prepared targets while resuming")?;
-                if target_semantic.digest() != journal.descriptor.semantic_digest {
-                    return Ok(PublicationOutcome::BlockedCorrupt {
-                        reason: "prepared targets no longer match the journal semantic digest"
-                            .to_string(),
-                    });
-                }
+                let target_semantic = self.importer.read_target_semantic(self.repository, &targets);
+                let target_semantic = match target_semantic {
+                    Ok(semantic)
+                        if semantic.digest() == journal.descriptor.semantic_digest =>
+                    {
+                        semantic
+                    }
+                    result => {
+                        return self.recover_unpublished_preparation(
+                            &journal,
+                            observed_format,
+                            result,
+                        );
+                    }
+                };
+                anyhow::ensure!(
+                    target_semantic.digest() == journal.descriptor.semantic_digest,
+                    "prepared target digest differs from the generation descriptor"
+                );
                 let mut resumed = journal;
                 resumed.stage = JournalStage::Verified;
                 self.persist(&resumed)?;
@@ -573,6 +599,67 @@ impl<'a, I: HistoricalImporter> RepositoryReconciler<'a, I> {
         }
     }
 
+    fn recover_unpublished_preparation(
+        &mut self,
+        journal: &ReconciliationJournal,
+        observed_format: &RepositoryFormat,
+        target_semantic: Result<CanonicalSemantic>,
+    ) -> Result<PublicationOutcome> {
+        let authority_before = local_authority_refs(self.repository)?;
+        let provisional_id = journal
+            .descriptor
+            .source
+            .fingerprint
+            .get(..24)
+            .unwrap_or(&journal.descriptor.source.fingerprint);
+        let expected = match self.prepare_source(&journal.descriptor.source, provisional_id) {
+            Ok(prepared) => prepared.semantic,
+            Err(error) => {
+                ensure_authority_unchanged(self.repository, &authority_before)?;
+                return Ok(PublicationOutcome::BlockedCorrupt {
+                    reason: format!(
+                        "unpublished preparation failed and the pinned source could not be re-verified: {error:#}"
+                    ),
+                });
+            }
+        };
+        ensure_authority_unchanged(self.repository, &authority_before)?;
+        if expected.digest() != journal.descriptor.semantic_digest {
+            return Ok(PublicationOutcome::BlockedCorrupt {
+                reason: "unpublished preparation failed and the pinned source semantic digest is no longer reproducible"
+                    .to_string(),
+            });
+        }
+        let (reason, differing_sections) = match target_semantic {
+            Ok(target) => {
+                let sections = expected.differing_sections(&target);
+                let detail = if sections.is_empty() {
+                    "digest".to_string()
+                } else {
+                    sections.join(", ")
+                };
+                (
+                    format!(
+                        "prepared target semantics differ from the pinned historical source in sections: {detail}"
+                    ),
+                    sections,
+                )
+            }
+            Err(error) => (
+                format!("prepared targets could not be read: {error:#}"),
+                vec!["target".to_string()],
+            ),
+        };
+        let archived =
+            archive_unpublished_journal(&self.journal_path, journal, &reason, &differing_sections)?;
+        tracing::warn!(
+            journal = %archived.display(),
+            reason,
+            "archived invalid unpublished reconciliation preparation"
+        );
+        self.reconcile_inner(observed_format)
+    }
+
     fn verify_prepared(
         &self,
         journal: &ReconciliationJournal,
@@ -582,9 +669,11 @@ impl<'a, I: HistoricalImporter> RepositoryReconciler<'a, I> {
             self.repository,
             &descriptor_target_oids(&journal.descriptor),
         )?;
+        let differing_sections = source_semantic.differing_sections(&target_semantic);
         anyhow::ensure!(
-            target_semantic.value() == source_semantic.value(),
-            "prepared target semantics differ from the pinned historical source"
+            differing_sections.is_empty(),
+            "prepared target semantics differ from the pinned historical source in sections: {}",
+            differing_sections.join(", ")
         );
         anyhow::ensure!(
             target_semantic.digest() == journal.descriptor.semantic_digest,
@@ -2742,6 +2831,83 @@ fn remove_journal(path: &Path) -> Result<()> {
     }
 }
 
+fn archive_unpublished_journal(
+    path: &Path,
+    journal: &ReconciliationJournal,
+    reason: &str,
+    differing_sections: &[String],
+) -> Result<PathBuf> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("journal path has no parent: {}", path.display()))?;
+    let archive_root = parent
+        .join(crate::db::snapshot::SNAPSHOT_DIR)
+        .join(RECOVERY_ARCHIVE_DIR);
+    fs::create_dir_all(&archive_root).with_context(|| {
+        format!(
+            "creating reconciliation journal archive {}",
+            archive_root.display()
+        )
+    })?;
+    let evidence_path = path.join("recovery-evidence");
+    let evidence = serde_json::to_vec_pretty(&serde_json::json!({
+        "descriptor_oid": journal.descriptor_oid,
+        "generation_id": journal.descriptor.generation_id,
+        "stage": journal.stage,
+        "semantic_digest": journal.descriptor.semantic_digest,
+        "reason": reason,
+        "differing_sections": differing_sections,
+    }))
+    .context("serializing reconciliation recovery evidence")?;
+    let mut evidence_file = OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(&evidence_path)
+        .with_context(|| {
+            format!(
+                "opening reconciliation recovery evidence {}",
+                evidence_path.display()
+            )
+        })?;
+    evidence_file.write_all(&evidence).with_context(|| {
+        format!(
+            "writing reconciliation recovery evidence {}",
+            evidence_path.display()
+        )
+    })?;
+    evidence_file.sync_all().with_context(|| {
+        format!(
+            "syncing reconciliation recovery evidence {}",
+            evidence_path.display()
+        )
+    })?;
+    sync_directory(path)?;
+    let mut sequence = 1_u64;
+    let destination = loop {
+        let candidate = archive_root.join(format!(
+            "{}-{sequence:020}",
+            journal.descriptor.generation_id
+        ));
+        if !candidate.exists() {
+            break candidate;
+        }
+        sequence = sequence
+            .checked_add(1)
+            .ok_or_else(|| anyhow::anyhow!("reconciliation journal archive sequence exhausted"))?;
+    };
+    crate::utils::durable_rename(path, &destination, false).with_context(|| {
+        format!(
+            "archiving unpublished reconciliation journal {} as {}",
+            path.display(),
+            destination.display()
+        )
+    })?;
+    sync_directory(parent)?;
+    sync_directory(&archive_root)?;
+    Ok(destination)
+}
+
 fn next_journal_sequence(path: &Path) -> Result<u64> {
     Ok(latest_journal_record(path)?
         .and_then(|record| {
@@ -3691,6 +3857,76 @@ mod tests {
                 .output()?;
             ensure_git_success(&output, "read object-backed target state")?;
             CanonicalSemantic::from_value(serde_json::from_slice(&output.stdout)?)
+        }
+    }
+
+    struct MismatchedImporter {
+        target: ObjectImporter,
+        expected: Value,
+    }
+
+    impl MismatchedImporter {
+        fn replace_semantic(&self, prepared: PreparedImport) -> Result<PreparedImport> {
+            Ok(PreparedImport {
+                targets: prepared.targets,
+                semantic: CanonicalSemantic::from_value(self.expected.clone())?,
+            })
+        }
+    }
+
+    impl HistoricalImporter for MismatchedImporter {
+        fn snapshot_source_refs(
+            &self,
+            repository: &Path,
+            source: &SourceEvidence,
+        ) -> Result<BTreeMap<String, String>> {
+            self.target.snapshot_source_refs(repository, source)
+        }
+
+        fn prepare_file_source(
+            &self,
+            repository: &Path,
+            source: &SourceEvidence,
+            generation_id: &str,
+        ) -> Result<PreparedImport> {
+            self.replace_semantic(self.target.prepare_file_source(
+                repository,
+                source,
+                generation_id,
+            )?)
+        }
+
+        fn prepare_local_source(
+            &self,
+            repository: &Path,
+            source: &SourceEvidence,
+            generation_id: &str,
+        ) -> Result<PreparedImport> {
+            self.replace_semantic(self.target.prepare_local_source(
+                repository,
+                source,
+                generation_id,
+            )?)
+        }
+
+        fn prepare_current_source(
+            &self,
+            repository: &Path,
+            source: &SourceEvidence,
+        ) -> Result<PreparedImport> {
+            self.replace_semantic(self.target.prepare_current_source(repository, source)?)
+        }
+
+        fn file_source_is_newer(&self, repository: &Path, source: &SourceEvidence) -> Result<bool> {
+            self.target.file_source_is_newer(repository, source)
+        }
+
+        fn read_target_semantic(
+            &self,
+            repository: &Path,
+            targets: &BTreeMap<String, String>,
+        ) -> Result<CanonicalSemantic> {
+            self.target.read_target_semantic(repository, targets)
         }
     }
 
@@ -4946,6 +5182,62 @@ mod tests {
         );
         assert!(remote_oid(&fixture, GENERATION_REF).is_none());
         assert!(remote_oid(&fixture, V2).is_some());
+    }
+
+    #[test]
+    fn unpublished_semantic_mismatch_is_archived_and_rebuilt() {
+        let fixture = v2_fixture();
+        let fixed = ObjectImporter::new("fixed-preparation");
+        let mut poisoned_value = fixed.semantic.clone();
+        poisoned_value.as_object_mut().unwrap().remove("trust");
+        let poisoned = MismatchedImporter {
+            target: ObjectImporter {
+                semantic: poisoned_value,
+                salt: "poisoned-preparation".to_string(),
+            },
+            expected: fixed.semantic.clone(),
+        };
+        let error = RepositoryReconciler::new(
+            fixture.repository.path(),
+            fixture.journal.clone(),
+            "origin",
+            &poisoned,
+        )
+        .reconcile(fixture.format.clone())
+        .unwrap_err();
+        assert!(format!("{error:#}").contains("sections: trust"));
+        let JournalRecord::Generation(failed) =
+            read_journal(fixture.repository.path(), &fixture.journal)
+                .unwrap()
+                .unwrap()
+        else {
+            panic!("expected failed preparation journal");
+        };
+        assert_eq!(failed.stage, JournalStage::Prepared);
+
+        let outcome = reconcile_fixture(&fixture, &fixed).unwrap();
+        assert!(matches!(outcome, PublicationOutcome::Published { .. }));
+        assert!(!fixture.journal.exists());
+        let archive_root = fixture
+            .repository
+            .path()
+            .join(crate::db::snapshot::SNAPSHOT_DIR)
+            .join(RECOVERY_ARCHIVE_DIR);
+        let archived = fs::read_dir(&archive_root)
+            .unwrap()
+            .map(|entry| entry.unwrap().path())
+            .collect::<Vec<_>>();
+        assert_eq!(archived.len(), 1);
+        let evidence: Value =
+            serde_json::from_slice(&fs::read(archived[0].join("recovery-evidence")).unwrap())
+                .unwrap();
+        assert_eq!(evidence["descriptor_oid"], failed.descriptor_oid);
+        assert_eq!(evidence["differing_sections"], serde_json::json!(["trust"]));
+        assert!(evidence["reason"]
+            .as_str()
+            .unwrap()
+            .contains("sections: trust"));
+        assert!(remote_oid(&fixture, GENERATION_REF).is_some());
     }
 
     #[test]

--- a/crosslink/src/reconcile/readiness.rs
+++ b/crosslink/src/reconcile/readiness.rs
@@ -1486,7 +1486,7 @@ const fn state_name(state: ReadinessState) -> &'static str {
 
 fn evidence_path(crosslink_dir: &Path) -> Option<String> {
     let journal = crosslink_dir.join("reconciliation-journal.json");
-    if journal.is_file() {
+    if journal.exists() {
         return Some(journal.display().to_string());
     }
     let integrity = crosslink_dir.join(crate::db::snapshot::SNAPSHOT_DIR);
@@ -1542,7 +1542,7 @@ fn write_observation_evidence(
         reason: reason.map(str::to_string),
         publication_journal: crosslink_dir
             .join("reconciliation-journal.json")
-            .is_file()
+            .exists()
             .then(|| {
                 crosslink_dir
                     .join("reconciliation-journal.json")

--- a/crosslink/tests/cli_integration.rs
+++ b/crosslink/tests/cli_integration.rs
@@ -3858,7 +3858,7 @@ fn test_design_detects_both_agent_environments() {
 }
 
 #[test]
-fn test_reconcile_check_json_reports_current_without_writes() {
+fn test_reconcile_check_json_reports_pre_generation_v3_without_writes() {
     let dir = test_dir();
     let crosslink_dir = dir.path().join(".crosslink");
     std::fs::create_dir_all(&crosslink_dir).unwrap();
@@ -3883,7 +3883,12 @@ fn test_reconcile_check_json_reports_current_without_writes() {
     let (success, stdout, stderr) = run_crosslink(dir.path(), &["reconcile", "--check", "--json"]);
     assert!(success, "{stderr}");
     let report: serde_json::Value = serde_json::from_str(&stdout).unwrap();
-    assert_eq!(report["plan"]["state"], "ready_current");
+    assert_eq!(report["plan"]["state"], "migration_required");
+    assert!(report["plan"]["actions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|action| action["action"] == "establish_reconciliation_generation"));
     assert_eq!(report["format"]["local_database"]["kind"], "sqlite");
     assert_eq!(report["format"]["shared_store"]["kind"], "visible_v3");
     assert_eq!(database_before, std::fs::read(&database_path).unwrap());


### PR DESCRIPTION
## Summary

- pass pinned `allowed_signers` bytes explicitly through every v3 target-construction path
- archive and automatically rebuild invalid unpublished preparations only while source evidence remains pinned and no generation pointer has committed
- report pre-generation visible-v3 repositories as migration-required and identify semantic mismatch sections such as `trust`
- cover visible v3 plus trust metadata plus unshared SQLite projection state through `ready_migrated` and subsequent `ready_current`

## Runtime proof

- fixed binary passed a disposable worktree plus local bare-origin smoke
- installed binary archived the real failed journal with `differing_sections: ["trust"]`
- signer SHA-256 remained `15731bc87b950b103987487b5c78b85c282515a0959489cf0ce8a2bfba900dc6`
- real repository published generation `027dcd4a87f7645740f3ea73fc57faaf` and now reports `ready_current`

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features` (5,400 passed; 4 infrastructure-dependent smoke tests ignored)
- `cargo check --locked --target x86_64-pc-windows-gnu --all-targets --all-features`
- `cargo +1.88.0 check --locked --all-targets --all-features`
- `python3 crosslink/scripts/sync-codex-plugin.py --check`
- zero-byte rule and generated-drift checks