### PR TITLE
feat(application): enforce authoritative command/query boundary

### DIFF
--- a/.design/crosslink-architecture-overhead-map.md
+++ b/.design/crosslink-architecture-overhead-map.md
@@ -370,7 +370,7 @@ The existing `docs/ARCHITECTURE.md` is not a reliable current source of truth. I
 | Failure | Current behavior | Risk | Required behavior |
 |---|---|---|---|
 | Shared writer construction fails | Warning, optional writer becomes absent | Silent local-only mutation | Fail shared mutation or enter explicit local/read-only mode |
-| Own ref push fails | `LocalOnly` outcome | User may assume collaboration succeeded | Persist visible pending-push state and report it in command result/status |
+| Own ref push fails | Command fails, the unpublished ref append is rolled back, and SQLite remains unchanged | No projection-only success and no surprise delivery after reconnect | Restore publication, then retry the command |
 | Checkpoint serialize/write/push fails | Warning, mutation continues | Stale readers and unclear durability | Mutation remains durable in owner ref, but result must expose stale checkpoint and retry queue |
 | Late event sorts below watermark | Event is not selected | Permanent omission from materialized state | Per-agent causal frontier and prefix verification |
 | Remote checkpoint has equal/higher sequence from another agent | Remote checkpoint may be adopted | Regression or incomplete state | Compare complete frontier and validate it against pinned refs |
@@ -633,11 +633,14 @@ Exit condition: every supported historical fixture reaches a verified current st
 
 ### Phase 1 — Introduce one application boundary
 
-- Create typed `CommandService` and `QueryService` interfaces inside the existing crate first.
-- Move issue, comment, relation, milestone, lock, and session-to-issue mutations behind commands.
-- Adapt CLI handlers, the newer dashboard, legacy HTTP handlers, TUI actions, sentinel, kickoff, swarm, and orchestrator.
-- Make the Git event store mandatory in shared mode.
-- Keep SQLite writes inside a projector or explicit local-state service.
+- Status: implemented on `feature/authoritative-command-query-boundary`.
+- `application::CommandService` is the exhaustive typed mutation boundary for issues, imports, archive state, comments, interventions, labels, dependencies, relations, milestones, locks, and session-to-issue association.
+- `application::QueryService` owns shared projection reads. `application::LocalStateService` owns sessions, timers, token usage, and sentinel operational state.
+- CLI handlers and aliases, dashboard CLI actions, legacy HTTP handlers, TUI reads, sentinel, kickoff, swarm delegation, and orchestrator route through these services.
+- `RepositoryService::new` resolves shared authority without converting writer construction failures into local mode. A configured shared repository cannot fall back to SQLite when its writer, cache, readiness state, or remote publication is unavailable.
+- Shared v3 commands append and publish the agent ref before hydration. Failed publication rolls the append back with compare-and-swap and returns an error without changing SQLite.
+- `RepositoryService::projection` can query shared data and use the explicitly local session-to-issue association, but rejects all other domain commands. Projector, hydration, reconciliation, migration, and compaction code remain the only direct shared-domain SQLite writers.
+- Source guards reject new direct domain `Database` mutations in production adapters. Recording tests cover the command variants and the CLI, legacy HTTP, sentinel, kickoff, and orchestrator adapters; query parity tests compare every `QueryService` result with the underlying projection.
 
 Exit condition: production interfaces cannot directly call shared-domain `Database` mutation methods.
 

--- a/.design/crosslink-architecture-overhead-map.md
+++ b/.design/crosslink-architecture-overhead-map.md
@@ -635,12 +635,12 @@ Exit condition: every supported historical fixture reaches a verified current st
 
 - Status: implemented on `feature/authoritative-command-query-boundary`.
 - `application::CommandService` is the exhaustive typed mutation boundary for issues, imports, archive state, comments, interventions, labels, dependencies, relations, milestones, locks, and session-to-issue association.
-- `application::QueryService` owns shared projection reads. `application::LocalStateService` owns sessions, timers, token usage, and sentinel operational state.
+- `application::QueryService` owns shared projection reads, including the dashboard's Git-backed `HubSnapshot`. `application::LocalStateService` owns sessions, timers, token usage, and sentinel operational state.
 - CLI handlers and aliases, dashboard CLI actions, legacy HTTP handlers, TUI reads, sentinel, kickoff, swarm delegation, and orchestrator route through these services.
 - `RepositoryService::new` resolves shared authority without converting writer construction failures into local mode. A configured shared repository cannot fall back to SQLite when its writer, cache, readiness state, or remote publication is unavailable.
 - Shared v3 commands append and publish the agent ref before hydration. Failed publication rolls the append back with compare-and-swap and returns an error without changing SQLite.
 - `RepositoryService::projection` can query shared data and use the explicitly local session-to-issue association, but rejects all other domain commands. Projector, hydration, reconciliation, migration, and compaction code remain the only direct shared-domain SQLite writers.
-- Source guards reject new direct domain `Database` mutations in production adapters. Recording tests cover the command variants and the CLI, legacy HTTP, sentinel, kickoff, and orchestrator adapters; query parity tests compare every `QueryService` result with the underlying projection.
+- Source guards reject direct domain `Database` mutation methods under any receiver name and raw SQL writes to shared tables in production adapters. Recording tests cover every command variant and exercise CLI and alias handlers, cpitd, legacy HTTP, sentinel, kickoff, swarm's kickoff delegation, and orchestrator paths. Query parity covers the SQLite projection and the dashboard snapshot implementation.
 
 Exit condition: production interfaces cannot directly call shared-domain `Database` mutation methods.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,7 +223,9 @@ jobs:
       CLI_TEST_FILTERS: >-
         test_a test_b test_c test_d test_e test_f test_g test_h test_i test_j test_k test_l
         test_m test_n test_o test_p test_q test_r test_search test_security test_sentinel
-        test_session test_show test_special test_sql test_start test_stop test_stress test_subissue
+        test_session test_show test_special test_sql test_start test_stop test_stress_deep_nesting
+        test_stress_many_issues test_stress_rapid_operations test_stress_very_long_description
+        test_stress_very_long_title test_subissue
         test_t test_u test_v test_w test_x test_y test_z
     defaults:
       run:
@@ -240,8 +242,10 @@ jobs:
             prefixes: test_m test_n test_o test_p test_q test_r
           - shard: s-core
             prefixes: test_search test_security test_sentinel test_session test_show test_special test_sql test_start test_stop
-          - shard: s-stress
-            prefixes: test_stress test_subissue
+          - shard: s-stress-create
+            prefixes: test_stress_many_issues test_stress_very_long_description test_stress_very_long_title
+          - shard: s-stress-mutate
+            prefixes: test_stress_deep_nesting test_stress_rapid_operations test_subissue
           - shard: t-z
             prefixes: test_t test_u test_v test_w test_x test_y test_z
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,8 +244,10 @@ jobs:
             prefixes: test_search test_security test_sentinel test_session test_show test_special test_sql test_start test_stop
           - shard: s-stress-create
             prefixes: test_stress_many_issues test_stress_very_long_description test_stress_very_long_title
-          - shard: s-stress-mutate
-            prefixes: test_stress_deep_nesting test_stress_rapid_operations test_subissue
+          - shard: s-stress-rapid
+            prefixes: test_stress_rapid_operations
+          - shard: s-stress-tree
+            prefixes: test_stress_deep_nesting test_subissue
           - shard: t-z
             prefixes: test_t test_u test_v test_w test_x test_y test_z
     steps:

--- a/crosslink/src/agent_requests.rs
+++ b/crosslink/src/agent_requests.rs
@@ -127,7 +127,8 @@ pub fn new_request_id() -> String {
 pub mod poll {
     use super::*;
     use crate::agent_flags;
-    use crate::shared_writer::{PushOutcome, SharedWriter};
+    use crate::application::CommandService;
+    use crate::shared_writer::PushOutcome;
 
     #[derive(Debug, Clone, Default)]
     pub struct PollResult {
@@ -147,16 +148,16 @@ pub mod poll {
     }
 
     pub fn process_pending(
-        writer: &SharedWriter,
+        commands: &(impl CommandService + ?Sized),
         crosslink_dir: &std::path::Path,
         agent_id: &str,
     ) -> Result<PollResult> {
-        if writer.is_v3_public() {
-            return process_pending_v3(writer, crosslink_dir, agent_id);
+        let sync = crate::sync::SyncManager::new(crosslink_dir)?;
+        if sync.hub_mode().is_v3() {
+            return process_pending_v3(commands, crosslink_dir, agent_id, sync.cache_path());
         }
 
-        let cache_dir = crosslink_dir.join("hub-cache");
-        let entries = scan(&cache_dir, agent_id)?;
+        let entries = scan(sync.cache_path(), agent_id)?;
         let mut result = PollResult::default();
 
         for row in entries {
@@ -174,13 +175,7 @@ pub mod poll {
                 result: summary.clone(),
                 notes: None,
             };
-            let push_outcome = writer.write_agent_ack(agent_id, &ack).unwrap_or_else(|e| {
-                tracing::warn!(
-                    "failed to push ack for {}: {e}; treating as LocalOnly",
-                    row.request.request_id
-                );
-                PushOutcome::LocalOnly
-            });
+            let push_outcome = commands.write_agent_ack(agent_id, &ack)?;
 
             result.acted.push(PollAction {
                 request_id: row.request.request_id,
@@ -195,11 +190,11 @@ pub mod poll {
     }
 
     fn process_pending_v3(
-        writer: &SharedWriter,
+        commands: &(impl CommandService + ?Sized),
         crosslink_dir: &std::path::Path,
         agent_id: &str,
+        cache_dir: &std::path::Path,
     ) -> Result<PollResult> {
-        let cache_dir = writer.cache_dir_public();
         let pending = crate::hub_v3::poll_requests_for_agent(cache_dir, agent_id)?;
         let mut result = PollResult::default();
 
@@ -214,13 +209,7 @@ pub mod poll {
                 result: summary.clone(),
                 notes: None,
             };
-            let push_outcome = writer.write_agent_ack(agent_id, &ack).unwrap_or_else(|e| {
-                tracing::warn!(
-                    "failed to push v3 ack for {}: {e}; treating as LocalOnly",
-                    request.request_id
-                );
-                PushOutcome::LocalOnly
-            });
+            let push_outcome = commands.write_agent_ack(agent_id, &ack)?;
 
             result.acted.push(PollAction {
                 request_id: request.request_id,
@@ -285,7 +274,16 @@ pub mod poll {
     #[cfg(test)]
     mod tests {
         use super::*;
+        use crate::application::{Command, CommandResult};
         use tempfile::tempdir;
+
+        struct RejectingCommands;
+
+        impl CommandService for RejectingCommands {
+            fn execute(&self, _command: Command) -> Result<CommandResult> {
+                anyhow::bail!("acknowledgement rejected")
+            }
+        }
 
         fn make_req(kind: RequestKind, issue_id: Option<i64>) -> AgentRequest {
             AgentRequest {
@@ -346,6 +344,27 @@ pub mod poll {
                 .unwrap()
                 .unwrap();
             assert_eq!(hint.issue_id, 7);
+        }
+
+        #[test]
+        fn process_pending_propagates_acknowledgement_failure() {
+            let directory = tempdir().unwrap();
+            let crosslink_dir = directory.path().join(".crosslink");
+            let request_dir = crosslink_dir
+                .join(".hub-cache")
+                .join(requests_dir("agent-x"));
+            std::fs::create_dir_all(&request_dir).unwrap();
+            let request = make_req(RequestKind::Pause, None);
+            std::fs::write(
+                request_dir.join(format!("{}.json", request.request_id)),
+                serde_json::to_vec(&request).unwrap(),
+            )
+            .unwrap();
+
+            let error = process_pending(&RejectingCommands, &crosslink_dir, "agent-x")
+                .expect_err("acknowledgement failure must not become local-only success");
+
+            assert!(error.to_string().contains("acknowledgement rejected"));
         }
     }
 }

--- a/crosslink/src/application.rs
+++ b/crosslink/src/application.rs
@@ -469,6 +469,7 @@ impl OwnedIssueUpdate {
 }
 
 pub trait QueryService {
+    fn list_issue_records(&self) -> Result<Vec<crate::issue_file::IssueFile>>;
     fn get_issue(&self, id: i64) -> Result<Option<Issue>>;
     fn require_issue(&self, id: i64) -> Result<Issue>;
     fn list_issues(
@@ -1134,6 +1135,10 @@ impl CommandService for RepositoryService<'_> {
 }
 
 impl QueryService for RepositoryService<'_> {
+    fn list_issue_records(&self) -> Result<Vec<crate::issue_file::IssueFile>> {
+        build_issue_records(self)
+    }
+
     fn get_issue(&self, id: i64) -> Result<Option<Issue>> {
         self.database.get_issue(id)
     }
@@ -1432,6 +1437,121 @@ impl LocalStateService for RepositoryService<'_> {
     }
 }
 
+fn build_issue_records(
+    queries: &(impl QueryService + ?Sized),
+) -> Result<Vec<crate::issue_file::IssueFile>> {
+    let issues = queries.list_issues(Some("all"), None, None)?;
+    let mut uuid_map = std::collections::HashMap::new();
+    for issue in &issues {
+        let (uuid, _) = queries.get_issue_export_metadata(issue.id)?;
+        let uuid = uuid
+            .and_then(|value| value.parse().ok())
+            .unwrap_or_else(uuid::Uuid::new_v4);
+        uuid_map.insert(issue.id, uuid);
+    }
+    let mut records = Vec::with_capacity(issues.len());
+    for issue in issues {
+        let (uuid, created_by) = queries.get_issue_export_metadata(issue.id)?;
+        let uuid = uuid
+            .and_then(|value| value.parse().ok())
+            .or_else(|| uuid_map.get(&issue.id).copied())
+            .unwrap_or_else(uuid::Uuid::new_v4);
+        let parent_uuid = issue
+            .parent_id
+            .map(|parent_id| resolve_issue_record_uuid(queries, &uuid_map, parent_id));
+        let blockers = queries
+            .get_blockers(issue.id)?
+            .into_iter()
+            .map(|id| resolve_issue_record_uuid(queries, &uuid_map, id))
+            .collect();
+        let related = queries
+            .get_related_issue_ids(issue.id)?
+            .into_iter()
+            .map(|id| resolve_issue_record_uuid(queries, &uuid_map, id))
+            .collect();
+        let milestone_uuid = queries
+            .get_milestone_uuid_for_issue(issue.id)?
+            .and_then(|uuid| uuid.parse().ok());
+        let comments = queries
+            .get_comments_with_author(issue.id)?
+            .into_iter()
+            .map(
+                |(
+                    id,
+                    author,
+                    content,
+                    created_at,
+                    kind,
+                    trigger_type,
+                    intervention_context,
+                    driver_key_fingerprint,
+                )| {
+                    crate::issue_file::CommentEntry {
+                        id,
+                        author: author.unwrap_or_else(|| "unknown".to_string()),
+                        content,
+                        created_at,
+                        kind,
+                        trigger_type,
+                        intervention_context,
+                        driver_key_fingerprint,
+                        signed_by: None,
+                        signature: None,
+                    }
+                },
+            )
+            .collect();
+        let time_entries = queries
+            .get_time_entries_for_issue(issue.id)?
+            .into_iter()
+            .map(
+                |(id, started_at, ended_at, duration_seconds)| crate::issue_file::TimeEntry {
+                    id,
+                    started_at,
+                    ended_at,
+                    duration_seconds,
+                },
+            )
+            .collect();
+        records.push(crate::issue_file::IssueFile {
+            uuid,
+            display_id: Some(issue.id),
+            title: issue.title,
+            description: issue.description,
+            status: issue.status,
+            priority: issue.priority,
+            parent_uuid,
+            created_by: created_by.unwrap_or_else(|| "unknown".to_string()),
+            created_at: issue.created_at,
+            updated_at: issue.updated_at,
+            closed_at: issue.closed_at,
+            scheduled_at: issue.scheduled_at,
+            due_at: issue.due_at,
+            labels: queries.get_labels(issue.id)?,
+            comments,
+            blockers,
+            related,
+            milestone_uuid,
+            time_entries,
+        });
+    }
+    Ok(records)
+}
+
+fn resolve_issue_record_uuid(
+    queries: &(impl QueryService + ?Sized),
+    uuid_map: &std::collections::HashMap<i64, uuid::Uuid>,
+    id: i64,
+) -> uuid::Uuid {
+    uuid_map.get(&id).copied().unwrap_or_else(|| {
+        queries
+            .get_issue_uuid_by_id(id)
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or_else(uuid::Uuid::new_v4)
+    })
+}
+
 const fn map_datetime_change(change: DateTimeChange) -> FieldUpdate<DateTime<Utc>> {
     match change {
         DateTimeChange::Unchanged => FieldUpdate::Unchanged,
@@ -1489,6 +1609,10 @@ impl CommandService for Database {
 }
 
 impl QueryService for Database {
+    fn list_issue_records(&self) -> Result<Vec<crate::issue_file::IssueFile>> {
+        build_issue_records(self)
+    }
+
     fn get_issue(&self, id: i64) -> Result<Option<Issue>> {
         Database::get_issue(self, id)
     }
@@ -1813,6 +1937,10 @@ mod tests {
         let since = "1970-01-01T00:00:00Z";
 
         assert_eq!(
+            service.list_issue_records().unwrap(),
+            QueryService::list_issue_records(&database).unwrap()
+        );
+        assert_eq!(
             service.get_issue(parent).unwrap(),
             database.get_issue(parent).unwrap()
         );
@@ -2029,7 +2157,6 @@ mod tests {
         let source_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
         let mut files = Vec::new();
         source_files(&source_root, &mut files);
-        let receivers = ["db", "database", "main_db", "writable"];
         let database_methods = [
             "create_issue",
             "create_subissue",
@@ -2065,27 +2192,11 @@ mod tests {
             "complete_sentinel_run",
             "insert_sentinel_dispatch",
             "update_dispatch_outcome",
-        ];
-        let writer_methods = [
-            "create_issue",
-            "create_subissue",
-            "update_issue",
-            "delete_issue",
-            "close_issue",
-            "reopen_issue",
-            "add_comment",
-            "add_intervention_comment",
-            "add_label",
-            "remove_label",
+            "clear_shared_data",
             "add_blocker",
             "remove_blocker",
-            "add_relation",
-            "remove_relation",
-            "create_milestone",
             "set_milestone_on_issues",
             "clear_milestone_on_issue",
-            "close_milestone",
-            "delete_milestone",
             "claim_lock_v2",
             "release_lock_v2",
             "steal_lock_v2",
@@ -2093,6 +2204,17 @@ mod tests {
             "write_agent_request",
             "write_agent_ack",
         ];
+        let method_calls = regex::Regex::new(&format!(
+            r"(?m)\b([A-Za-z_][A-Za-z0-9_]*)\s*\.\s*({})\s*\(",
+            database_methods.join("|")
+        ))
+        .unwrap();
+        let test_module =
+            regex::Regex::new(r"(?m)^\s*#\[cfg\(test\)\]\s*\n\s*mod\s+[A-Za-z0-9_]+\s*\{").unwrap();
+        let raw_shared_sql = regex::Regex::new(
+            r"(?i)\b(?:INSERT\s+INTO|REPLACE\s+INTO|UPDATE|DELETE\s+FROM)\s+(?:issues|comments|labels|dependencies|relations|milestones|milestone_issues)\b",
+        )
+        .unwrap();
         let mut violations = Vec::new();
 
         for path in files {
@@ -2109,24 +2231,22 @@ mod tests {
                 continue;
             }
             let source = std::fs::read_to_string(&path).unwrap();
-            let production = source
-                .find("#[cfg(test)]\nmod tests")
-                .map_or(source.as_str(), |index| &source[..index]);
-            for receiver in receivers {
-                for method in database_methods {
-                    let pattern = format!("{receiver}.{method}(");
-                    if production.contains(&pattern) {
-                        violations.push(format!("{}: {pattern}", relative.display()));
-                    }
+            let production = test_module
+                .find(&source)
+                .map_or(source.as_str(), |found| &source[..found.start()]);
+            for capture in method_calls.captures_iter(production) {
+                let receiver = &capture[1];
+                if !matches!(receiver, "service" | "commands") {
+                    violations.push(format!(
+                        "{}: {}.{}(",
+                        relative.display(),
+                        receiver,
+                        &capture[2]
+                    ));
                 }
             }
-            for receiver in ["writer", "shared_writer"] {
-                for method in writer_methods {
-                    let pattern = format!("{receiver}.{method}(");
-                    if production.contains(&pattern) {
-                        violations.push(format!("{}: {pattern}", relative.display()));
-                    }
-                }
+            if raw_shared_sql.is_match(production) {
+                violations.push(format!("{}: raw shared-domain SQL", relative.display()));
             }
             if production.contains("SharedWriter::new(") {
                 violations.push(format!("{}: SharedWriter::new(", relative.display()));

--- a/crosslink/src/application.rs
+++ b/crosslink/src/application.rs
@@ -1,0 +1,2142 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+use chrono::{DateTime, Utc};
+
+use crate::agent_requests::{AgentRequest, AgentRequestAck};
+use crate::db::sentinel::{
+    DispatchMetric, NewDispatch, RunCounters, SentinelDispatch, SentinelRun,
+};
+use crate::db::Database;
+use crate::db::UsageSummaryRow;
+use crate::models::{Comment, Issue, Milestone, Session, TokenUsage};
+use crate::shared_writer::{
+    DescriptionUpdate, FieldUpdate, ImportedIssueSpec, IssueUpdate, LockClaimResult, PushOutcome,
+    SharedWriter,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthorityMode {
+    Local,
+    Shared,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Command {
+    CreateIssue {
+        title: String,
+        description: Option<String>,
+        priority: String,
+        labels: Vec<String>,
+        scheduled_at: Option<DateTime<Utc>>,
+        due_at: Option<DateTime<Utc>>,
+    },
+    CreateSubissue {
+        parent_id: i64,
+        title: String,
+        description: Option<String>,
+        priority: String,
+        labels: Vec<String>,
+    },
+    ImportIssues {
+        specs: Vec<ImportedIssueSpec>,
+    },
+    UpdateIssue {
+        id: i64,
+        title: Option<String>,
+        description: DescriptionChange,
+        status: Option<String>,
+        priority: Option<String>,
+        scheduled_at: DateTimeChange,
+        due_at: DateTimeChange,
+    },
+    DeleteIssue {
+        id: i64,
+    },
+    ArchiveIssue {
+        id: i64,
+    },
+    UnarchiveIssue {
+        id: i64,
+    },
+    AddComment {
+        issue_id: i64,
+        content: String,
+        kind: String,
+    },
+    AddIntervention {
+        issue_id: i64,
+        content: String,
+        trigger_type: String,
+        context: Option<String>,
+        driver_key_fingerprint: Option<String>,
+    },
+    AddLabel {
+        issue_id: i64,
+        label: String,
+    },
+    RemoveLabel {
+        issue_id: i64,
+        label: String,
+    },
+    AddDependency {
+        issue_id: i64,
+        blocker_id: i64,
+    },
+    RemoveDependency {
+        issue_id: i64,
+        blocker_id: i64,
+    },
+    AddRelation {
+        issue_id: i64,
+        related_id: i64,
+    },
+    RemoveRelation {
+        issue_id: i64,
+        related_id: i64,
+    },
+    CreateMilestone {
+        name: String,
+        description: Option<String>,
+    },
+    AssignMilestone {
+        milestone_id: i64,
+        issue_ids: Vec<i64>,
+    },
+    ClearMilestone {
+        milestone_id: i64,
+        issue_id: i64,
+    },
+    CloseMilestone {
+        id: i64,
+    },
+    DeleteMilestone {
+        id: i64,
+    },
+    ClaimLock {
+        issue_id: i64,
+        branch: Option<String>,
+    },
+    ReleaseLock {
+        issue_id: i64,
+    },
+    StealLock {
+        issue_id: i64,
+        stale_agent_id: String,
+        branch: Option<String>,
+    },
+    ForceReleaseLock {
+        issue_id: i64,
+        stale_agent_id: String,
+    },
+    SetSessionIssue {
+        session_id: i64,
+        issue_id: i64,
+    },
+    ClearSessionIssue {
+        session_id: i64,
+    },
+    WriteAgentRequest {
+        target_agent_id: String,
+        request: AgentRequest,
+    },
+    WriteAgentAck {
+        target_agent_id: String,
+        ack: AgentRequestAck,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DescriptionChange {
+    Unchanged,
+    Clear,
+    Set(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DateTimeChange {
+    Unchanged,
+    Clear,
+    Set(DateTime<Utc>),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct LocalTokenUsage {
+    pub agent_id: String,
+    pub session_id: Option<i64>,
+    pub provider: String,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cached_input_tokens: Option<i64>,
+    pub reasoning_output_tokens: Option<i64>,
+    pub cache_read_tokens: Option<i64>,
+    pub cache_creation_tokens: Option<i64>,
+    pub model: String,
+    pub cost_estimate: Option<f64>,
+    pub provider_metadata_json: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CommandResult {
+    None,
+    Id(i64),
+    Changed(bool),
+    Lock(LockClaimResult),
+    Imported(Vec<(uuid::Uuid, i64)>),
+    Push(PushOutcome),
+}
+
+pub trait CommandService {
+    fn execute(&self, command: Command) -> Result<CommandResult>;
+
+    fn create_issue(
+        &self,
+        title: &str,
+        description: Option<&str>,
+        priority: &str,
+        scheduled_at: Option<DateTime<Utc>>,
+        due_at: Option<DateTime<Utc>>,
+    ) -> Result<i64> {
+        self.create_issue_with_labels(title, description, priority, &[], scheduled_at, due_at)
+    }
+
+    fn create_issue_with_labels(
+        &self,
+        title: &str,
+        description: Option<&str>,
+        priority: &str,
+        labels: &[String],
+        scheduled_at: Option<DateTime<Utc>>,
+        due_at: Option<DateTime<Utc>>,
+    ) -> Result<i64> {
+        expect_id(self.execute(Command::CreateIssue {
+            title: title.to_string(),
+            description: description.map(str::to_string),
+            priority: priority.to_string(),
+            labels: labels.to_vec(),
+            scheduled_at,
+            due_at,
+        })?)
+    }
+
+    fn create_subissue(
+        &self,
+        parent_id: i64,
+        title: &str,
+        description: Option<&str>,
+        priority: &str,
+    ) -> Result<i64> {
+        self.create_subissue_with_labels(parent_id, title, description, priority, &[])
+    }
+
+    fn create_subissue_with_labels(
+        &self,
+        parent_id: i64,
+        title: &str,
+        description: Option<&str>,
+        priority: &str,
+        labels: &[String],
+    ) -> Result<i64> {
+        expect_id(self.execute(Command::CreateSubissue {
+            parent_id,
+            title: title.to_string(),
+            description: description.map(str::to_string),
+            priority: priority.to_string(),
+            labels: labels.to_vec(),
+        })?)
+    }
+
+    fn update_issue(&self, id: i64, update: OwnedIssueUpdate) -> Result<()> {
+        expect_none(self.execute(Command::UpdateIssue {
+            id,
+            title: update.title,
+            description: update.description,
+            status: update.status,
+            priority: update.priority,
+            scheduled_at: update.scheduled_at,
+            due_at: update.due_at,
+        })?)
+    }
+
+    fn import_issues(&self, specs: &[ImportedIssueSpec]) -> Result<Vec<(uuid::Uuid, i64)>> {
+        match self.execute(Command::ImportIssues {
+            specs: specs.to_vec(),
+        })? {
+            CommandResult::Imported(assigned) => Ok(assigned),
+            other => bail!("command returned unexpected result: {other:?}"),
+        }
+    }
+
+    fn close_issue(&self, id: i64) -> Result<()> {
+        self.update_issue(id, OwnedIssueUpdate::status("closed"))
+    }
+
+    fn reopen_issue(&self, id: i64) -> Result<()> {
+        self.update_issue(id, OwnedIssueUpdate::status("open"))
+    }
+
+    fn archive_issue(&self, id: i64) -> Result<()> {
+        expect_none(self.execute(Command::ArchiveIssue { id })?)
+    }
+
+    fn unarchive_issue(&self, id: i64) -> Result<()> {
+        expect_none(self.execute(Command::UnarchiveIssue { id })?)
+    }
+
+    fn delete_issue(&self, id: i64) -> Result<()> {
+        expect_none(self.execute(Command::DeleteIssue { id })?)
+    }
+
+    fn add_comment(&self, issue_id: i64, content: &str, kind: &str) -> Result<i64> {
+        expect_id(self.execute(Command::AddComment {
+            issue_id,
+            content: content.to_string(),
+            kind: kind.to_string(),
+        })?)
+    }
+
+    fn add_intervention(
+        &self,
+        issue_id: i64,
+        content: &str,
+        trigger_type: &str,
+        context: Option<&str>,
+        driver_key_fingerprint: Option<&str>,
+    ) -> Result<i64> {
+        expect_id(self.execute(Command::AddIntervention {
+            issue_id,
+            content: content.to_string(),
+            trigger_type: trigger_type.to_string(),
+            context: context.map(str::to_string),
+            driver_key_fingerprint: driver_key_fingerprint.map(str::to_string),
+        })?)
+    }
+
+    fn add_label(&self, issue_id: i64, label: &str) -> Result<bool> {
+        expect_changed(self.execute(Command::AddLabel {
+            issue_id,
+            label: label.to_string(),
+        })?)
+    }
+
+    fn remove_label(&self, issue_id: i64, label: &str) -> Result<bool> {
+        expect_changed(self.execute(Command::RemoveLabel {
+            issue_id,
+            label: label.to_string(),
+        })?)
+    }
+
+    fn add_dependency(&self, issue_id: i64, blocker_id: i64) -> Result<bool> {
+        expect_changed(self.execute(Command::AddDependency {
+            issue_id,
+            blocker_id,
+        })?)
+    }
+
+    fn remove_dependency(&self, issue_id: i64, blocker_id: i64) -> Result<bool> {
+        expect_changed(self.execute(Command::RemoveDependency {
+            issue_id,
+            blocker_id,
+        })?)
+    }
+
+    fn add_relation(&self, issue_id: i64, related_id: i64) -> Result<bool> {
+        expect_changed(self.execute(Command::AddRelation {
+            issue_id,
+            related_id,
+        })?)
+    }
+
+    fn remove_relation(&self, issue_id: i64, related_id: i64) -> Result<bool> {
+        expect_changed(self.execute(Command::RemoveRelation {
+            issue_id,
+            related_id,
+        })?)
+    }
+
+    fn create_milestone(&self, name: &str, description: Option<&str>) -> Result<i64> {
+        expect_id(self.execute(Command::CreateMilestone {
+            name: name.to_string(),
+            description: description.map(str::to_string),
+        })?)
+    }
+
+    fn assign_milestone(&self, milestone_id: i64, issue_ids: &[i64]) -> Result<()> {
+        expect_none(self.execute(Command::AssignMilestone {
+            milestone_id,
+            issue_ids: issue_ids.to_vec(),
+        })?)
+    }
+
+    fn clear_milestone(&self, milestone_id: i64, issue_id: i64) -> Result<bool> {
+        expect_changed(self.execute(Command::ClearMilestone {
+            milestone_id,
+            issue_id,
+        })?)
+    }
+
+    fn close_milestone(&self, id: i64) -> Result<()> {
+        expect_none(self.execute(Command::CloseMilestone { id })?)
+    }
+
+    fn delete_milestone(&self, id: i64) -> Result<()> {
+        expect_none(self.execute(Command::DeleteMilestone { id })?)
+    }
+
+    fn claim_lock(&self, issue_id: i64, branch: Option<&str>) -> Result<LockClaimResult> {
+        expect_lock(self.execute(Command::ClaimLock {
+            issue_id,
+            branch: branch.map(str::to_string),
+        })?)
+    }
+
+    fn release_lock(&self, issue_id: i64) -> Result<bool> {
+        expect_changed(self.execute(Command::ReleaseLock { issue_id })?)
+    }
+
+    fn steal_lock(
+        &self,
+        issue_id: i64,
+        stale_agent_id: &str,
+        branch: Option<&str>,
+    ) -> Result<LockClaimResult> {
+        expect_lock(self.execute(Command::StealLock {
+            issue_id,
+            stale_agent_id: stale_agent_id.to_string(),
+            branch: branch.map(str::to_string),
+        })?)
+    }
+
+    fn force_release_lock(&self, issue_id: i64, stale_agent_id: &str) -> Result<bool> {
+        expect_changed(self.execute(Command::ForceReleaseLock {
+            issue_id,
+            stale_agent_id: stale_agent_id.to_string(),
+        })?)
+    }
+
+    fn set_session_issue(&self, session_id: i64, issue_id: i64) -> Result<bool> {
+        expect_changed(self.execute(Command::SetSessionIssue {
+            session_id,
+            issue_id,
+        })?)
+    }
+
+    fn clear_session_issue(&self, session_id: i64) -> Result<bool> {
+        expect_changed(self.execute(Command::ClearSessionIssue { session_id })?)
+    }
+
+    fn write_agent_request(
+        &self,
+        target_agent_id: &str,
+        request: &AgentRequest,
+    ) -> Result<PushOutcome> {
+        expect_push(self.execute(Command::WriteAgentRequest {
+            target_agent_id: target_agent_id.to_string(),
+            request: request.clone(),
+        })?)
+    }
+
+    fn write_agent_ack(&self, target_agent_id: &str, ack: &AgentRequestAck) -> Result<PushOutcome> {
+        expect_push(self.execute(Command::WriteAgentAck {
+            target_agent_id: target_agent_id.to_string(),
+            ack: ack.clone(),
+        })?)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OwnedIssueUpdate {
+    pub title: Option<String>,
+    pub description: DescriptionChange,
+    pub status: Option<String>,
+    pub priority: Option<String>,
+    pub scheduled_at: DateTimeChange,
+    pub due_at: DateTimeChange,
+}
+
+impl OwnedIssueUpdate {
+    #[must_use]
+    pub fn status(status: &str) -> Self {
+        Self {
+            title: None,
+            description: DescriptionChange::Unchanged,
+            status: Some(status.to_string()),
+            priority: None,
+            scheduled_at: DateTimeChange::Unchanged,
+            due_at: DateTimeChange::Unchanged,
+        }
+    }
+}
+
+pub trait QueryService {
+    fn get_issue(&self, id: i64) -> Result<Option<Issue>>;
+    fn require_issue(&self, id: i64) -> Result<Issue>;
+    fn list_issues(
+        &self,
+        status: Option<&str>,
+        label: Option<&str>,
+        priority: Option<&str>,
+    ) -> Result<Vec<Issue>>;
+    fn search_issues(&self, query: &str) -> Result<Vec<Issue>>;
+    fn get_subissues(&self, parent_id: i64) -> Result<Vec<Issue>>;
+    fn get_labels(&self, issue_id: i64) -> Result<Vec<String>>;
+    fn get_labels_batch(
+        &self,
+        issue_ids: &[i64],
+    ) -> Result<std::collections::HashMap<i64, Vec<String>>>;
+    fn get_comments(&self, issue_id: i64) -> Result<Vec<Comment>>;
+    fn search_comments(&self, query: &str) -> Result<Vec<(Comment, i64, String)>>;
+    fn get_blockers(&self, issue_id: i64) -> Result<Vec<i64>>;
+    fn get_blocking(&self, issue_id: i64) -> Result<Vec<i64>>;
+    fn get_blocker_counts_batch(
+        &self,
+        issue_ids: &[i64],
+    ) -> Result<std::collections::HashMap<i64, usize>>;
+    fn list_blocked_issues(&self) -> Result<Vec<Issue>>;
+    fn list_ready_issues(&self) -> Result<Vec<Issue>>;
+    fn list_archived_issues(&self) -> Result<Vec<Issue>>;
+    fn get_related_issues(&self, issue_id: i64) -> Result<Vec<Issue>>;
+    fn get_related_issue_ids(&self, issue_id: i64) -> Result<Vec<i64>>;
+    fn get_milestone(&self, id: i64) -> Result<Option<Milestone>>;
+    fn list_milestones(&self, status: Option<&str>) -> Result<Vec<Milestone>>;
+    fn get_milestone_issues(&self, milestone_id: i64) -> Result<Vec<Issue>>;
+    fn get_issue_milestone(&self, issue_id: i64) -> Result<Option<Milestone>>;
+    fn get_milestone_uuid_for_issue(&self, issue_id: i64) -> Result<Option<String>>;
+    fn count_issues_since(&self, since: &str) -> Result<i64>;
+    fn count_comments_since(&self, since: &str) -> Result<i64>;
+    fn get_issue_count(&self) -> Result<i64>;
+    fn get_milestone_count(&self) -> Result<i64>;
+    fn get_issue_uuid_by_id(&self, id: i64) -> Result<String>;
+    fn get_issue_export_metadata(&self, id: i64) -> Result<(Option<String>, Option<String>)>;
+    fn get_comments_with_author(&self, issue_id: i64) -> Result<Vec<crate::db::CommentAuthorRow>>;
+    fn get_time_entries_for_issue(&self, issue_id: i64) -> Result<Vec<crate::db::TimeEntryRow>>;
+    fn authority_mode(&self) -> AuthorityMode;
+}
+
+pub trait LocalStateService {
+    fn get_schema_version(&self) -> Result<i32>;
+    fn start_session(&self, agent_id: Option<&str>) -> Result<i64>;
+    fn end_session(&self, id: i64, notes: Option<&str>) -> Result<bool>;
+    fn set_session_action(&self, id: i64, action: &str) -> Result<bool>;
+    fn start_timer(&self, issue_id: i64) -> Result<i64>;
+    fn stop_timer(&self, issue_id: i64) -> Result<bool>;
+    fn get_active_timer(&self) -> Result<Option<(i64, DateTime<Utc>)>>;
+    fn get_total_time(&self, issue_id: i64) -> Result<i64>;
+    fn get_current_session_for_agent(&self, agent_id: Option<&str>) -> Result<Option<Session>>;
+    fn get_last_session_for_agent(&self, agent_id: Option<&str>) -> Result<Option<Session>>;
+    fn record_token_usage(&self, usage: &LocalTokenUsage) -> Result<i64>;
+    fn get_token_usage(&self, id: i64) -> Result<Option<TokenUsage>>;
+    fn list_token_usage(
+        &self,
+        agent_id: Option<&str>,
+        session_id: Option<i64>,
+        model: Option<&str>,
+        from: Option<&str>,
+        to: Option<&str>,
+        limit: Option<i64>,
+    ) -> Result<Vec<TokenUsage>>;
+    fn get_usage_summary(
+        &self,
+        agent_id: Option<&str>,
+        from: Option<&str>,
+        to: Option<&str>,
+    ) -> Result<Vec<UsageSummaryRow>>;
+    fn insert_sentinel_run(&self, run_id: &str, mode: &str) -> Result<i64>;
+    fn complete_sentinel_run(&self, run_id: &str, counters: &RunCounters) -> Result<()>;
+    fn list_sentinel_runs(&self, limit: usize) -> Result<Vec<SentinelRun>>;
+    fn insert_sentinel_dispatch(&self, dispatch: &NewDispatch<'_>) -> Result<i64>;
+    fn update_dispatch_outcome(
+        &self,
+        dispatch_id: i64,
+        outcome: &str,
+        outcome_detail: &str,
+    ) -> Result<()>;
+    fn get_pending_dispatches(&self) -> Result<Vec<SentinelDispatch>>;
+    fn count_pending_dispatches(&self) -> Result<i64>;
+    fn get_latest_dispatch_for_signal(
+        &self,
+        issue_number: i64,
+        label: &str,
+    ) -> Result<Option<SentinelDispatch>>;
+    fn load_dispatch_seen_set(&self) -> Result<Vec<SentinelDispatch>>;
+    fn list_dispatches_for_run(&self, run_id: &str) -> Result<Vec<SentinelDispatch>>;
+    fn get_dispatch_metrics(&self) -> Result<Vec<DispatchMetric>>;
+    fn get_repeat_failure_counts(&self) -> Result<Vec<(String, i64)>>;
+    fn get_escalation_heavy_counts(&self) -> Result<Vec<(String, i64, i64, i64)>>;
+}
+
+pub struct RepositoryService<'a> {
+    database: &'a Database,
+    writer: Option<SharedWriter>,
+    allow_domain_commands: bool,
+    operation_dir: Option<PathBuf>,
+}
+
+impl<'a> RepositoryService<'a> {
+    pub fn new(database: &'a Database, crosslink_dir: &Path) -> Result<Self> {
+        let writer = SharedWriter::new(crosslink_dir)?;
+        Ok(Self {
+            database,
+            writer,
+            allow_domain_commands: true,
+            operation_dir: Some(crosslink_dir.to_path_buf()),
+        })
+    }
+
+    pub const fn projection(database: &'a Database) -> Self {
+        Self {
+            database,
+            writer: None,
+            allow_domain_commands: false,
+            operation_dir: None,
+        }
+    }
+
+    pub fn local_state(database: &'a Database, crosslink_dir: &Path) -> Self {
+        Self {
+            database,
+            writer: None,
+            allow_domain_commands: false,
+            operation_dir: Some(crosslink_dir.to_path_buf()),
+        }
+    }
+
+    pub fn for_kickoff(database: &'a Database, crosslink_dir: &Path) -> Result<Self> {
+        if crate::identity::AgentConfig::load(crosslink_dir)?.is_some() {
+            let sync = crate::sync::SyncManager::new(crosslink_dir)?;
+            if !sync.remote_exists() && !sync.is_initialized() {
+                sync.init_cache()
+                    .context("failed to initialize local Git authority for kickoff")?;
+                match crate::reconcile::migration::activate_repository(crosslink_dir)
+                    .context("failed to reconcile local Git authority for kickoff")?
+                {
+                    crate::reconcile::migration::RepositoryActivation::ReadyCurrent { .. }
+                    | crate::reconcile::migration::RepositoryActivation::ReadyMigrated { .. }
+                    | crate::reconcile::migration::RepositoryActivation::ReadyAdopted { .. } => {}
+                    crate::reconcile::migration::RepositoryActivation::WaitingForRemote {
+                        reason,
+                    } => bail!("local kickoff reconciliation is waiting for remote: {reason}"),
+                    crate::reconcile::migration::RepositoryActivation::BlockedCorrupt {
+                        reason,
+                    } => bail!("local kickoff reconciliation is blocked: {reason}"),
+                }
+            }
+        }
+        Self::new(database, crosslink_dir)
+    }
+
+    fn issue_update<'b>(
+        title: &'b Option<String>,
+        description: &'b DescriptionChange,
+        status: &'b Option<String>,
+        priority: &'b Option<String>,
+        scheduled_at: DateTimeChange,
+        due_at: DateTimeChange,
+    ) -> IssueUpdate<'b> {
+        let description = match description {
+            DescriptionChange::Unchanged => DescriptionUpdate::Unchanged,
+            DescriptionChange::Clear => DescriptionUpdate::Clear,
+            DescriptionChange::Set(value) => DescriptionUpdate::Set(value),
+        };
+        IssueUpdate {
+            title: title.as_deref(),
+            description,
+            status: status.as_deref(),
+            priority: priority.as_deref(),
+            scheduled_at: map_datetime_change(scheduled_at),
+            due_at: map_datetime_change(due_at),
+        }
+    }
+
+    fn acquire_operation(
+        &self,
+    ) -> Result<Option<crate::reconcile::readiness::MutationOperationPermit>> {
+        self.operation_dir
+            .as_deref()
+            .map(crate::reconcile::readiness::acquire_mutation_operation_permit)
+            .transpose()
+    }
+}
+
+impl CommandService for RepositoryService<'_> {
+    fn execute(&self, command: Command) -> Result<CommandResult> {
+        if !self.allow_domain_commands
+            && !matches!(
+                &command,
+                Command::SetSessionIssue { .. } | Command::ClearSessionIssue { .. }
+            )
+        {
+            bail!("domain mutation is unavailable through a projection-only service");
+        }
+        let _operation = self.acquire_operation()?;
+        match command {
+            Command::CreateIssue {
+                title,
+                description,
+                priority,
+                labels,
+                scheduled_at,
+                due_at,
+            } => {
+                let id = if let Some(writer) = &self.writer {
+                    let id = writer.create_issue(
+                        self.database,
+                        &title,
+                        description.as_deref(),
+                        &priority,
+                        scheduled_at,
+                        due_at,
+                    )?;
+                    for label in labels {
+                        writer.add_label(self.database, id, &label)?;
+                    }
+                    id
+                } else {
+                    if scheduled_at.is_some() || due_at.is_some() {
+                        bail!("scheduling dates require shared Git authority");
+                    }
+                    self.database.transaction(|| {
+                        let id = self.database.create_issue(
+                            &title,
+                            description.as_deref(),
+                            &priority,
+                        )?;
+                        for label in labels {
+                            self.database.add_label(id, &label)?;
+                        }
+                        Ok(id)
+                    })?
+                };
+                Ok(CommandResult::Id(id))
+            }
+            Command::CreateSubissue {
+                parent_id,
+                title,
+                description,
+                priority,
+                labels,
+            } => {
+                let id = if let Some(writer) = &self.writer {
+                    let id = writer.create_subissue(
+                        self.database,
+                        parent_id,
+                        &title,
+                        description.as_deref(),
+                        &priority,
+                    )?;
+                    for label in labels {
+                        writer.add_label(self.database, id, &label)?;
+                    }
+                    id
+                } else {
+                    self.database.transaction(|| {
+                        let id = self.database.create_subissue(
+                            parent_id,
+                            &title,
+                            description.as_deref(),
+                            &priority,
+                        )?;
+                        for label in labels {
+                            self.database.add_label(id, &label)?;
+                        }
+                        Ok(id)
+                    })?
+                };
+                Ok(CommandResult::Id(id))
+            }
+            Command::ImportIssues { specs } => {
+                let assigned = if let Some(writer) = &self.writer {
+                    writer.import_issues(self.database, &specs)?
+                } else {
+                    self.database.transaction(|| {
+                        let mut assigned = Vec::with_capacity(specs.len());
+                        let mut uuid_to_id = std::collections::HashMap::new();
+                        for spec in &specs {
+                            let id = self.database.create_issue(
+                                &spec.title,
+                                spec.description.as_deref(),
+                                &spec.priority,
+                            )?;
+                            for label in &spec.labels {
+                                self.database.add_label(id, label)?;
+                            }
+                            for comment in &spec.comments {
+                                self.database
+                                    .add_comment(id, &comment.content, &comment.kind)?;
+                            }
+                            if spec.closed {
+                                self.database.close_issue(id)?;
+                            }
+                            uuid_to_id.insert(spec.uuid, id);
+                            assigned.push((spec.uuid, id));
+                        }
+                        for spec in &specs {
+                            let issue_id = uuid_to_id[&spec.uuid];
+                            if let Some(parent_uuid) = spec.parent_uuid {
+                                if let Some(parent_id) = uuid_to_id.get(&parent_uuid) {
+                                    self.database.update_parent(issue_id, Some(*parent_id))?;
+                                }
+                            }
+                            for blocker_uuid in &spec.blockers {
+                                if let Some(blocker_id) = uuid_to_id.get(blocker_uuid) {
+                                    self.database.add_dependency(issue_id, *blocker_id)?;
+                                }
+                            }
+                        }
+                        Ok(assigned)
+                    })?
+                };
+                Ok(CommandResult::Imported(assigned))
+            }
+            Command::UpdateIssue {
+                id,
+                title,
+                description,
+                status,
+                priority,
+                scheduled_at,
+                due_at,
+            } => {
+                let update = Self::issue_update(
+                    &title,
+                    &description,
+                    &status,
+                    &priority,
+                    scheduled_at,
+                    due_at,
+                );
+                if let Some(writer) = &self.writer {
+                    let metadata_changed = update.title.is_some()
+                        || !matches!(update.description, DescriptionUpdate::Unchanged)
+                        || update.priority.is_some()
+                        || !matches!(update.scheduled_at, FieldUpdate::Unchanged)
+                        || !matches!(update.due_at, FieldUpdate::Unchanged);
+                    let current_status = self.database.get_issue(id)?.map(|issue| issue.status);
+                    match (update.status, metadata_changed, current_status) {
+                        (Some("archived"), false, Some(crate::models::IssueStatus::Closed))
+                        | (Some("closed"), false, Some(crate::models::IssueStatus::Archived)) => {
+                            writer.update_issue(self.database, id, update)?;
+                        }
+                        (Some("archived"), false, Some(status)) => {
+                            bail!("can only archive a closed issue, found '{status}'");
+                        }
+                        (Some("archived"), false, None) => bail!("issue #{id} not found"),
+                        (Some("closed"), false, _) => writer.close_issue(self.database, id)?,
+                        (Some("open"), false, _) => writer.reopen_issue(self.database, id)?,
+                        _ => writer.update_issue(self.database, id, update)?,
+                    }
+                } else {
+                    if !matches!(scheduled_at, DateTimeChange::Unchanged)
+                        || !matches!(due_at, DateTimeChange::Unchanged)
+                    {
+                        bail!("scheduling dates require shared Git authority");
+                    }
+                    let description = match update.description {
+                        DescriptionUpdate::Unchanged => None,
+                        DescriptionUpdate::Clear => Some(""),
+                        DescriptionUpdate::Set(value) => Some(value),
+                    };
+                    if !self.database.update_issue(
+                        id,
+                        update.title,
+                        description,
+                        update.priority,
+                    )? {
+                        bail!("issue #{id} not found");
+                    }
+                    if matches!(update.description, DescriptionUpdate::Clear) {
+                        self.database
+                            .conn
+                            .execute("UPDATE issues SET description = NULL WHERE id = ?1", [id])?;
+                    }
+                    if let Some(status) = update.status {
+                        match status {
+                            "open" => {
+                                self.database.reopen_issue(id)?;
+                            }
+                            "closed" => {
+                                let current = self.database.require_issue(id)?;
+                                if current.status == crate::models::IssueStatus::Archived {
+                                    self.database.unarchive_issue(id)?;
+                                } else {
+                                    self.database.close_issue(id)?;
+                                }
+                            }
+                            "archived" => {
+                                if !self.database.archive_issue(id)? {
+                                    bail!("can only archive a closed issue");
+                                }
+                            }
+                            other => bail!("unsupported issue status '{other}'"),
+                        }
+                    }
+                }
+                Ok(CommandResult::None)
+            }
+            Command::DeleteIssue { id } => {
+                if let Some(writer) = &self.writer {
+                    writer.delete_issue(self.database, id)?;
+                } else if !self.database.delete_issue(id)? {
+                    bail!("issue #{id} not found");
+                }
+                Ok(CommandResult::None)
+            }
+            Command::ArchiveIssue { id } => {
+                let issue = self.database.require_issue(id)?;
+                if issue.status != crate::models::IssueStatus::Closed {
+                    bail!("can only archive a closed issue, found '{}'", issue.status);
+                }
+                if let Some(writer) = &self.writer {
+                    writer.update_issue(
+                        self.database,
+                        id,
+                        IssueUpdate {
+                            status: Some("archived"),
+                            ..IssueUpdate::default()
+                        },
+                    )?;
+                } else if !self.database.archive_issue(id)? {
+                    bail!("issue #{id} not found or not closed");
+                }
+                Ok(CommandResult::None)
+            }
+            Command::UnarchiveIssue { id } => {
+                let issue = self.database.require_issue(id)?;
+                if issue.status != crate::models::IssueStatus::Archived {
+                    bail!("issue #{id} not found or not archived");
+                }
+                if let Some(writer) = &self.writer {
+                    writer.update_issue(
+                        self.database,
+                        id,
+                        IssueUpdate {
+                            status: Some("closed"),
+                            ..IssueUpdate::default()
+                        },
+                    )?;
+                } else if !self.database.unarchive_issue(id)? {
+                    bail!("issue #{id} not found or not archived");
+                }
+                Ok(CommandResult::None)
+            }
+            Command::AddComment {
+                issue_id,
+                content,
+                kind,
+            } => {
+                let id = if let Some(writer) = &self.writer {
+                    writer.add_comment(self.database, issue_id, &content, &kind)?
+                } else {
+                    self.database.add_comment(issue_id, &content, &kind)?
+                };
+                Ok(CommandResult::Id(id))
+            }
+            Command::AddIntervention {
+                issue_id,
+                content,
+                trigger_type,
+                context,
+                driver_key_fingerprint,
+            } => {
+                let id = if let Some(writer) = &self.writer {
+                    writer.add_intervention_comment(
+                        self.database,
+                        issue_id,
+                        &content,
+                        &trigger_type,
+                        context.as_deref(),
+                        driver_key_fingerprint.as_deref(),
+                    )?
+                } else {
+                    self.database.add_intervention_comment(
+                        issue_id,
+                        &content,
+                        &trigger_type,
+                        context.as_deref(),
+                        driver_key_fingerprint.as_deref(),
+                    )?
+                };
+                Ok(CommandResult::Id(id))
+            }
+            Command::AddLabel { issue_id, label } => {
+                Ok(CommandResult::Changed(if let Some(writer) = &self.writer {
+                    writer.add_label(self.database, issue_id, &label)?
+                } else {
+                    self.database.add_label(issue_id, &label)?
+                }))
+            }
+            Command::RemoveLabel { issue_id, label } => {
+                Ok(CommandResult::Changed(if let Some(writer) = &self.writer {
+                    writer.remove_label(self.database, issue_id, &label)?
+                } else {
+                    self.database.remove_label(issue_id, &label)?
+                }))
+            }
+            Command::AddDependency {
+                issue_id,
+                blocker_id,
+            } => Ok(CommandResult::Changed(if let Some(writer) = &self.writer {
+                writer.add_blocker(self.database, issue_id, blocker_id)?
+            } else {
+                self.database.add_dependency(issue_id, blocker_id)?
+            })),
+            Command::RemoveDependency {
+                issue_id,
+                blocker_id,
+            } => Ok(CommandResult::Changed(if let Some(writer) = &self.writer {
+                writer.remove_blocker(self.database, issue_id, blocker_id)?
+            } else {
+                self.database.remove_dependency(issue_id, blocker_id)?
+            })),
+            Command::AddRelation {
+                issue_id,
+                related_id,
+            } => Ok(CommandResult::Changed(if let Some(writer) = &self.writer {
+                writer.add_relation(self.database, issue_id, related_id)?
+            } else {
+                self.database.add_relation(issue_id, related_id)?
+            })),
+            Command::RemoveRelation {
+                issue_id,
+                related_id,
+            } => Ok(CommandResult::Changed(if let Some(writer) = &self.writer {
+                writer.remove_relation(self.database, issue_id, related_id)?
+            } else {
+                self.database.remove_relation(issue_id, related_id)?
+            })),
+            Command::CreateMilestone { name, description } => {
+                let id = if let Some(writer) = &self.writer {
+                    writer.create_milestone(self.database, &name, description.as_deref())?
+                } else {
+                    self.database
+                        .create_milestone(&name, description.as_deref())?
+                };
+                Ok(CommandResult::Id(id))
+            }
+            Command::AssignMilestone {
+                milestone_id,
+                issue_ids,
+            } => {
+                if let Some(writer) = &self.writer {
+                    writer.set_milestone_on_issues(self.database, milestone_id, &issue_ids)?;
+                } else {
+                    for issue_id in issue_ids {
+                        self.database
+                            .add_issue_to_milestone(milestone_id, issue_id)?;
+                    }
+                }
+                Ok(CommandResult::None)
+            }
+            Command::ClearMilestone {
+                milestone_id,
+                issue_id,
+            } => {
+                let changed = if let Some(writer) = &self.writer {
+                    writer.clear_milestone_on_issue(self.database, issue_id)?;
+                    true
+                } else {
+                    self.database
+                        .remove_issue_from_milestone(milestone_id, issue_id)?
+                };
+                Ok(CommandResult::Changed(changed))
+            }
+            Command::CloseMilestone { id } => {
+                if let Some(writer) = &self.writer {
+                    writer.close_milestone(self.database, id)?;
+                } else if !self.database.close_milestone(id)? {
+                    bail!("milestone #{id} not found");
+                }
+                Ok(CommandResult::None)
+            }
+            Command::DeleteMilestone { id } => {
+                if let Some(writer) = &self.writer {
+                    writer.delete_milestone(self.database, id)?;
+                } else if !self.database.delete_milestone(id)? {
+                    bail!("milestone #{id} not found");
+                }
+                Ok(CommandResult::None)
+            }
+            Command::ClaimLock { issue_id, branch } => {
+                let writer = self.writer.as_ref().ok_or_else(|| {
+                    anyhow::anyhow!("locks require configured shared Git authority")
+                })?;
+                Ok(CommandResult::Lock(
+                    writer.claim_lock_v2(issue_id, branch.as_deref())?,
+                ))
+            }
+            Command::ReleaseLock { issue_id } => {
+                Ok(CommandResult::Changed(if let Some(writer) = &self.writer {
+                    writer.release_lock_v2(issue_id)?
+                } else {
+                    false
+                }))
+            }
+            Command::StealLock {
+                issue_id,
+                stale_agent_id,
+                branch,
+            } => {
+                let writer = self.writer.as_ref().ok_or_else(|| {
+                    anyhow::anyhow!("locks require configured shared Git authority")
+                })?;
+                Ok(CommandResult::Lock(writer.steal_lock_v2(
+                    issue_id,
+                    &stale_agent_id,
+                    branch.as_deref(),
+                )?))
+            }
+            Command::ForceReleaseLock {
+                issue_id,
+                stale_agent_id,
+            } => {
+                let writer = self.writer.as_ref().ok_or_else(|| {
+                    anyhow::anyhow!("locks require configured shared Git authority")
+                })?;
+                Ok(CommandResult::Changed(
+                    writer.force_release_lock_v2(issue_id, &stale_agent_id)?,
+                ))
+            }
+            Command::SetSessionIssue {
+                session_id,
+                issue_id,
+            } => Ok(CommandResult::Changed(
+                self.database.set_session_issue(session_id, issue_id)?,
+            )),
+            Command::ClearSessionIssue { session_id } => Ok(CommandResult::Changed(
+                self.database.clear_session_issue(session_id)?,
+            )),
+            Command::WriteAgentRequest {
+                target_agent_id,
+                request,
+            } => {
+                let writer = self.writer.as_ref().ok_or_else(|| {
+                    anyhow::anyhow!("agent requests require configured shared Git authority")
+                })?;
+                Ok(CommandResult::Push(
+                    writer.write_agent_request(&target_agent_id, &request)?,
+                ))
+            }
+            Command::WriteAgentAck {
+                target_agent_id,
+                ack,
+            } => {
+                let writer = self.writer.as_ref().ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "agent acknowledgements require configured shared Git authority"
+                    )
+                })?;
+                Ok(CommandResult::Push(
+                    writer.write_agent_ack(&target_agent_id, &ack)?,
+                ))
+            }
+        }
+    }
+}
+
+impl QueryService for RepositoryService<'_> {
+    fn get_issue(&self, id: i64) -> Result<Option<Issue>> {
+        self.database.get_issue(id)
+    }
+
+    fn require_issue(&self, id: i64) -> Result<Issue> {
+        self.database.require_issue(id)
+    }
+
+    fn list_issues(
+        &self,
+        status: Option<&str>,
+        label: Option<&str>,
+        priority: Option<&str>,
+    ) -> Result<Vec<Issue>> {
+        self.database.list_issues(status, label, priority)
+    }
+
+    fn search_issues(&self, query: &str) -> Result<Vec<Issue>> {
+        self.database.search_issues(query)
+    }
+
+    fn get_subissues(&self, parent_id: i64) -> Result<Vec<Issue>> {
+        self.database.get_subissues(parent_id)
+    }
+
+    fn get_labels(&self, issue_id: i64) -> Result<Vec<String>> {
+        self.database.get_labels(issue_id)
+    }
+
+    fn get_labels_batch(
+        &self,
+        issue_ids: &[i64],
+    ) -> Result<std::collections::HashMap<i64, Vec<String>>> {
+        self.database.get_labels_batch(issue_ids)
+    }
+
+    fn get_comments(&self, issue_id: i64) -> Result<Vec<Comment>> {
+        self.database.get_comments(issue_id)
+    }
+
+    fn search_comments(&self, query: &str) -> Result<Vec<(Comment, i64, String)>> {
+        self.database.search_comments(query)
+    }
+
+    fn get_blockers(&self, issue_id: i64) -> Result<Vec<i64>> {
+        self.database.get_blockers(issue_id)
+    }
+
+    fn get_blocking(&self, issue_id: i64) -> Result<Vec<i64>> {
+        self.database.get_blocking(issue_id)
+    }
+
+    fn get_blocker_counts_batch(
+        &self,
+        issue_ids: &[i64],
+    ) -> Result<std::collections::HashMap<i64, usize>> {
+        self.database.get_blocker_counts_batch(issue_ids)
+    }
+
+    fn list_blocked_issues(&self) -> Result<Vec<Issue>> {
+        self.database.list_blocked_issues()
+    }
+
+    fn list_ready_issues(&self) -> Result<Vec<Issue>> {
+        self.database.list_ready_issues()
+    }
+
+    fn list_archived_issues(&self) -> Result<Vec<Issue>> {
+        self.database.list_archived_issues()
+    }
+
+    fn get_related_issues(&self, issue_id: i64) -> Result<Vec<Issue>> {
+        self.database.get_related_issues(issue_id)
+    }
+
+    fn get_related_issue_ids(&self, issue_id: i64) -> Result<Vec<i64>> {
+        self.database.get_related_issue_ids(issue_id)
+    }
+
+    fn get_milestone(&self, id: i64) -> Result<Option<Milestone>> {
+        self.database.get_milestone(id)
+    }
+
+    fn list_milestones(&self, status: Option<&str>) -> Result<Vec<Milestone>> {
+        self.database.list_milestones(status)
+    }
+
+    fn get_milestone_issues(&self, milestone_id: i64) -> Result<Vec<Issue>> {
+        self.database.get_milestone_issues(milestone_id)
+    }
+
+    fn get_issue_milestone(&self, issue_id: i64) -> Result<Option<Milestone>> {
+        self.database.get_issue_milestone(issue_id)
+    }
+
+    fn get_milestone_uuid_for_issue(&self, issue_id: i64) -> Result<Option<String>> {
+        self.database.get_milestone_uuid_for_issue(issue_id)
+    }
+
+    fn count_issues_since(&self, since: &str) -> Result<i64> {
+        self.database.count_issues_since(since)
+    }
+
+    fn count_comments_since(&self, since: &str) -> Result<i64> {
+        self.database.count_comments_since(since)
+    }
+
+    fn get_issue_count(&self) -> Result<i64> {
+        self.database.get_issue_count()
+    }
+
+    fn get_milestone_count(&self) -> Result<i64> {
+        self.database.get_milestone_count()
+    }
+
+    fn get_issue_uuid_by_id(&self, id: i64) -> Result<String> {
+        self.database.get_issue_uuid_by_id(id)
+    }
+
+    fn get_issue_export_metadata(&self, id: i64) -> Result<(Option<String>, Option<String>)> {
+        self.database.get_issue_export_metadata(id)
+    }
+
+    fn get_comments_with_author(&self, issue_id: i64) -> Result<Vec<crate::db::CommentAuthorRow>> {
+        self.database.get_comments_with_author(issue_id)
+    }
+
+    fn get_time_entries_for_issue(&self, issue_id: i64) -> Result<Vec<crate::db::TimeEntryRow>> {
+        self.database.get_time_entries_for_issue(issue_id)
+    }
+
+    fn authority_mode(&self) -> AuthorityMode {
+        if self.writer.is_some() {
+            AuthorityMode::Shared
+        } else {
+            AuthorityMode::Local
+        }
+    }
+}
+
+impl LocalStateService for RepositoryService<'_> {
+    fn get_schema_version(&self) -> Result<i32> {
+        self.database.get_schema_version()
+    }
+
+    fn start_session(&self, agent_id: Option<&str>) -> Result<i64> {
+        let _operation = self.acquire_operation()?;
+        self.database.start_session_with_agent(agent_id)
+    }
+
+    fn end_session(&self, id: i64, notes: Option<&str>) -> Result<bool> {
+        let _operation = self.acquire_operation()?;
+        self.database.end_session(id, notes)
+    }
+
+    fn set_session_action(&self, id: i64, action: &str) -> Result<bool> {
+        let _operation = self.acquire_operation()?;
+        self.database.set_session_action(id, action)
+    }
+
+    fn start_timer(&self, issue_id: i64) -> Result<i64> {
+        let _operation = self.acquire_operation()?;
+        self.database.start_timer(issue_id)
+    }
+
+    fn stop_timer(&self, issue_id: i64) -> Result<bool> {
+        let _operation = self.acquire_operation()?;
+        self.database.stop_timer(issue_id)
+    }
+
+    fn get_active_timer(&self) -> Result<Option<(i64, DateTime<Utc>)>> {
+        self.database.get_active_timer()
+    }
+
+    fn get_total_time(&self, issue_id: i64) -> Result<i64> {
+        self.database.get_total_time(issue_id)
+    }
+
+    fn get_current_session_for_agent(&self, agent_id: Option<&str>) -> Result<Option<Session>> {
+        self.database.get_current_session_for_agent(agent_id)
+    }
+
+    fn get_last_session_for_agent(&self, agent_id: Option<&str>) -> Result<Option<Session>> {
+        self.database.get_last_session_for_agent(agent_id)
+    }
+
+    fn record_token_usage(&self, usage: &LocalTokenUsage) -> Result<i64> {
+        let _operation = self.acquire_operation()?;
+        self.database.create_token_usage_for_provider(
+            &usage.agent_id,
+            usage.session_id,
+            &usage.provider,
+            usage.input_tokens,
+            usage.output_tokens,
+            usage.cached_input_tokens,
+            usage.reasoning_output_tokens,
+            usage.cache_read_tokens,
+            usage.cache_creation_tokens,
+            &usage.model,
+            usage.cost_estimate,
+            usage.provider_metadata_json.as_deref(),
+        )
+    }
+
+    fn get_token_usage(&self, id: i64) -> Result<Option<TokenUsage>> {
+        self.database.get_token_usage(id)
+    }
+
+    fn list_token_usage(
+        &self,
+        agent_id: Option<&str>,
+        session_id: Option<i64>,
+        model: Option<&str>,
+        from: Option<&str>,
+        to: Option<&str>,
+        limit: Option<i64>,
+    ) -> Result<Vec<TokenUsage>> {
+        self.database
+            .list_token_usage(agent_id, session_id, model, from, to, limit)
+    }
+
+    fn get_usage_summary(
+        &self,
+        agent_id: Option<&str>,
+        from: Option<&str>,
+        to: Option<&str>,
+    ) -> Result<Vec<UsageSummaryRow>> {
+        self.database.get_usage_summary(agent_id, from, to)
+    }
+
+    fn insert_sentinel_run(&self, run_id: &str, mode: &str) -> Result<i64> {
+        let _operation = self.acquire_operation()?;
+        self.database.insert_sentinel_run(run_id, mode)
+    }
+
+    fn complete_sentinel_run(&self, run_id: &str, counters: &RunCounters) -> Result<()> {
+        let _operation = self.acquire_operation()?;
+        self.database.complete_sentinel_run(run_id, counters)
+    }
+
+    fn list_sentinel_runs(&self, limit: usize) -> Result<Vec<SentinelRun>> {
+        self.database.list_sentinel_runs(limit)
+    }
+
+    fn insert_sentinel_dispatch(&self, dispatch: &NewDispatch<'_>) -> Result<i64> {
+        let _operation = self.acquire_operation()?;
+        self.database.insert_sentinel_dispatch(dispatch)
+    }
+
+    fn update_dispatch_outcome(
+        &self,
+        dispatch_id: i64,
+        outcome: &str,
+        outcome_detail: &str,
+    ) -> Result<()> {
+        let _operation = self.acquire_operation()?;
+        self.database
+            .update_dispatch_outcome(dispatch_id, outcome, outcome_detail)
+    }
+
+    fn get_pending_dispatches(&self) -> Result<Vec<SentinelDispatch>> {
+        self.database.get_pending_dispatches()
+    }
+
+    fn count_pending_dispatches(&self) -> Result<i64> {
+        self.database.count_pending_dispatches()
+    }
+
+    fn get_latest_dispatch_for_signal(
+        &self,
+        issue_number: i64,
+        label: &str,
+    ) -> Result<Option<SentinelDispatch>> {
+        self.database
+            .get_latest_dispatch_for_signal(issue_number, label)
+    }
+
+    fn load_dispatch_seen_set(&self) -> Result<Vec<SentinelDispatch>> {
+        self.database.load_dispatch_seen_set()
+    }
+
+    fn list_dispatches_for_run(&self, run_id: &str) -> Result<Vec<SentinelDispatch>> {
+        self.database.list_dispatches_for_run(run_id)
+    }
+
+    fn get_dispatch_metrics(&self) -> Result<Vec<DispatchMetric>> {
+        self.database.get_dispatch_metrics()
+    }
+
+    fn get_repeat_failure_counts(&self) -> Result<Vec<(String, i64)>> {
+        self.database.get_repeat_failure_counts()
+    }
+
+    fn get_escalation_heavy_counts(&self) -> Result<Vec<(String, i64, i64, i64)>> {
+        self.database.get_escalation_heavy_counts()
+    }
+}
+
+const fn map_datetime_change(change: DateTimeChange) -> FieldUpdate<DateTime<Utc>> {
+    match change {
+        DateTimeChange::Unchanged => FieldUpdate::Unchanged,
+        DateTimeChange::Clear => FieldUpdate::Clear,
+        DateTimeChange::Set(value) => FieldUpdate::Set(value),
+    }
+}
+
+fn expect_none(result: CommandResult) -> Result<()> {
+    match result {
+        CommandResult::None => Ok(()),
+        other => bail!("command returned unexpected result: {other:?}"),
+    }
+}
+
+fn expect_id(result: CommandResult) -> Result<i64> {
+    match result {
+        CommandResult::Id(id) => Ok(id),
+        other => bail!("command returned unexpected result: {other:?}"),
+    }
+}
+
+fn expect_changed(result: CommandResult) -> Result<bool> {
+    match result {
+        CommandResult::Changed(changed) => Ok(changed),
+        other => bail!("command returned unexpected result: {other:?}"),
+    }
+}
+
+fn expect_lock(result: CommandResult) -> Result<LockClaimResult> {
+    match result {
+        CommandResult::Lock(result) => Ok(result),
+        other => bail!("command returned unexpected result: {other:?}"),
+    }
+}
+
+fn expect_push(result: CommandResult) -> Result<PushOutcome> {
+    match result {
+        CommandResult::Push(result) => Ok(result),
+        other => bail!("command returned unexpected result: {other:?}"),
+    }
+}
+
+#[cfg(test)]
+impl CommandService for Database {
+    fn execute(&self, command: Command) -> Result<CommandResult> {
+        RepositoryService {
+            database: self,
+            writer: None,
+            allow_domain_commands: true,
+            operation_dir: None,
+        }
+        .execute(command)
+    }
+}
+
+impl QueryService for Database {
+    fn get_issue(&self, id: i64) -> Result<Option<Issue>> {
+        Database::get_issue(self, id)
+    }
+
+    fn require_issue(&self, id: i64) -> Result<Issue> {
+        Database::require_issue(self, id)
+    }
+
+    fn list_issues(
+        &self,
+        status: Option<&str>,
+        label: Option<&str>,
+        priority: Option<&str>,
+    ) -> Result<Vec<Issue>> {
+        Database::list_issues(self, status, label, priority)
+    }
+
+    fn search_issues(&self, query: &str) -> Result<Vec<Issue>> {
+        Database::search_issues(self, query)
+    }
+
+    fn get_subissues(&self, parent_id: i64) -> Result<Vec<Issue>> {
+        Database::get_subissues(self, parent_id)
+    }
+
+    fn get_labels(&self, issue_id: i64) -> Result<Vec<String>> {
+        Database::get_labels(self, issue_id)
+    }
+
+    fn get_labels_batch(
+        &self,
+        issue_ids: &[i64],
+    ) -> Result<std::collections::HashMap<i64, Vec<String>>> {
+        Database::get_labels_batch(self, issue_ids)
+    }
+
+    fn get_comments(&self, issue_id: i64) -> Result<Vec<Comment>> {
+        Database::get_comments(self, issue_id)
+    }
+
+    fn search_comments(&self, query: &str) -> Result<Vec<(Comment, i64, String)>> {
+        Database::search_comments(self, query)
+    }
+
+    fn get_blockers(&self, issue_id: i64) -> Result<Vec<i64>> {
+        Database::get_blockers(self, issue_id)
+    }
+
+    fn get_blocking(&self, issue_id: i64) -> Result<Vec<i64>> {
+        Database::get_blocking(self, issue_id)
+    }
+
+    fn get_blocker_counts_batch(
+        &self,
+        issue_ids: &[i64],
+    ) -> Result<std::collections::HashMap<i64, usize>> {
+        Database::get_blocker_counts_batch(self, issue_ids)
+    }
+
+    fn list_blocked_issues(&self) -> Result<Vec<Issue>> {
+        Database::list_blocked_issues(self)
+    }
+
+    fn list_ready_issues(&self) -> Result<Vec<Issue>> {
+        Database::list_ready_issues(self)
+    }
+
+    fn list_archived_issues(&self) -> Result<Vec<Issue>> {
+        Database::list_archived_issues(self)
+    }
+
+    fn get_related_issues(&self, issue_id: i64) -> Result<Vec<Issue>> {
+        Database::get_related_issues(self, issue_id)
+    }
+
+    fn get_related_issue_ids(&self, issue_id: i64) -> Result<Vec<i64>> {
+        Database::get_related_issue_ids(self, issue_id)
+    }
+
+    fn get_milestone(&self, id: i64) -> Result<Option<Milestone>> {
+        Database::get_milestone(self, id)
+    }
+
+    fn list_milestones(&self, status: Option<&str>) -> Result<Vec<Milestone>> {
+        Database::list_milestones(self, status)
+    }
+
+    fn get_milestone_issues(&self, milestone_id: i64) -> Result<Vec<Issue>> {
+        Database::get_milestone_issues(self, milestone_id)
+    }
+
+    fn get_issue_milestone(&self, issue_id: i64) -> Result<Option<Milestone>> {
+        Database::get_issue_milestone(self, issue_id)
+    }
+
+    fn get_milestone_uuid_for_issue(&self, issue_id: i64) -> Result<Option<String>> {
+        Database::get_milestone_uuid_for_issue(self, issue_id)
+    }
+
+    fn count_issues_since(&self, since: &str) -> Result<i64> {
+        Database::count_issues_since(self, since)
+    }
+
+    fn count_comments_since(&self, since: &str) -> Result<i64> {
+        Database::count_comments_since(self, since)
+    }
+
+    fn get_issue_count(&self) -> Result<i64> {
+        Database::get_issue_count(self)
+    }
+
+    fn get_milestone_count(&self) -> Result<i64> {
+        Database::get_milestone_count(self)
+    }
+
+    fn get_issue_uuid_by_id(&self, id: i64) -> Result<String> {
+        Database::get_issue_uuid_by_id(self, id)
+    }
+
+    fn get_issue_export_metadata(&self, id: i64) -> Result<(Option<String>, Option<String>)> {
+        Database::get_issue_export_metadata(self, id)
+    }
+
+    fn get_comments_with_author(&self, issue_id: i64) -> Result<Vec<crate::db::CommentAuthorRow>> {
+        Database::get_comments_with_author(self, issue_id)
+    }
+
+    fn get_time_entries_for_issue(&self, issue_id: i64) -> Result<Vec<crate::db::TimeEntryRow>> {
+        Database::get_time_entries_for_issue(self, issue_id)
+    }
+
+    fn authority_mode(&self) -> AuthorityMode {
+        AuthorityMode::Local
+    }
+}
+
+#[cfg(test)]
+impl LocalStateService for Database {
+    fn get_schema_version(&self) -> Result<i32> {
+        Database::get_schema_version(self)
+    }
+
+    fn start_session(&self, agent_id: Option<&str>) -> Result<i64> {
+        Database::start_session_with_agent(self, agent_id)
+    }
+
+    fn end_session(&self, id: i64, notes: Option<&str>) -> Result<bool> {
+        Database::end_session(self, id, notes)
+    }
+
+    fn set_session_action(&self, id: i64, action: &str) -> Result<bool> {
+        Database::set_session_action(self, id, action)
+    }
+
+    fn start_timer(&self, issue_id: i64) -> Result<i64> {
+        Database::start_timer(self, issue_id)
+    }
+
+    fn stop_timer(&self, issue_id: i64) -> Result<bool> {
+        Database::stop_timer(self, issue_id)
+    }
+
+    fn get_active_timer(&self) -> Result<Option<(i64, DateTime<Utc>)>> {
+        Database::get_active_timer(self)
+    }
+
+    fn get_total_time(&self, issue_id: i64) -> Result<i64> {
+        Database::get_total_time(self, issue_id)
+    }
+
+    fn get_current_session_for_agent(&self, agent_id: Option<&str>) -> Result<Option<Session>> {
+        Database::get_current_session_for_agent(self, agent_id)
+    }
+
+    fn get_last_session_for_agent(&self, agent_id: Option<&str>) -> Result<Option<Session>> {
+        Database::get_last_session_for_agent(self, agent_id)
+    }
+
+    fn record_token_usage(&self, usage: &LocalTokenUsage) -> Result<i64> {
+        Database::create_token_usage_for_provider(
+            self,
+            &usage.agent_id,
+            usage.session_id,
+            &usage.provider,
+            usage.input_tokens,
+            usage.output_tokens,
+            usage.cached_input_tokens,
+            usage.reasoning_output_tokens,
+            usage.cache_read_tokens,
+            usage.cache_creation_tokens,
+            &usage.model,
+            usage.cost_estimate,
+            usage.provider_metadata_json.as_deref(),
+        )
+    }
+
+    fn get_token_usage(&self, id: i64) -> Result<Option<TokenUsage>> {
+        Database::get_token_usage(self, id)
+    }
+
+    fn list_token_usage(
+        &self,
+        agent_id: Option<&str>,
+        session_id: Option<i64>,
+        model: Option<&str>,
+        from: Option<&str>,
+        to: Option<&str>,
+        limit: Option<i64>,
+    ) -> Result<Vec<TokenUsage>> {
+        Database::list_token_usage(self, agent_id, session_id, model, from, to, limit)
+    }
+
+    fn get_usage_summary(
+        &self,
+        agent_id: Option<&str>,
+        from: Option<&str>,
+        to: Option<&str>,
+    ) -> Result<Vec<UsageSummaryRow>> {
+        Database::get_usage_summary(self, agent_id, from, to)
+    }
+
+    fn insert_sentinel_run(&self, run_id: &str, mode: &str) -> Result<i64> {
+        Database::insert_sentinel_run(self, run_id, mode)
+    }
+
+    fn complete_sentinel_run(&self, run_id: &str, counters: &RunCounters) -> Result<()> {
+        Database::complete_sentinel_run(self, run_id, counters)
+    }
+
+    fn list_sentinel_runs(&self, limit: usize) -> Result<Vec<SentinelRun>> {
+        Database::list_sentinel_runs(self, limit)
+    }
+
+    fn insert_sentinel_dispatch(&self, dispatch: &NewDispatch<'_>) -> Result<i64> {
+        Database::insert_sentinel_dispatch(self, dispatch)
+    }
+
+    fn update_dispatch_outcome(
+        &self,
+        dispatch_id: i64,
+        outcome: &str,
+        outcome_detail: &str,
+    ) -> Result<()> {
+        Database::update_dispatch_outcome(self, dispatch_id, outcome, outcome_detail)
+    }
+
+    fn get_pending_dispatches(&self) -> Result<Vec<SentinelDispatch>> {
+        Database::get_pending_dispatches(self)
+    }
+
+    fn count_pending_dispatches(&self) -> Result<i64> {
+        Database::count_pending_dispatches(self)
+    }
+
+    fn get_latest_dispatch_for_signal(
+        &self,
+        issue_number: i64,
+        label: &str,
+    ) -> Result<Option<SentinelDispatch>> {
+        Database::get_latest_dispatch_for_signal(self, issue_number, label)
+    }
+
+    fn load_dispatch_seen_set(&self) -> Result<Vec<SentinelDispatch>> {
+        Database::load_dispatch_seen_set(self)
+    }
+
+    fn list_dispatches_for_run(&self, run_id: &str) -> Result<Vec<SentinelDispatch>> {
+        Database::list_dispatches_for_run(self, run_id)
+    }
+
+    fn get_dispatch_metrics(&self) -> Result<Vec<DispatchMetric>> {
+        Database::get_dispatch_metrics(self)
+    }
+
+    fn get_repeat_failure_counts(&self) -> Result<Vec<(String, i64)>> {
+        Database::get_repeat_failure_counts(self)
+    }
+
+    fn get_escalation_heavy_counts(&self) -> Result<Vec<(String, i64, i64, i64)>> {
+        Database::get_escalation_heavy_counts(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn populated_database() -> (Database, tempfile::TempDir, i64, i64, i64) {
+        let directory = tempfile::tempdir().unwrap();
+        let database = Database::open(&directory.path().join("issues.db")).unwrap();
+        let parent = database
+            .create_issue("parent boundary", Some("query marker"), "high")
+            .unwrap();
+        let child = database
+            .create_subissue(parent, "child boundary", None, "medium")
+            .unwrap();
+        let archived = database
+            .create_issue("archived boundary", None, "low")
+            .unwrap();
+        database.add_label(parent, "boundary").unwrap();
+        database
+            .add_comment(parent, "boundary comment", "note")
+            .unwrap();
+        database.add_dependency(child, parent).unwrap();
+        database.add_relation(parent, archived).unwrap();
+        let milestone = database
+            .create_milestone("boundary milestone", Some("parity"))
+            .unwrap();
+        database.add_issue_to_milestone(milestone, parent).unwrap();
+        database.close_issue(archived).unwrap();
+        database.archive_issue(archived).unwrap();
+        database.start_timer(parent).unwrap();
+        database.stop_timer(parent).unwrap();
+        (database, directory, parent, child, milestone)
+    }
+
+    #[test]
+    fn query_service_matches_database_projection() {
+        let (database, _directory, parent, child, milestone) = populated_database();
+        let service = RepositoryService::projection(&database);
+        let ids = [parent, child];
+        let since = "1970-01-01T00:00:00Z";
+
+        assert_eq!(
+            service.get_issue(parent).unwrap(),
+            database.get_issue(parent).unwrap()
+        );
+        assert_eq!(
+            service.require_issue(parent).unwrap(),
+            database.require_issue(parent).unwrap()
+        );
+        assert_eq!(
+            service.list_issues(Some("all"), None, None).unwrap(),
+            database.list_issues(Some("all"), None, None).unwrap()
+        );
+        assert_eq!(
+            service.search_issues("marker").unwrap(),
+            database.search_issues("marker").unwrap()
+        );
+        assert_eq!(
+            service.get_subissues(parent).unwrap(),
+            database.get_subissues(parent).unwrap()
+        );
+        assert_eq!(
+            service.get_labels(parent).unwrap(),
+            database.get_labels(parent).unwrap()
+        );
+        assert_eq!(
+            service.get_labels_batch(&ids).unwrap(),
+            database.get_labels_batch(&ids).unwrap()
+        );
+        assert_eq!(
+            service.get_comments(parent).unwrap(),
+            database.get_comments(parent).unwrap()
+        );
+        assert_eq!(
+            service.search_comments("boundary").unwrap(),
+            database.search_comments("boundary").unwrap()
+        );
+        assert_eq!(
+            service.get_blockers(child).unwrap(),
+            database.get_blockers(child).unwrap()
+        );
+        assert_eq!(
+            service.get_blocking(parent).unwrap(),
+            database.get_blocking(parent).unwrap()
+        );
+        assert_eq!(
+            service.get_blocker_counts_batch(&ids).unwrap(),
+            database.get_blocker_counts_batch(&ids).unwrap()
+        );
+        assert_eq!(
+            service.list_blocked_issues().unwrap(),
+            database.list_blocked_issues().unwrap()
+        );
+        assert_eq!(
+            service.list_ready_issues().unwrap(),
+            database.list_ready_issues().unwrap()
+        );
+        assert_eq!(
+            service.list_archived_issues().unwrap(),
+            database.list_archived_issues().unwrap()
+        );
+        assert_eq!(
+            service.get_related_issues(parent).unwrap(),
+            database.get_related_issues(parent).unwrap()
+        );
+        assert_eq!(
+            service.get_related_issue_ids(parent).unwrap(),
+            database.get_related_issue_ids(parent).unwrap()
+        );
+        assert_eq!(
+            service.get_milestone(milestone).unwrap(),
+            database.get_milestone(milestone).unwrap()
+        );
+        assert_eq!(
+            service.list_milestones(None).unwrap(),
+            database.list_milestones(None).unwrap()
+        );
+        assert_eq!(
+            service.get_milestone_issues(milestone).unwrap(),
+            database.get_milestone_issues(milestone).unwrap()
+        );
+        assert_eq!(
+            service.get_issue_milestone(parent).unwrap(),
+            database.get_issue_milestone(parent).unwrap()
+        );
+        assert_eq!(
+            service.get_milestone_uuid_for_issue(parent).unwrap(),
+            database.get_milestone_uuid_for_issue(parent).unwrap()
+        );
+        assert_eq!(
+            service.count_issues_since(since).unwrap(),
+            database.count_issues_since(since).unwrap()
+        );
+        assert_eq!(
+            service.count_comments_since(since).unwrap(),
+            database.count_comments_since(since).unwrap()
+        );
+        assert_eq!(
+            service.get_issue_count().unwrap(),
+            database.get_issue_count().unwrap()
+        );
+        assert_eq!(
+            service.get_milestone_count().unwrap(),
+            database.get_milestone_count().unwrap()
+        );
+        assert_eq!(
+            service.get_issue_uuid_by_id(parent).unwrap(),
+            database.get_issue_uuid_by_id(parent).unwrap()
+        );
+        assert_eq!(
+            service.get_issue_export_metadata(parent).unwrap(),
+            database.get_issue_export_metadata(parent).unwrap()
+        );
+        assert_eq!(
+            service.get_comments_with_author(parent).unwrap(),
+            database.get_comments_with_author(parent).unwrap()
+        );
+        assert_eq!(
+            service.get_time_entries_for_issue(parent).unwrap(),
+            database.get_time_entries_for_issue(parent).unwrap()
+        );
+    }
+
+    #[test]
+    fn projection_only_service_rejects_domain_mutation_but_allows_local_state() {
+        let (database, _directory, parent, _child, _milestone) = populated_database();
+        let before = database.get_issue_count().unwrap();
+        let service = RepositoryService::projection(&database);
+
+        let error = service
+            .create_issue("must fail", None, "medium", None, None)
+            .unwrap_err();
+        assert!(error.to_string().contains("projection-only"));
+        assert_eq!(database.get_issue_count().unwrap(), before);
+
+        let session = service.start_session(Some("boundary-agent")).unwrap();
+        assert!(service.set_session_issue(session, parent).unwrap());
+        assert_eq!(
+            service
+                .get_current_session_for_agent(Some("boundary-agent"))
+                .unwrap()
+                .unwrap()
+                .active_issue_id,
+            Some(parent)
+        );
+        service.start_timer(parent).unwrap();
+        assert_eq!(service.get_active_timer().unwrap().unwrap().0, parent);
+        service.stop_timer(parent).unwrap();
+        let usage_id = service
+            .record_token_usage(&LocalTokenUsage {
+                agent_id: "boundary-agent".to_string(),
+                session_id: Some(session),
+                provider: "codex".to_string(),
+                input_tokens: 10,
+                output_tokens: 4,
+                cached_input_tokens: Some(2),
+                reasoning_output_tokens: Some(1),
+                cache_read_tokens: None,
+                cache_creation_tokens: None,
+                model: "test".to_string(),
+                cost_estimate: None,
+                provider_metadata_json: None,
+            })
+            .unwrap();
+        assert!(service.get_token_usage(usage_id).unwrap().is_some());
+        service.insert_sentinel_run("boundary-run", "test").unwrap();
+        assert_eq!(
+            service.list_sentinel_runs(1).unwrap()[0].run_id,
+            "boundary-run"
+        );
+    }
+
+    #[test]
+    fn configured_shared_mode_cannot_fall_back_when_writer_is_missing() {
+        let directory = tempfile::tempdir().unwrap();
+        let crosslink_dir = directory.path().join(".crosslink");
+        std::fs::create_dir(&crosslink_dir).unwrap();
+        let database = Database::open(&crosslink_dir.join("issues.db")).unwrap();
+        let agent = crate::identity::AgentConfig {
+            agent_id: "boundary-agent".to_string(),
+            machine_id: "boundary-machine".to_string(),
+            description: None,
+            role: crate::identity::AgentRole::Driver,
+            ssh_key_path: None,
+            ssh_fingerprint: None,
+            ssh_public_key: None,
+        };
+        std::fs::write(
+            crosslink_dir.join("agent.json"),
+            serde_json::to_vec(&agent).unwrap(),
+        )
+        .unwrap();
+        let before = database.get_issue_count().unwrap();
+
+        let Err(error) = RepositoryService::new(&database, &crosslink_dir) else {
+            panic!("configured shared mode unexpectedly resolved as local")
+        };
+
+        assert!(error.to_string().contains("shared Git authority"));
+        assert_eq!(database.get_issue_count().unwrap(), before);
+    }
+
+    fn source_files(root: &Path, output: &mut Vec<std::path::PathBuf>) {
+        for entry in std::fs::read_dir(root).unwrap() {
+            let path = entry.unwrap().path();
+            if path.is_dir() {
+                source_files(&path, output);
+            } else if path.extension().is_some_and(|extension| extension == "rs") {
+                output.push(path);
+            }
+        }
+    }
+
+    #[test]
+    fn production_source_cannot_bypass_application_mutation_boundary() {
+        let source_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let mut files = Vec::new();
+        source_files(&source_root, &mut files);
+        let receivers = ["db", "database", "main_db", "writable"];
+        let database_methods = [
+            "create_issue",
+            "create_subissue",
+            "update_issue",
+            "delete_issue",
+            "close_issue",
+            "reopen_issue",
+            "archive_issue",
+            "unarchive_issue",
+            "add_comment",
+            "add_intervention_comment",
+            "add_label",
+            "remove_label",
+            "add_dependency",
+            "remove_dependency",
+            "add_relation",
+            "remove_relation",
+            "update_parent",
+            "create_milestone",
+            "add_issue_to_milestone",
+            "remove_issue_from_milestone",
+            "close_milestone",
+            "delete_milestone",
+            "set_session_issue",
+            "clear_session_issue",
+            "start_session_with_agent",
+            "end_session",
+            "set_session_action",
+            "start_timer",
+            "stop_timer",
+            "create_token_usage_for_provider",
+            "insert_sentinel_run",
+            "complete_sentinel_run",
+            "insert_sentinel_dispatch",
+            "update_dispatch_outcome",
+        ];
+        let writer_methods = [
+            "create_issue",
+            "create_subissue",
+            "update_issue",
+            "delete_issue",
+            "close_issue",
+            "reopen_issue",
+            "add_comment",
+            "add_intervention_comment",
+            "add_label",
+            "remove_label",
+            "add_blocker",
+            "remove_blocker",
+            "add_relation",
+            "remove_relation",
+            "create_milestone",
+            "set_milestone_on_issues",
+            "clear_milestone_on_issue",
+            "close_milestone",
+            "delete_milestone",
+            "claim_lock_v2",
+            "release_lock_v2",
+            "steal_lock_v2",
+            "force_release_lock_v2",
+            "write_agent_request",
+            "write_agent_ack",
+        ];
+        let mut violations = Vec::new();
+
+        for path in files {
+            let relative = path.strip_prefix(&source_root).unwrap();
+            let relative_text = relative.to_string_lossy();
+            if relative_text == "application.rs"
+                || relative_text.starts_with("db/")
+                || relative_text.starts_with("shared_writer/")
+                || relative_text.starts_with("reconcile/")
+                || relative_text == "hydration.rs"
+                || relative_text == "compaction.rs"
+                || relative_text.contains("tests.rs")
+            {
+                continue;
+            }
+            let source = std::fs::read_to_string(&path).unwrap();
+            let production = source
+                .find("#[cfg(test)]\nmod tests")
+                .map_or(source.as_str(), |index| &source[..index]);
+            for receiver in receivers {
+                for method in database_methods {
+                    let pattern = format!("{receiver}.{method}(");
+                    if production.contains(&pattern) {
+                        violations.push(format!("{}: {pattern}", relative.display()));
+                    }
+                }
+            }
+            for receiver in ["writer", "shared_writer"] {
+                for method in writer_methods {
+                    let pattern = format!("{receiver}.{method}(");
+                    if production.contains(&pattern) {
+                        violations.push(format!("{}: {pattern}", relative.display()));
+                    }
+                }
+            }
+            if production.contains("SharedWriter::new(") {
+                violations.push(format!("{}: SharedWriter::new(", relative.display()));
+            }
+        }
+
+        assert!(
+            violations.is_empty(),
+            "direct production mutation bypasses:\n{}",
+            violations.join("\n")
+        );
+    }
+}

--- a/crosslink/src/application_boundary_tests.rs
+++ b/crosslink/src/application_boundary_tests.rs
@@ -36,6 +36,10 @@ impl CommandService for RecordingService<'_> {
 }
 
 impl QueryService for RecordingService<'_> {
+    fn list_issue_records(&self) -> Result<Vec<crate::issue_file::IssueFile>> {
+        QueryService::list_issue_records(self.database)
+    }
+
     fn get_issue(&self, id: i64) -> Result<Option<Issue>> {
         self.database.get_issue(id)
     }
@@ -326,6 +330,8 @@ fn cli_and_sentinel_adapters_emit_typed_commands() {
     let database = Database::open(&directory.path().join("issues.db")).unwrap();
     let first = database.create_issue("first", None, "medium").unwrap();
     let second = database.create_issue("second", None, "high").unwrap();
+    let clone = database.create_issue("clone", None, "low").unwrap();
+    database.add_label(clone, "cpitd").unwrap();
     let service = RecordingService::new(&database);
 
     crate::commands::create::run(
@@ -338,6 +344,23 @@ fn cli_and_sentinel_adapters_emit_typed_commands() {
         None,
         &crate::commands::create::CreateOpts {
             labels: &["adapter".to_string()],
+            work: false,
+            quiet: true,
+            crosslink_dir: None,
+            defer_id: false,
+            force: false,
+        },
+    )
+    .unwrap();
+    crate::commands::create::run_subissue(
+        &service,
+        first,
+        "subissue through adapter",
+        None,
+        "medium",
+        None,
+        &crate::commands::create::CreateOpts {
+            labels: &[],
             work: false,
             quiet: true,
             crosslink_dir: None,
@@ -384,10 +407,39 @@ fn cli_and_sentinel_adapters_emit_typed_commands() {
         &["sentinel"],
     )
     .unwrap();
+    crate::commands::cpitd::clear(&service).unwrap();
     crate::commands::lifecycle::close_quiet(&service, first, false, directory.path()).unwrap();
     crate::commands::archive::archive(&service, first).unwrap();
     crate::commands::archive::unarchive(&service, first).unwrap();
     crate::commands::milestone::create(&service, "recorded milestone", None).unwrap();
+    let milestone = service
+        .list_milestones(Some("all"))
+        .unwrap()
+        .into_iter()
+        .find(|milestone| milestone.name == "recorded milestone")
+        .unwrap();
+    crate::commands::milestone::add(&service, milestone.id, &[first]).unwrap();
+    crate::commands::milestone::remove(&service, milestone.id, first).unwrap();
+    crate::commands::milestone::close(&service, milestone.id).unwrap();
+    crate::commands::milestone::delete(&service, milestone.id).unwrap();
+    crate::lock_check::try_claim_lock(&service, first, None).unwrap();
+    crate::lock_check::try_release_lock(&service, first).unwrap();
+    crate::commands::delete::run(&service, second, true).unwrap();
+    let agent_request = crate::commands::agent::run(
+        crate::AgentCommands::Request {
+            target: "recorded-agent".to_string(),
+            kind: "pause".to_string(),
+            subject_issue: Some(first),
+            reason: Some("recording".to_string()),
+        },
+        directory.path(),
+        Some(&service),
+    );
+    assert!(agent_request.is_err());
+    let session_id = service.start_session(None).unwrap();
+    service.set_session_issue(session_id, first).unwrap();
+    crate::commands::session::action(&service, "recorded action", directory.path()).unwrap();
+    crate::commands::session::end(&service, Some("recorded handoff"), directory.path()).unwrap();
 
     let commands = service.recorded();
     assert!(commands
@@ -422,10 +474,40 @@ fn cli_and_sentinel_adapters_emit_typed_commands() {
         .any(|command| matches!(command, Command::CreateIssue { .. })));
     assert!(commands
         .iter()
+        .any(|command| matches!(command, Command::CreateSubissue { .. })));
+    assert!(commands
+        .iter()
         .any(|command| matches!(command, Command::ImportIssues { .. })));
     assert!(commands
         .iter()
         .any(|command| matches!(command, Command::CreateMilestone { .. })));
+    assert!(commands
+        .iter()
+        .any(|command| matches!(command, Command::AssignMilestone { .. })));
+    assert!(commands
+        .iter()
+        .any(|command| matches!(command, Command::ClearMilestone { .. })));
+    assert!(commands
+        .iter()
+        .any(|command| matches!(command, Command::CloseMilestone { .. })));
+    assert!(commands
+        .iter()
+        .any(|command| matches!(command, Command::DeleteMilestone { .. })));
+    assert!(commands
+        .iter()
+        .any(|command| matches!(command, Command::ClaimLock { .. })));
+    assert!(commands
+        .iter()
+        .any(|command| matches!(command, Command::ReleaseLock { .. })));
+    assert!(commands
+        .iter()
+        .any(|command| matches!(command, Command::DeleteIssue { .. })));
+    assert!(commands
+        .iter()
+        .any(|command| matches!(command, Command::WriteAgentRequest { .. })));
+    assert!(commands
+        .iter()
+        .any(|command| matches!(command, Command::SetSessionIssue { .. })));
     assert!(commands
         .iter()
         .any(|command| matches!(command, Command::ArchiveIssue { .. })));

--- a/crosslink/src/application_boundary_tests.rs
+++ b/crosslink/src/application_boundary_tests.rs
@@ -1,0 +1,802 @@
+use std::cell::RefCell;
+
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+
+use crate::application::{Command, CommandResult, CommandService, LocalStateService, QueryService};
+use crate::db::sentinel::{
+    DispatchMetric, NewDispatch, RunCounters, SentinelDispatch, SentinelRun,
+};
+use crate::db::{CommentAuthorRow, Database, TimeEntryRow, UsageSummaryRow};
+use crate::models::{Comment, Issue, Milestone, Session, TokenUsage};
+
+struct RecordingService<'a> {
+    database: &'a Database,
+    commands: RefCell<Vec<Command>>,
+}
+
+impl<'a> RecordingService<'a> {
+    fn new(database: &'a Database) -> Self {
+        Self {
+            database,
+            commands: RefCell::new(Vec::new()),
+        }
+    }
+
+    fn recorded(&self) -> Vec<Command> {
+        self.commands.borrow().clone()
+    }
+}
+
+impl CommandService for RecordingService<'_> {
+    fn execute(&self, command: Command) -> Result<CommandResult> {
+        self.commands.borrow_mut().push(command.clone());
+        self.database.execute(command)
+    }
+}
+
+impl QueryService for RecordingService<'_> {
+    fn get_issue(&self, id: i64) -> Result<Option<Issue>> {
+        self.database.get_issue(id)
+    }
+
+    fn require_issue(&self, id: i64) -> Result<Issue> {
+        self.database.require_issue(id)
+    }
+
+    fn list_issues(
+        &self,
+        status: Option<&str>,
+        label: Option<&str>,
+        priority: Option<&str>,
+    ) -> Result<Vec<Issue>> {
+        self.database.list_issues(status, label, priority)
+    }
+
+    fn search_issues(&self, query: &str) -> Result<Vec<Issue>> {
+        self.database.search_issues(query)
+    }
+
+    fn get_subissues(&self, parent_id: i64) -> Result<Vec<Issue>> {
+        self.database.get_subissues(parent_id)
+    }
+
+    fn get_labels(&self, issue_id: i64) -> Result<Vec<String>> {
+        self.database.get_labels(issue_id)
+    }
+
+    fn get_labels_batch(
+        &self,
+        issue_ids: &[i64],
+    ) -> Result<std::collections::HashMap<i64, Vec<String>>> {
+        self.database.get_labels_batch(issue_ids)
+    }
+
+    fn get_comments(&self, issue_id: i64) -> Result<Vec<Comment>> {
+        self.database.get_comments(issue_id)
+    }
+
+    fn search_comments(&self, query: &str) -> Result<Vec<(Comment, i64, String)>> {
+        self.database.search_comments(query)
+    }
+
+    fn get_blockers(&self, issue_id: i64) -> Result<Vec<i64>> {
+        self.database.get_blockers(issue_id)
+    }
+
+    fn get_blocking(&self, issue_id: i64) -> Result<Vec<i64>> {
+        self.database.get_blocking(issue_id)
+    }
+
+    fn get_blocker_counts_batch(
+        &self,
+        issue_ids: &[i64],
+    ) -> Result<std::collections::HashMap<i64, usize>> {
+        self.database.get_blocker_counts_batch(issue_ids)
+    }
+
+    fn list_blocked_issues(&self) -> Result<Vec<Issue>> {
+        self.database.list_blocked_issues()
+    }
+
+    fn list_ready_issues(&self) -> Result<Vec<Issue>> {
+        self.database.list_ready_issues()
+    }
+
+    fn list_archived_issues(&self) -> Result<Vec<Issue>> {
+        self.database.list_archived_issues()
+    }
+
+    fn get_related_issues(&self, issue_id: i64) -> Result<Vec<Issue>> {
+        self.database.get_related_issues(issue_id)
+    }
+
+    fn get_related_issue_ids(&self, issue_id: i64) -> Result<Vec<i64>> {
+        self.database.get_related_issue_ids(issue_id)
+    }
+
+    fn get_milestone(&self, id: i64) -> Result<Option<Milestone>> {
+        self.database.get_milestone(id)
+    }
+
+    fn list_milestones(&self, status: Option<&str>) -> Result<Vec<Milestone>> {
+        self.database.list_milestones(status)
+    }
+
+    fn get_milestone_issues(&self, milestone_id: i64) -> Result<Vec<Issue>> {
+        self.database.get_milestone_issues(milestone_id)
+    }
+
+    fn get_issue_milestone(&self, issue_id: i64) -> Result<Option<Milestone>> {
+        self.database.get_issue_milestone(issue_id)
+    }
+
+    fn get_milestone_uuid_for_issue(&self, issue_id: i64) -> Result<Option<String>> {
+        self.database.get_milestone_uuid_for_issue(issue_id)
+    }
+
+    fn count_issues_since(&self, since: &str) -> Result<i64> {
+        self.database.count_issues_since(since)
+    }
+
+    fn count_comments_since(&self, since: &str) -> Result<i64> {
+        self.database.count_comments_since(since)
+    }
+
+    fn get_issue_count(&self) -> Result<i64> {
+        self.database.get_issue_count()
+    }
+
+    fn get_milestone_count(&self) -> Result<i64> {
+        self.database.get_milestone_count()
+    }
+
+    fn get_issue_uuid_by_id(&self, id: i64) -> Result<String> {
+        self.database.get_issue_uuid_by_id(id)
+    }
+
+    fn get_issue_export_metadata(&self, id: i64) -> Result<(Option<String>, Option<String>)> {
+        self.database.get_issue_export_metadata(id)
+    }
+
+    fn get_comments_with_author(&self, issue_id: i64) -> Result<Vec<CommentAuthorRow>> {
+        self.database.get_comments_with_author(issue_id)
+    }
+
+    fn get_time_entries_for_issue(&self, issue_id: i64) -> Result<Vec<TimeEntryRow>> {
+        self.database.get_time_entries_for_issue(issue_id)
+    }
+
+    fn authority_mode(&self) -> crate::application::AuthorityMode {
+        crate::application::AuthorityMode::Local
+    }
+}
+
+impl LocalStateService for RecordingService<'_> {
+    fn get_schema_version(&self) -> Result<i32> {
+        self.database.get_schema_version()
+    }
+
+    fn start_session(&self, agent_id: Option<&str>) -> Result<i64> {
+        self.database.start_session_with_agent(agent_id)
+    }
+
+    fn end_session(&self, id: i64, notes: Option<&str>) -> Result<bool> {
+        self.database.end_session(id, notes)
+    }
+
+    fn set_session_action(&self, id: i64, action: &str) -> Result<bool> {
+        self.database.set_session_action(id, action)
+    }
+
+    fn start_timer(&self, issue_id: i64) -> Result<i64> {
+        self.database.start_timer(issue_id)
+    }
+
+    fn stop_timer(&self, issue_id: i64) -> Result<bool> {
+        self.database.stop_timer(issue_id)
+    }
+
+    fn get_active_timer(&self) -> Result<Option<(i64, DateTime<Utc>)>> {
+        self.database.get_active_timer()
+    }
+
+    fn get_total_time(&self, issue_id: i64) -> Result<i64> {
+        self.database.get_total_time(issue_id)
+    }
+
+    fn get_current_session_for_agent(&self, agent_id: Option<&str>) -> Result<Option<Session>> {
+        self.database.get_current_session_for_agent(agent_id)
+    }
+
+    fn get_last_session_for_agent(&self, agent_id: Option<&str>) -> Result<Option<Session>> {
+        self.database.get_last_session_for_agent(agent_id)
+    }
+
+    fn record_token_usage(&self, usage: &crate::application::LocalTokenUsage) -> Result<i64> {
+        self.database.create_token_usage_for_provider(
+            &usage.agent_id,
+            usage.session_id,
+            &usage.provider,
+            usage.input_tokens,
+            usage.output_tokens,
+            usage.cached_input_tokens,
+            usage.reasoning_output_tokens,
+            usage.cache_read_tokens,
+            usage.cache_creation_tokens,
+            &usage.model,
+            usage.cost_estimate,
+            usage.provider_metadata_json.as_deref(),
+        )
+    }
+
+    fn get_token_usage(&self, id: i64) -> Result<Option<TokenUsage>> {
+        self.database.get_token_usage(id)
+    }
+
+    fn list_token_usage(
+        &self,
+        agent_id: Option<&str>,
+        session_id: Option<i64>,
+        model: Option<&str>,
+        from: Option<&str>,
+        to: Option<&str>,
+        limit: Option<i64>,
+    ) -> Result<Vec<TokenUsage>> {
+        self.database
+            .list_token_usage(agent_id, session_id, model, from, to, limit)
+    }
+
+    fn get_usage_summary(
+        &self,
+        agent_id: Option<&str>,
+        from: Option<&str>,
+        to: Option<&str>,
+    ) -> Result<Vec<UsageSummaryRow>> {
+        self.database.get_usage_summary(agent_id, from, to)
+    }
+
+    fn insert_sentinel_run(&self, run_id: &str, mode: &str) -> Result<i64> {
+        self.database.insert_sentinel_run(run_id, mode)
+    }
+
+    fn complete_sentinel_run(&self, run_id: &str, counters: &RunCounters) -> Result<()> {
+        self.database.complete_sentinel_run(run_id, counters)
+    }
+
+    fn list_sentinel_runs(&self, limit: usize) -> Result<Vec<SentinelRun>> {
+        self.database.list_sentinel_runs(limit)
+    }
+
+    fn insert_sentinel_dispatch(&self, dispatch: &NewDispatch<'_>) -> Result<i64> {
+        self.database.insert_sentinel_dispatch(dispatch)
+    }
+
+    fn update_dispatch_outcome(
+        &self,
+        dispatch_id: i64,
+        outcome: &str,
+        outcome_detail: &str,
+    ) -> Result<()> {
+        self.database
+            .update_dispatch_outcome(dispatch_id, outcome, outcome_detail)
+    }
+
+    fn get_pending_dispatches(&self) -> Result<Vec<SentinelDispatch>> {
+        self.database.get_pending_dispatches()
+    }
+
+    fn count_pending_dispatches(&self) -> Result<i64> {
+        self.database.count_pending_dispatches()
+    }
+
+    fn get_latest_dispatch_for_signal(
+        &self,
+        issue_number: i64,
+        label: &str,
+    ) -> Result<Option<SentinelDispatch>> {
+        self.database
+            .get_latest_dispatch_for_signal(issue_number, label)
+    }
+
+    fn load_dispatch_seen_set(&self) -> Result<Vec<SentinelDispatch>> {
+        self.database.load_dispatch_seen_set()
+    }
+
+    fn list_dispatches_for_run(&self, run_id: &str) -> Result<Vec<SentinelDispatch>> {
+        self.database.list_dispatches_for_run(run_id)
+    }
+
+    fn get_dispatch_metrics(&self) -> Result<Vec<DispatchMetric>> {
+        self.database.get_dispatch_metrics()
+    }
+
+    fn get_repeat_failure_counts(&self) -> Result<Vec<(String, i64)>> {
+        self.database.get_repeat_failure_counts()
+    }
+
+    fn get_escalation_heavy_counts(&self) -> Result<Vec<(String, i64, i64, i64)>> {
+        self.database.get_escalation_heavy_counts()
+    }
+}
+
+#[test]
+fn cli_and_sentinel_adapters_emit_typed_commands() {
+    let directory = tempfile::tempdir().unwrap();
+    let database = Database::open(&directory.path().join("issues.db")).unwrap();
+    let first = database.create_issue("first", None, "medium").unwrap();
+    let second = database.create_issue("second", None, "high").unwrap();
+    let service = RecordingService::new(&database);
+
+    crate::commands::create::run(
+        &service,
+        "created through adapter",
+        None,
+        "medium",
+        None,
+        None,
+        None,
+        &crate::commands::create::CreateOpts {
+            labels: &["adapter".to_string()],
+            work: false,
+            quiet: true,
+            crosslink_dir: None,
+            defer_id: false,
+            force: false,
+        },
+    )
+    .unwrap();
+    let import_path = directory.path().join("import.json");
+    std::fs::write(&import_path, "[]").unwrap();
+    crate::commands::import::run_json(&service, &import_path).unwrap();
+
+    crate::commands::update::run(
+        &service,
+        first,
+        crate::shared_writer::IssueUpdate {
+            title: Some("updated"),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    crate::commands::comment::run(&service, first, "recorded", "note").unwrap();
+    crate::commands::label::add(&service, first, "recorded").unwrap();
+    crate::commands::label::remove(&service, first, "recorded").unwrap();
+    crate::commands::deps::block(&service, first, second).unwrap();
+    crate::commands::deps::unblock(&service, first, second).unwrap();
+    crate::commands::relate::add(&service, first, second).unwrap();
+    crate::commands::relate::remove(&service, first, second).unwrap();
+    crate::commands::intervene::run(
+        &service,
+        first,
+        "recorded intervention",
+        "manual_action",
+        None,
+        directory.path(),
+    )
+    .unwrap();
+    crate::commands::sentinel::engine::create_triage_issue(
+        &service,
+        "recording",
+        "sentinel recording",
+        "sentinel boundary",
+        "medium",
+        &["sentinel"],
+    )
+    .unwrap();
+    crate::commands::lifecycle::close_quiet(&service, first, false, directory.path()).unwrap();
+    crate::commands::archive::archive(&service, first).unwrap();
+    crate::commands::archive::unarchive(&service, first).unwrap();
+    crate::commands::milestone::create(&service, "recorded milestone", None).unwrap();
+
+    let commands = service.recorded();
+    assert!(commands
+        .iter()
+        .any(|command| matches!(command, Command::UpdateIssue { .. })));
+    assert!(commands
+        .iter()
+        .any(|command| matches!(command, Command::AddComment { .. })));
+    assert!(commands
+        .iter()
+        .any(|command| matches!(command, Command::AddLabel { .. })));
+    assert!(commands
+        .iter()
+        .any(|command| matches!(command, Command::RemoveLabel { .. })));
+    assert!(commands
+        .iter()
+        .any(|command| matches!(command, Command::AddDependency { .. })));
+    assert!(commands
+        .iter()
+        .any(|command| matches!(command, Command::RemoveDependency { .. })));
+    assert!(commands
+        .iter()
+        .any(|command| matches!(command, Command::AddRelation { .. })));
+    assert!(commands
+        .iter()
+        .any(|command| matches!(command, Command::RemoveRelation { .. })));
+    assert!(commands
+        .iter()
+        .any(|command| matches!(command, Command::AddIntervention { .. })));
+    assert!(commands
+        .iter()
+        .any(|command| matches!(command, Command::CreateIssue { .. })));
+    assert!(commands
+        .iter()
+        .any(|command| matches!(command, Command::ImportIssues { .. })));
+    assert!(commands
+        .iter()
+        .any(|command| matches!(command, Command::CreateMilestone { .. })));
+    assert!(commands
+        .iter()
+        .any(|command| matches!(command, Command::ArchiveIssue { .. })));
+    assert!(commands
+        .iter()
+        .any(|command| matches!(command, Command::UnarchiveIssue { .. })));
+}
+
+#[test]
+fn command_service_entrypoints_emit_every_typed_mutation() {
+    let directory = tempfile::tempdir().unwrap();
+    let database = Database::open(&directory.path().join("issues.db")).unwrap();
+    let service = RecordingService::new(&database);
+    let first = service
+        .create_issue("first", None, "medium", None, None)
+        .unwrap();
+    let second = service
+        .create_subissue(first, "second", None, "high")
+        .unwrap();
+    service.import_issues(&[]).unwrap();
+    service
+        .update_issue(
+            first,
+            crate::application::OwnedIssueUpdate {
+                title: Some("updated".to_string()),
+                description: crate::application::DescriptionChange::Unchanged,
+                status: None,
+                priority: None,
+                scheduled_at: crate::application::DateTimeChange::Unchanged,
+                due_at: crate::application::DateTimeChange::Unchanged,
+            },
+        )
+        .unwrap();
+    service.add_comment(first, "note", "note").unwrap();
+    service
+        .add_intervention(first, "intervention", "manual", None, None)
+        .unwrap();
+    service.add_label(first, "boundary").unwrap();
+    service.remove_label(first, "boundary").unwrap();
+    service.add_dependency(first, second).unwrap();
+    service.remove_dependency(first, second).unwrap();
+    service.add_relation(first, second).unwrap();
+    service.remove_relation(first, second).unwrap();
+    service.close_issue(first).unwrap();
+    service.archive_issue(first).unwrap();
+    service.unarchive_issue(first).unwrap();
+    let milestone = service.create_milestone("boundary", None).unwrap();
+    service.assign_milestone(milestone, &[first]).unwrap();
+    service.clear_milestone(milestone, first).unwrap();
+    service.close_milestone(milestone).unwrap();
+    service.delete_milestone(milestone).unwrap();
+    let session = service.start_session(Some("recorder")).unwrap();
+    service.set_session_issue(session, second).unwrap();
+    service.clear_session_issue(session).unwrap();
+    assert!(service.claim_lock(first, None).is_err());
+    service.release_lock(first).unwrap();
+    assert!(service.steal_lock(first, "stale", None).is_err());
+    assert!(service.force_release_lock(first, "stale").is_err());
+    assert!(service
+        .write_agent_request(
+            "target-agent",
+            &crate::agent_requests::AgentRequest {
+                request_id: "request".to_string(),
+                kind: crate::agent_requests::RequestKind::Pause,
+                subject: crate::agent_requests::RequestSubject::default(),
+                requested_by: "recorder".to_string(),
+                requested_at: Utc::now().to_rfc3339(),
+                reason: None,
+            },
+        )
+        .is_err());
+    assert!(service
+        .write_agent_ack(
+            "target-agent",
+            &crate::agent_requests::AgentRequestAck {
+                request_id: "request".to_string(),
+                ack_at: Utc::now().to_rfc3339(),
+                acted: true,
+                result: "recorded".to_string(),
+                notes: None,
+            },
+        )
+        .is_err());
+    service.delete_issue(second).unwrap();
+
+    let commands = service.recorded();
+    let covered = commands
+        .iter()
+        .map(|command| match command {
+            Command::CreateIssue { .. } => "create_issue",
+            Command::CreateSubissue { .. } => "create_subissue",
+            Command::ImportIssues { .. } => "import_issues",
+            Command::UpdateIssue { .. } => "update_issue",
+            Command::DeleteIssue { .. } => "delete_issue",
+            Command::ArchiveIssue { .. } => "archive_issue",
+            Command::UnarchiveIssue { .. } => "unarchive_issue",
+            Command::AddComment { .. } => "add_comment",
+            Command::AddIntervention { .. } => "add_intervention",
+            Command::AddLabel { .. } => "add_label",
+            Command::RemoveLabel { .. } => "remove_label",
+            Command::AddDependency { .. } => "add_dependency",
+            Command::RemoveDependency { .. } => "remove_dependency",
+            Command::AddRelation { .. } => "add_relation",
+            Command::RemoveRelation { .. } => "remove_relation",
+            Command::CreateMilestone { .. } => "create_milestone",
+            Command::AssignMilestone { .. } => "assign_milestone",
+            Command::ClearMilestone { .. } => "clear_milestone",
+            Command::CloseMilestone { .. } => "close_milestone",
+            Command::DeleteMilestone { .. } => "delete_milestone",
+            Command::ClaimLock { .. } => "claim_lock",
+            Command::ReleaseLock { .. } => "release_lock",
+            Command::StealLock { .. } => "steal_lock",
+            Command::ForceReleaseLock { .. } => "force_release_lock",
+            Command::SetSessionIssue { .. } => "set_session_issue",
+            Command::ClearSessionIssue { .. } => "clear_session_issue",
+            Command::WriteAgentRequest { .. } => "write_agent_request",
+            Command::WriteAgentAck { .. } => "write_agent_ack",
+        })
+        .collect::<std::collections::HashSet<_>>();
+    assert_eq!(covered.len(), 28);
+}
+
+#[test]
+fn legacy_http_mutation_adapters_emit_typed_commands() {
+    let directory = tempfile::tempdir().unwrap();
+    let database = Database::open(&directory.path().join("issues.db")).unwrap();
+    let first = database.create_issue("first", None, "medium").unwrap();
+    let second = database.create_issue("second", None, "high").unwrap();
+    let service = RecordingService::new(&database);
+    let created = crate::server::handlers::issues::execute_create_issue_command(
+        &service,
+        &crate::server::types::CreateIssueRequest {
+            title: "http create".to_string(),
+            description: Some("body".to_string()),
+            priority: crate::server::types::ApiPriority::Medium,
+            parent_id: None,
+        },
+    )
+    .unwrap();
+    crate::server::handlers::issues::execute_create_subissue_command(
+        &service,
+        first,
+        &crate::server::types::CreateSubissueRequest {
+            title: "http child".to_string(),
+            description: None,
+            priority: crate::server::types::ApiPriority::Low,
+        },
+    )
+    .unwrap();
+    crate::server::handlers::issues::execute_update_issue_command(
+        &service,
+        first,
+        crate::server::types::UpdateIssueRequest {
+            title: Some("http update".to_string()),
+            description: None,
+            priority: None,
+        },
+    )
+    .unwrap();
+    crate::server::handlers::issues::execute_add_comment_command(
+        &service,
+        first,
+        &crate::server::types::CreateCommentRequest {
+            content: "http note".to_string(),
+            kind: crate::server::types::CommentKind::Note,
+            trigger_type: None,
+            intervention_context: None,
+        },
+    )
+    .unwrap();
+    crate::server::handlers::issues::execute_add_comment_command(
+        &service,
+        first,
+        &crate::server::types::CreateCommentRequest {
+            content: "http intervention".to_string(),
+            kind: crate::server::types::CommentKind::Intervention,
+            trigger_type: Some("manual".to_string()),
+            intervention_context: None,
+        },
+    )
+    .unwrap();
+    crate::server::handlers::issues::execute_add_label_command(&service, first, "http").unwrap();
+    crate::server::handlers::issues::execute_remove_label_command(&service, first, "http").unwrap();
+    crate::server::handlers::issues::execute_add_blocker_command(&service, first, second).unwrap();
+    crate::server::handlers::issues::execute_remove_blocker_command(&service, first, second)
+        .unwrap();
+    crate::server::handlers::issues::execute_close_issue_command(&service, first).unwrap();
+    crate::server::handlers::issues::execute_reopen_issue_command(&service, first).unwrap();
+    let milestone = crate::server::handlers::milestones::execute_create_milestone_command(
+        &service,
+        &crate::server::types::CreateMilestoneRequest {
+            name: "http milestone".to_string(),
+            description: None,
+        },
+    )
+    .unwrap();
+    crate::server::handlers::milestones::execute_assign_milestone_command(
+        &service, milestone, first,
+    )
+    .unwrap();
+    crate::server::handlers::milestones::execute_close_milestone_command(&service, milestone)
+        .unwrap();
+    let session = service.start_session(Some("http")).unwrap();
+    crate::server::handlers::sessions::execute_set_session_issue_command(&service, session, first)
+        .unwrap();
+    crate::server::handlers::issues::execute_delete_issue_command(&service, created).unwrap();
+
+    let commands = service.recorded();
+    for expected in [
+        "create",
+        "subissue",
+        "update",
+        "comment",
+        "intervention",
+        "label",
+        "unlabel",
+        "block",
+        "unblock",
+        "close_reopen",
+        "milestone_create",
+        "milestone_assign",
+        "milestone_close",
+        "session_issue",
+        "delete",
+    ] {
+        let found = match expected {
+            "create" => commands
+                .iter()
+                .any(|command| matches!(command, Command::CreateIssue { .. })),
+            "subissue" => commands
+                .iter()
+                .any(|command| matches!(command, Command::CreateSubissue { .. })),
+            "update" | "close_reopen" => commands
+                .iter()
+                .any(|command| matches!(command, Command::UpdateIssue { .. })),
+            "comment" => commands
+                .iter()
+                .any(|command| matches!(command, Command::AddComment { .. })),
+            "intervention" => commands
+                .iter()
+                .any(|command| matches!(command, Command::AddIntervention { .. })),
+            "label" => commands
+                .iter()
+                .any(|command| matches!(command, Command::AddLabel { .. })),
+            "unlabel" => commands
+                .iter()
+                .any(|command| matches!(command, Command::RemoveLabel { .. })),
+            "block" => commands
+                .iter()
+                .any(|command| matches!(command, Command::AddDependency { .. })),
+            "unblock" => commands
+                .iter()
+                .any(|command| matches!(command, Command::RemoveDependency { .. })),
+            "milestone_create" => commands
+                .iter()
+                .any(|command| matches!(command, Command::CreateMilestone { .. })),
+            "milestone_assign" => commands
+                .iter()
+                .any(|command| matches!(command, Command::AssignMilestone { .. })),
+            "milestone_close" => commands
+                .iter()
+                .any(|command| matches!(command, Command::CloseMilestone { .. })),
+            "session_issue" => commands
+                .iter()
+                .any(|command| matches!(command, Command::SetSessionIssue { .. })),
+            "delete" => commands
+                .iter()
+                .any(|command| matches!(command, Command::DeleteIssue { .. })),
+            _ => false,
+        };
+        assert!(found, "HTTP adapter did not emit {expected}");
+    }
+}
+
+#[test]
+fn kickoff_and_orchestrator_adapters_emit_typed_commands() {
+    let directory = tempfile::tempdir().unwrap();
+    let crosslink_dir = directory.path().join(".crosslink");
+    std::fs::create_dir(&crosslink_dir).unwrap();
+    let database = Database::open(&crosslink_dir.join("issues.db")).unwrap();
+    let service = RecordingService::new(&database);
+
+    crate::commands::kickoff::resolve_kickoff_issue(&service, None, "kickoff recording").unwrap();
+    let plan = crate::orchestrator::models::OrchestratorPlan {
+        id: "recording-plan".to_string(),
+        document_slug: "recording".to_string(),
+        phases: vec![crate::orchestrator::models::OrchestratorPhase {
+            id: "phase".to_string(),
+            title: "Phase".to_string(),
+            description: "Phase recording".to_string(),
+            stages: vec![crate::orchestrator::models::OrchestratorStage {
+                id: "stage".to_string(),
+                title: "Stage".to_string(),
+                description: "Stage recording".to_string(),
+                tasks: Vec::new(),
+                depends_on: Vec::new(),
+                agent_count: 1,
+                complexity_hours: 1.0,
+            }],
+            gate_criteria: Vec::new(),
+        }],
+        created_at: Utc::now(),
+        total_stages: 1,
+        estimated_hours: 1.0,
+    };
+    crate::orchestrator::executor::OrchestratorExecutor::init(&crosslink_dir, &service, &plan)
+        .unwrap();
+
+    let commands = service.recorded();
+    assert!(commands
+        .iter()
+        .any(|command| matches!(command, Command::CreateMilestone { .. })));
+    assert!(
+        commands
+            .iter()
+            .filter(|command| matches!(command, Command::CreateIssue { .. }))
+            .count()
+            >= 2
+    );
+    assert!(commands
+        .iter()
+        .any(|command| matches!(command, Command::CreateSubissue { .. })));
+    assert!(commands
+        .iter()
+        .any(|command| matches!(command, Command::AssignMilestone { .. })));
+}
+
+#[test]
+fn mutation_adapter_registry_uses_the_application_boundary() {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let adapters = [
+        ("main.rs", "RepositoryService"),
+        ("commands/create.rs", "CommandService"),
+        ("commands/import.rs", "CommandService"),
+        ("commands/locks_cmd.rs", "CommandService"),
+        ("commands/session.rs", "CommandService"),
+        ("commands/cpitd.rs", "CommandService"),
+        ("commands/agent.rs", "CommandService"),
+        ("agent_requests.rs", "CommandService"),
+        ("commands/kickoff/run.rs", "CommandService"),
+        ("commands/swarm/lifecycle.rs", "kickoff::run"),
+        ("commands/sentinel/engine.rs", "CommandService"),
+        ("orchestrator/executor.rs", "CommandService"),
+        ("server/handlers/issues.rs", "RepositoryService::new"),
+        ("server/handlers/milestones.rs", "RepositoryService::new"),
+        ("server/handlers/sessions.rs", "CommandService"),
+        ("server/handlers/usage.rs", "RepositoryService::local_state"),
+        ("server/handlers/orchestrator.rs", "RepositoryService::new"),
+        ("dashboard/api.rs", "actions::run_cli"),
+        ("dashboard/actions.rs", "resolve_crosslink_bin"),
+    ];
+
+    for (path, boundary) in adapters {
+        let source = std::fs::read_to_string(root.join(path)).unwrap();
+        assert!(
+            source.contains(boundary),
+            "production adapter {path} is not wired through {boundary}"
+        );
+    }
+
+    let tui = std::fs::read_to_string(root.join("tui/issues_tab.rs")).unwrap();
+    assert!(tui.contains("QueryService"));
+    for mutation in [
+        "create_issue(",
+        "update_issue(",
+        "close_issue(",
+        "add_comment(",
+    ] {
+        let production = tui
+            .find("#[cfg(test)]\nmod tests")
+            .map_or(tui.as_str(), |index| &tui[..index]);
+        assert!(!production.contains(mutation));
+    }
+}

--- a/crosslink/src/commands/agent.rs
+++ b/crosslink/src/commands/agent.rs
@@ -2,13 +2,18 @@ use anyhow::{bail, Context, Result};
 use std::path::Path;
 use std::process::Command;
 
+use crate::application::CommandService;
 use crate::identity::{AgentConfig, AgentRole};
 use crate::signing;
 use crate::sync;
 use crate::utils::format_issue_id;
 use crate::AgentCommands;
 
-pub fn run(command: AgentCommands, crosslink_dir: &Path) -> Result<()> {
+pub fn run(
+    command: AgentCommands,
+    crosslink_dir: &Path,
+    commands: Option<&dyn CommandService>,
+) -> Result<()> {
     match command {
         AgentCommands::Init {
             agent_id,
@@ -63,6 +68,7 @@ pub fn run(command: AgentCommands, crosslink_dir: &Path) -> Result<()> {
             subject_issue,
             reason,
         } => request(
+            commands.ok_or_else(|| anyhow::anyhow!("agent request command service is missing"))?,
             crosslink_dir,
             &target,
             &kind,
@@ -72,7 +78,10 @@ pub fn run(command: AgentCommands, crosslink_dir: &Path) -> Result<()> {
         AgentCommands::Requests { target, pending } => {
             list_requests(crosslink_dir, target.as_deref(), pending)
         }
-        AgentCommands::PollRequests => poll_requests(crosslink_dir),
+        AgentCommands::PollRequests => poll_requests(
+            commands.ok_or_else(|| anyhow::anyhow!("agent poll command service is missing"))?,
+            crosslink_dir,
+        ),
         AgentCommands::Flags { strict } => {
             show_flags(crosslink_dir, strict);
             Ok(())
@@ -102,17 +111,12 @@ fn show_flags(crosslink_dir: &Path, strict: bool) {
     }
 }
 
-fn poll_requests(crosslink_dir: &Path) -> Result<()> {
-    let writer = crate::shared_writer::SharedWriter::new(crosslink_dir)?.ok_or_else(|| {
-        anyhow::anyhow!(
-            "agent poll-requests requires shared-writer mode (run `crosslink agent init` first)"
-        )
-    })?;
+fn poll_requests(commands: &dyn CommandService, crosslink_dir: &Path) -> Result<()> {
     let agent = AgentConfig::load(crosslink_dir)?
         .ok_or_else(|| anyhow::anyhow!("no agent config; run `crosslink agent init`"))?;
 
     let result =
-        crate::agent_requests::poll::process_pending(&writer, crosslink_dir, &agent.agent_id)?;
+        crate::agent_requests::poll::process_pending(commands, crosslink_dir, &agent.agent_id)?;
 
     if result.acted.is_empty() && result.skipped_existing_ack == 0 {
         println!("No pending requests for {}.", agent.agent_id);
@@ -134,6 +138,7 @@ fn poll_requests(crosslink_dir: &Path) -> Result<()> {
 }
 
 fn request(
+    commands: &dyn CommandService,
     crosslink_dir: &Path,
     target: &str,
     kind_str: &str,
@@ -141,12 +146,6 @@ fn request(
     reason: Option<&str>,
 ) -> Result<()> {
     let kind = crate::agent_requests::RequestKind::parse(kind_str)?;
-
-    let writer = crate::shared_writer::SharedWriter::new(crosslink_dir)?.ok_or_else(|| {
-        anyhow::anyhow!(
-            "agent request requires hub access — run `crosslink sync` to initialize, or `crosslink agent init` for a full agent identity"
-        )
-    })?;
 
     let requested_by = if let Some(driver) = AgentConfig::load(crosslink_dir)? {
         driver
@@ -169,7 +168,7 @@ fn request(
         reason: reason.map(str::to_string),
     };
 
-    let outcome = writer.write_agent_request(target, &req)?;
+    let outcome = commands.write_agent_request(target, &req)?;
     match outcome {
         crate::shared_writer::PushOutcome::Pushed => {
             println!(

--- a/crosslink/src/commands/archive.rs
+++ b/crosslink/src/commands/archive.rs
@@ -1,20 +1,24 @@
 use anyhow::{bail, Result};
+use chrono::Utc;
 
-use crate::db::Database;
+use crate::application::{CommandService, QueryService};
 use crate::utils::format_issue_id;
 use crate::ArchiveCommands;
 
-pub fn run(command: ArchiveCommands, db: &Database) -> Result<()> {
+#[cfg(test)]
+use crate::db::Database;
+
+pub fn run(command: ArchiveCommands, service: &(impl CommandService + QueryService)) -> Result<()> {
     match command {
-        ArchiveCommands::Add { id } => archive(db, id),
-        ArchiveCommands::Remove { id } => unarchive(db, id),
-        ArchiveCommands::List => list(db),
-        ArchiveCommands::Older { days } => archive_older(db, days),
+        ArchiveCommands::Add { id } => archive(service, id),
+        ArchiveCommands::Remove { id } => unarchive(service, id),
+        ArchiveCommands::List => list(service),
+        ArchiveCommands::Older { days } => archive_older(service, days),
     }
 }
 
-pub fn archive(db: &Database, id: i64) -> Result<()> {
-    let Some(issue) = db.get_issue(id)? else {
+pub fn archive(service: &(impl CommandService + QueryService), id: i64) -> Result<()> {
+    let Some(issue) = service.get_issue(id)? else {
         bail!("Issue {} not found", format_issue_id(id));
     };
 
@@ -26,26 +30,20 @@ pub fn archive(db: &Database, id: i64) -> Result<()> {
         );
     }
 
-    if db.archive_issue(id)? {
-        println!("Archived issue {}", format_issue_id(id));
-    } else {
-        println!("Issue {} could not be archived", format_issue_id(id));
-    }
+    service.archive_issue(id)?;
+    println!("Archived issue {}", format_issue_id(id));
 
     Ok(())
 }
 
-pub fn unarchive(db: &Database, id: i64) -> Result<()> {
-    if db.unarchive_issue(id)? {
-        println!("Unarchived issue {} (now closed)", format_issue_id(id));
-    } else {
-        bail!("Issue {} not found or not archived", format_issue_id(id));
-    }
+pub fn unarchive(service: &impl CommandService, id: i64) -> Result<()> {
+    service.unarchive_issue(id)?;
+    println!("Unarchived issue {} (now closed)", format_issue_id(id));
 
     Ok(())
 }
 
-pub fn list(db: &Database) -> Result<()> {
+pub fn list(db: &impl QueryService) -> Result<()> {
     let issues = db.list_archived_issues()?;
 
     if issues.is_empty() {
@@ -71,8 +69,17 @@ pub fn list(db: &Database) -> Result<()> {
     Ok(())
 }
 
-pub fn archive_older(db: &Database, days: i64) -> Result<()> {
-    let count = db.archive_older_than(days)?;
+pub fn archive_older(service: &(impl CommandService + QueryService), days: i64) -> Result<()> {
+    let cutoff = Utc::now() - chrono::Duration::days(days);
+    let eligible = service
+        .list_issues(Some("closed"), None, None)?
+        .into_iter()
+        .filter(|issue| issue.closed_at.is_some_and(|closed| closed < cutoff))
+        .collect::<Vec<_>>();
+    for issue in &eligible {
+        service.archive_issue(issue.id)?;
+    }
+    let count = eligible.len();
     if count > 0 {
         println!("Archived {count} issue(s) closed more than {days} days ago");
     } else {

--- a/crosslink/src/commands/comment.rs
+++ b/crosslink/src/commands/comment.rs
@@ -1,13 +1,14 @@
 use anyhow::Result;
 
-use crate::db::Database;
+use crate::application::{CommandService, QueryService};
 use crate::issue_file::validate_comment_kind;
-use crate::shared_writer::SharedWriter;
 use crate::utils::format_issue_id;
 
+#[cfg(test)]
+use crate::db::Database;
+
 pub fn run(
-    db: &Database,
-    writer: Option<&SharedWriter>,
+    service: &(impl CommandService + QueryService),
     issue_id: i64,
     content: &str,
     kind: &str,
@@ -15,12 +16,8 @@ pub fn run(
     if !validate_comment_kind(kind) {
         tracing::warn!("unknown comment kind '{}'. Known kinds: note, plan, decision, observation, blocker, resolution, result, handoff, human", kind);
     }
-    db.require_issue(issue_id)?;
-    if let Some(w) = writer {
-        w.add_comment(db, issue_id, content, kind)?;
-    } else {
-        db.add_comment(issue_id, content, kind)?;
-    }
+    service.require_issue(issue_id)?;
+    service.add_comment(issue_id, content, kind)?;
     println!("Added comment to issue {}", format_issue_id(issue_id));
     Ok(())
 }
@@ -43,7 +40,7 @@ mod tests {
         let (db, _dir) = setup_test_db();
         let issue_id = db.create_issue("Test issue", None, "medium").unwrap();
 
-        let result = run(&db, None, issue_id, "This is a comment", "note");
+        let result = run(&db, issue_id, "This is a comment", "note");
         assert!(result.is_ok());
 
         let comments = db.get_comments(issue_id).unwrap();
@@ -55,7 +52,7 @@ mod tests {
     fn test_add_comment_to_nonexistent_issue() {
         let (db, _dir) = setup_test_db();
 
-        let result = run(&db, None, 99999, "Comment on nothing", "note");
+        let result = run(&db, 99999, "Comment on nothing", "note");
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("not found"));
     }
@@ -65,9 +62,9 @@ mod tests {
         let (db, _dir) = setup_test_db();
         let issue_id = db.create_issue("Test issue", None, "medium").unwrap();
 
-        run(&db, None, issue_id, "First comment", "note").unwrap();
-        run(&db, None, issue_id, "Second comment", "note").unwrap();
-        run(&db, None, issue_id, "Third comment", "note").unwrap();
+        run(&db, issue_id, "First comment", "note").unwrap();
+        run(&db, issue_id, "Second comment", "note").unwrap();
+        run(&db, issue_id, "Third comment", "note").unwrap();
 
         let comments = db.get_comments(issue_id).unwrap();
         assert_eq!(comments.len(), 3);
@@ -81,7 +78,7 @@ mod tests {
         let (db, _dir) = setup_test_db();
         let issue_id = db.create_issue("Test issue", None, "medium").unwrap();
 
-        let result = run(&db, None, issue_id, "", "note");
+        let result = run(&db, issue_id, "", "note");
         assert!(result.is_ok());
 
         let comments = db.get_comments(issue_id).unwrap();
@@ -95,7 +92,7 @@ mod tests {
         let issue_id = db.create_issue("Test issue", None, "medium").unwrap();
 
         let unicode_content = "こんにちは 🎉 مرحبا αβγδ ← → ↑ ↓";
-        let result = run(&db, None, issue_id, unicode_content, "note");
+        let result = run(&db, issue_id, unicode_content, "note");
         assert!(result.is_ok());
 
         let comments = db.get_comments(issue_id).unwrap();
@@ -108,7 +105,7 @@ mod tests {
         let issue_id = db.create_issue("Test issue", None, "medium").unwrap();
 
         let long_content = "a".repeat(100_000);
-        let result = run(&db, None, issue_id, &long_content, "note");
+        let result = run(&db, issue_id, &long_content, "note");
         assert!(result.is_ok());
 
         let comments = db.get_comments(issue_id).unwrap();
@@ -121,7 +118,7 @@ mod tests {
         let issue_id = db.create_issue("Test issue", None, "medium").unwrap();
 
         let multiline = "Line 1\nLine 2\nLine 3\n\nLine 5";
-        let result = run(&db, None, issue_id, multiline, "note");
+        let result = run(&db, issue_id, multiline, "note");
         assert!(result.is_ok());
 
         let comments = db.get_comments(issue_id).unwrap();
@@ -134,7 +131,7 @@ mod tests {
         let issue_id = db.create_issue("Test issue", None, "medium").unwrap();
 
         let special = "Quotes: \"test\" 'test' `test` | Symbols: @#$%^&*() | SQL: '; DROP TABLE;--";
-        let result = run(&db, None, issue_id, special, "note");
+        let result = run(&db, issue_id, special, "note");
         assert!(result.is_ok());
 
         let comments = db.get_comments(issue_id).unwrap();
@@ -147,7 +144,7 @@ mod tests {
         let issue_id = db.create_issue("Test issue", None, "medium").unwrap();
 
         let malicious = "'); DELETE FROM comments; --";
-        run(&db, None, issue_id, malicious, "note").unwrap();
+        run(&db, issue_id, malicious, "note").unwrap();
 
         let comments = db.get_comments(issue_id).unwrap();
         assert_eq!(comments.len(), 1);
@@ -163,7 +160,7 @@ mod tests {
         let issue_id = db.create_issue("Test issue", None, "medium").unwrap();
         db.close_issue(issue_id).unwrap();
 
-        let result = run(&db, None, issue_id, "Comment on closed issue", "note");
+        let result = run(&db, issue_id, "Comment on closed issue", "note");
         assert!(result.is_ok());
 
         let comments = db.get_comments(issue_id).unwrap();
@@ -176,7 +173,7 @@ mod tests {
         let issue_id = db.create_issue("Test issue", None, "medium").unwrap();
 
         let with_null = "before\0after";
-        let result = run(&db, None, issue_id, with_null, "note");
+        let result = run(&db, issue_id, with_null, "note");
         assert!(result.is_ok());
 
         let comments = db.get_comments(issue_id).unwrap();
@@ -189,7 +186,7 @@ mod tests {
             let (db, _dir) = setup_test_db();
             let issue_id = db.create_issue("Test", None, "medium").unwrap();
 
-            let result = run(&db, None, issue_id, &content, "note");
+            let result = run(&db, issue_id, &content, "note");
             prop_assert!(result.is_ok());
 
             let comments = db.get_comments(issue_id).unwrap();
@@ -201,7 +198,7 @@ mod tests {
         fn prop_nonexistent_issue_fails(issue_id in 1000i64..10000) {
             let (db, _dir) = setup_test_db();
 
-            let result = run(&db, None, issue_id, "Comment", "note");
+            let result = run(&db, issue_id, "Comment", "note");
             prop_assert!(result.is_err());
         }
 
@@ -211,7 +208,7 @@ mod tests {
             let issue_id = db.create_issue("Test", None, "medium").unwrap();
 
             for i in 0..count {
-                run(&db, None, issue_id, &format!("Comment {i}"), "note").unwrap();
+                run(&db, issue_id, &format!("Comment {i}"), "note").unwrap();
             }
 
             let comments = db.get_comments(issue_id).unwrap();
@@ -232,7 +229,7 @@ mod tests {
             let issue_id = db.create_issue("Test", None, "medium").unwrap();
 
             let content = format!("{prefix}{emoji}{suffix}");
-            run(&db, None, issue_id, &content, "note").unwrap();
+            run(&db, issue_id, &content, "note").unwrap();
 
             let comments = db.get_comments(issue_id).unwrap();
             prop_assert_eq!(&comments[0].content, &content);

--- a/crosslink/src/commands/cpitd.rs
+++ b/crosslink/src/commands/cpitd.rs
@@ -7,18 +7,22 @@ use serde::Deserialize;
 
 use crate::CpitdCommands;
 
-use crate::db::Database;
+use crate::application::{CommandService, QueryService};
 
-pub fn run(command: CpitdCommands, db: &Database, quiet: bool) -> Result<()> {
+pub fn run(
+    command: CpitdCommands,
+    service: &(impl CommandService + QueryService),
+    quiet: bool,
+) -> Result<()> {
     match command {
         CpitdCommands::Scan {
             paths,
             min_tokens,
             ignore,
             dry_run,
-        } => scan(db, &paths, min_tokens, &ignore, dry_run, quiet),
-        CpitdCommands::Status => status(db),
-        CpitdCommands::Clear => clear(db),
+        } => scan(service, &paths, min_tokens, &ignore, dry_run, quiet),
+        CpitdCommands::Status => status(service),
+        CpitdCommands::Clear => clear(service),
     }
 }
 use crate::utils::format_issue_id;
@@ -116,7 +120,11 @@ fn dedup_marker(file_a: &str, file_b: &str) -> String {
     format!("<!-- cpitd:file_a={a}:file_b={b} -->")
 }
 
-fn find_existing_clone_issue(db: &Database, file_a: &str, file_b: &str) -> Result<Option<i64>> {
+fn find_existing_clone_issue(
+    db: &impl QueryService,
+    file_a: &str,
+    file_b: &str,
+) -> Result<Option<i64>> {
     let marker = dedup_marker(file_a, file_b);
     let issues = db.list_issues(Some("open"), Some("cpitd"), None)?;
     for issue in issues {
@@ -167,7 +175,11 @@ fn format_clone_description(report: &CpitdCloneReport) -> String {
     desc
 }
 
-fn create_clone_issue(db: &Database, report: &CpitdCloneReport, quiet: bool) -> Result<i64> {
+fn create_clone_issue(
+    service: &impl CommandService,
+    report: &CpitdCloneReport,
+    quiet: bool,
+) -> Result<i64> {
     let title = format!(
         "Code clone: {} <-> {} ({} lines)",
         shorten_path(&report.file_a),
@@ -176,9 +188,14 @@ fn create_clone_issue(db: &Database, report: &CpitdCloneReport, quiet: bool) -> 
     );
 
     let description = format_clone_description(report);
-    let id = db.create_issue(&title, Some(&description), "low")?;
-    db.add_label(id, "cpitd")?;
-    db.add_label(id, "refactor")?;
+    let id = service.create_issue_with_labels(
+        &title,
+        Some(&description),
+        "low",
+        &["cpitd".to_string(), "refactor".to_string()],
+        None,
+        None,
+    )?;
 
     if !quiet {
         println!("  Created issue {}: {}", format_issue_id(id), title);
@@ -187,7 +204,7 @@ fn create_clone_issue(db: &Database, report: &CpitdCloneReport, quiet: bool) -> 
     Ok(id)
 }
 
-fn relate_clone_issues(db: &Database, created: &[(i64, String, String)]) {
+fn relate_clone_issues(service: &impl CommandService, created: &[(i64, String, String)]) {
     let mut file_to_issues: HashMap<&str, Vec<i64>> = HashMap::new();
     for (id, file_a, file_b) in created {
         file_to_issues.entry(file_a).or_default().push(*id);
@@ -196,7 +213,7 @@ fn relate_clone_issues(db: &Database, created: &[(i64, String, String)]) {
     for ids in file_to_issues.values() {
         for i in 0..ids.len() {
             for j in (i + 1)..ids.len() {
-                let _ = db.add_relation(ids[i], ids[j]);
+                let _ = service.add_relation(ids[i], ids[j]);
             }
         }
     }
@@ -210,7 +227,7 @@ pub struct ScanOutcome {
 }
 
 pub fn scan_and_file(
-    db: &Database,
+    service: &(impl CommandService + QueryService),
     paths: &[String],
     min_tokens: u32,
     ignore_patterns: &[String],
@@ -220,16 +237,18 @@ pub fn scan_and_file(
     let mut outcome = ScanOutcome::default();
 
     for report in &output.clone_reports {
-        if let Some(existing_id) = find_existing_clone_issue(db, &report.file_a, &report.file_b)? {
+        if let Some(existing_id) =
+            find_existing_clone_issue(service, &report.file_a, &report.file_b)?
+        {
             let comment = format!(
                 "[cpitd rescan] {} total cloned lines, {} group(s)",
                 report.total_cloned_lines,
                 report.groups.len(),
             );
-            db.add_comment(existing_id, &comment, "note")?;
+            service.add_comment(existing_id, &comment, "note")?;
             outcome.updated.push(existing_id);
         } else {
-            let id = create_clone_issue(db, report, true)?;
+            let id = create_clone_issue(service, report, true)?;
             outcome
                 .created
                 .push((id, report.file_a.clone(), report.file_b.clone()));
@@ -237,14 +256,14 @@ pub fn scan_and_file(
     }
 
     if outcome.created.len() > 1 {
-        relate_clone_issues(db, &outcome.created);
+        relate_clone_issues(service, &outcome.created);
     }
 
     Ok(outcome)
 }
 
 pub fn scan(
-    db: &Database,
+    service: &(impl CommandService + QueryService),
     paths: &[String],
     min_tokens: u32,
     ignore_patterns: &[String],
@@ -282,7 +301,7 @@ pub fn scan(
         return Ok(());
     }
 
-    let outcome = scan_and_file(db, paths, min_tokens, ignore_patterns)?;
+    let outcome = scan_and_file(service, paths, min_tokens, ignore_patterns)?;
 
     if outcome.created.is_empty() && outcome.updated.is_empty() {
         if !quiet {
@@ -311,7 +330,7 @@ pub fn scan(
     Ok(())
 }
 
-pub fn status(db: &Database) -> Result<()> {
+pub fn status(db: &impl QueryService) -> Result<()> {
     let issues = db.list_issues(Some("open"), Some("cpitd"), None)?;
 
     if issues.is_empty() {
@@ -326,8 +345,8 @@ pub fn status(db: &Database) -> Result<()> {
     Ok(())
 }
 
-pub fn clear(db: &Database) -> Result<()> {
-    let issues = db.list_issues(Some("open"), Some("cpitd"), None)?;
+pub fn clear(service: &(impl CommandService + QueryService)) -> Result<()> {
+    let issues = service.list_issues(Some("open"), Some("cpitd"), None)?;
 
     if issues.is_empty() {
         println!("No open cpitd clone issues to close.");
@@ -336,7 +355,7 @@ pub fn clear(db: &Database) -> Result<()> {
 
     let count = issues.len();
     for issue in &issues {
-        db.close_issue(issue.id)?;
+        service.close_issue(issue.id)?;
     }
 
     println!("Closed {count} cpitd clone issue(s).");

--- a/crosslink/src/commands/create.rs
+++ b/crosslink/src/commands/create.rs
@@ -1,9 +1,7 @@
 use anyhow::{bail, Context, Result};
 use regex::Regex;
 
-use crate::db::Database;
-use crate::lock_check::{release_lock_best_effort, try_claim_lock, ClaimResult};
-use crate::shared_writer::SharedWriter;
+use crate::application::{AuthorityMode, CommandService, LocalStateService, QueryService};
 use crate::utils::format_issue_id;
 
 const VALID_PRIORITIES: [&str; 4] = ["low", "medium", "high", "critical"];
@@ -251,7 +249,7 @@ fn apply_template(
 }
 
 fn auto_claim_and_set_work(
-    db: &Database,
+    service: &(impl CommandService + LocalStateService + QueryService),
     id: i64,
     title: &str,
     crosslink_dir: Option<&std::path::Path>,
@@ -259,18 +257,20 @@ fn auto_claim_and_set_work(
 ) -> Result<()> {
     let mut freshly_claimed = false;
 
-    if let Some(dir) = crosslink_dir {
-        crate::lock_check::enforce_lock(dir, id, db)?;
-
-        match try_claim_lock(dir, id, None) {
-            Ok(ClaimResult::Claimed) => {
+    if crosslink_dir.is_some() {
+        match if service.authority_mode() == AuthorityMode::Shared {
+            service.claim_lock(id, None).map(Some)
+        } else {
+            Ok(None)
+        } {
+            Ok(Some(crate::shared_writer::LockClaimResult::Claimed)) => {
                 freshly_claimed = true;
                 if !quiet {
                     println!("Auto-claimed lock on issue {}", format_issue_id(id));
                 }
             }
-            Ok(ClaimResult::AlreadyHeld | ClaimResult::NotConfigured) => {}
-            Ok(ClaimResult::Contended { winner_agent_id }) => {
+            Ok(Some(crate::shared_writer::LockClaimResult::AlreadyHeld) | None) => {}
+            Ok(Some(crate::shared_writer::LockClaimResult::Contended { winner_agent_id })) => {
                 tracing::warn!(
                     "Lock on {} won by '{}'",
                     format_issue_id(id),
@@ -287,12 +287,10 @@ fn auto_claim_and_set_work(
             .flatten()
             .map(|a| a.agent_id)
     });
-    if let Ok(Some(session)) = db.get_current_session_for_agent(agent_id.as_deref()) {
-        if let Err(e) = db.set_session_issue(session.id, id) {
+    if let Ok(Some(session)) = service.get_current_session_for_agent(agent_id.as_deref()) {
+        if let Err(e) = service.set_session_issue(session.id, id) {
             if freshly_claimed {
-                if let Some(dir) = crosslink_dir {
-                    release_lock_best_effort(dir, id);
-                }
+                let _ = service.release_lock(id);
             }
             return Err(e);
         }
@@ -324,8 +322,7 @@ pub struct CreateOpts<'a> {
 
 #[allow(clippy::too_many_arguments)]
 pub fn run(
-    db: &Database,
-    writer: Option<&SharedWriter>,
+    service: &(impl CommandService + LocalStateService + QueryService),
     title: &str,
     description: Option<&str>,
     priority: &str,
@@ -360,47 +357,18 @@ pub fn run(
         );
     }
 
-    let id = if let Some(w) = writer {
-        let id = w.create_issue(
-            db,
-            title,
-            final_description.as_deref(),
-            &final_priority,
-            scheduled_at,
-            due_at,
-        )?;
-
-        if let Some(lbl) = template_label {
-            w.add_label(db, id, lbl)?;
-        }
-
-        for lbl in opts.labels {
-            w.add_label(db, id, lbl)?;
-        }
-
-        id
-    } else {
-        if scheduled_at.is_some() || due_at.is_some() {
-            bail!(
-                "Scheduling dates require the shared-writer path. \
-                 Run `crosslink agent init <id>` first to enable it."
-            );
-        }
-
-        db.transaction(|| {
-            let id = db.create_issue(title, final_description.as_deref(), &final_priority)?;
-
-            if let Some(lbl) = template_label {
-                db.add_label(id, lbl)?;
-            }
-
-            for lbl in opts.labels {
-                db.add_label(id, lbl)?;
-            }
-
-            Ok(id)
-        })?
-    };
+    let mut labels = opts.labels.to_vec();
+    if let Some(label) = template_label {
+        labels.insert(0, label.to_string());
+    }
+    let id = service.create_issue_with_labels(
+        title,
+        final_description.as_deref(),
+        &final_priority,
+        &labels,
+        scheduled_at,
+        due_at,
+    )?;
 
     if opts.defer_id && !opts.quiet {
         println!(
@@ -417,7 +385,7 @@ pub fn run(
     }
 
     if opts.work {
-        auto_claim_and_set_work(db, id, title, opts.crosslink_dir, opts.quiet)?;
+        auto_claim_and_set_work(service, id, title, opts.crosslink_dir, opts.quiet)?;
     }
 
     Ok(())
@@ -425,8 +393,7 @@ pub fn run(
 
 #[allow(clippy::too_many_arguments)]
 pub fn run_subissue(
-    db: &Database,
-    writer: Option<&SharedWriter>,
+    service: &(impl CommandService + LocalStateService + QueryService),
     parent_id: i64,
     title: &str,
     description: Option<&str>,
@@ -450,49 +417,22 @@ pub fn run_subissue(
         );
     }
 
-    let parent = db.get_issue(parent_id)?;
+    let parent = service.get_issue(parent_id)?;
     if parent.is_none() {
         bail!("Parent issue {} not found", format_issue_id(parent_id));
     }
 
-    let id = if let Some(w) = writer {
-        let id = w.create_subissue(
-            db,
-            parent_id,
-            title,
-            final_description.as_deref(),
-            &final_priority,
-        )?;
-
-        if let Some(lbl) = template_label {
-            w.add_label(db, id, lbl)?;
-        }
-
-        for lbl in opts.labels {
-            w.add_label(db, id, lbl)?;
-        }
-
-        id
-    } else {
-        db.transaction(|| {
-            let id = db.create_subissue(
-                parent_id,
-                title,
-                final_description.as_deref(),
-                &final_priority,
-            )?;
-
-            if let Some(lbl) = template_label {
-                db.add_label(id, lbl)?;
-            }
-
-            for lbl in opts.labels {
-                db.add_label(id, lbl)?;
-            }
-
-            Ok(id)
-        })?
-    };
+    let mut labels = opts.labels.to_vec();
+    if let Some(label) = template_label {
+        labels.insert(0, label.to_string());
+    }
+    let id = service.create_subissue_with_labels(
+        parent_id,
+        title,
+        final_description.as_deref(),
+        &final_priority,
+        &labels,
+    )?;
 
     if opts.quiet {
         println!("{id}");
@@ -505,7 +445,7 @@ pub fn run_subissue(
     }
 
     if opts.work {
-        auto_claim_and_set_work(db, id, title, opts.crosslink_dir, opts.quiet)?;
+        auto_claim_and_set_work(service, id, title, opts.crosslink_dir, opts.quiet)?;
     }
 
     Ok(())
@@ -642,18 +582,7 @@ mod tests {
             defer_id: false,
             force: false,
         };
-        run(
-            &db,
-            None,
-            "Test issue",
-            None,
-            "medium",
-            None,
-            None,
-            None,
-            &opts,
-        )
-        .unwrap();
+        run(&db, "Test issue", None, "medium", None, None, None, &opts).unwrap();
         let issues = db.list_issues(Some("all"), None, None).unwrap();
         assert_eq!(issues.len(), 1);
         assert_eq!(issues[0].title, "Test issue");
@@ -670,18 +599,7 @@ mod tests {
             defer_id: false,
             force: false,
         };
-        run(
-            &db,
-            None,
-            "A bug",
-            None,
-            "medium",
-            Some("bug"),
-            None,
-            None,
-            &opts,
-        )
-        .unwrap();
+        run(&db, "A bug", None, "medium", Some("bug"), None, None, &opts).unwrap();
         let issues = db.list_issues(Some("all"), None, None).unwrap();
         assert_eq!(issues.len(), 1);
         let labels = db.get_labels(issues[0].id).unwrap();
@@ -700,18 +618,7 @@ mod tests {
             defer_id: false,
             force: false,
         };
-        run(
-            &db,
-            None,
-            "Labeled issue",
-            None,
-            "high",
-            None,
-            None,
-            None,
-            &opts,
-        )
-        .unwrap();
+        run(&db, "Labeled issue", None, "high", None, None, None, &opts).unwrap();
         let issues = db.list_issues(Some("all"), None, None).unwrap();
         let issue_labels = db.get_labels(issues[0].id).unwrap();
         assert_eq!(issue_labels.len(), 2);
@@ -731,17 +638,7 @@ mod tests {
             defer_id: false,
             force: false,
         };
-        run_subissue(
-            &db,
-            None,
-            parent_id,
-            "Child task",
-            None,
-            "medium",
-            None,
-            &opts,
-        )
-        .unwrap();
+        run_subissue(&db, parent_id, "Child task", None, "medium", None, &opts).unwrap();
         let subs = db.get_subissues(parent_id).unwrap();
         assert_eq!(subs.len(), 1);
         assert_eq!(subs[0].title, "Child task");
@@ -758,17 +655,7 @@ mod tests {
             defer_id: false,
             force: false,
         };
-        let result = run(
-            &db,
-            None,
-            "Bad priority",
-            None,
-            "urgent",
-            None,
-            None,
-            None,
-            &opts,
-        );
+        let result = run(&db, "Bad priority", None, "urgent", None, None, None, &opts);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Invalid priority"));
     }
@@ -900,7 +787,6 @@ mod tests {
         let opts = validating_opts(dir.path(), false);
         run(
             &db,
-            None,
             "Investigate",
             Some("Rationale: we need this to understand the failure mode in detail"),
             "medium",
@@ -920,7 +806,6 @@ mod tests {
         let opts = validating_opts(dir.path(), false);
         let err = run(
             &db,
-            None,
             "Investigate",
             None,
             "medium",
@@ -943,7 +828,6 @@ mod tests {
         let opts = validating_opts(dir.path(), false);
         let err = run(
             &db,
-            None,
             "Investigate",
             Some("Rationale: tiny"),
             "medium",
@@ -964,7 +848,6 @@ mod tests {
         let opts = validating_opts(dir.path(), true);
         run(
             &db,
-            None,
             "Investigate",
             Some("Rationale: tiny"),
             "medium",
@@ -991,7 +874,6 @@ mod tests {
 
         run(
             &db,
-            None,
             "Investigate",
             None,
             "medium",
@@ -1011,7 +893,6 @@ mod tests {
         let opts = validating_opts(dir.path(), false);
         run(
             &db,
-            None,
             "A feature",
             None,
             "medium",
@@ -1033,7 +914,6 @@ mod tests {
 
         let err = run_subissue(
             &db,
-            None,
             parent_id,
             "Child",
             Some("Rationale: tiny"),
@@ -1048,7 +928,6 @@ mod tests {
 
         run_subissue(
             &db,
-            None,
             parent_id,
             "Child",
             Some("Rationale: a thoroughly detailed explanation of the child task"),
@@ -1074,7 +953,6 @@ mod tests {
         };
         let err = run(
             &db,
-            None,
             "Quick research",
             None,
             "medium",

--- a/crosslink/src/commands/delete.rs
+++ b/crosslink/src/commands/delete.rs
@@ -1,12 +1,14 @@
 use anyhow::{bail, Result};
 use std::io::{self, Write};
 
-use crate::db::Database;
-use crate::shared_writer::SharedWriter;
+use crate::application::{CommandService, QueryService};
 use crate::utils::format_issue_id;
 
-pub fn run(db: &Database, writer: Option<&SharedWriter>, id: i64, force: bool) -> Result<()> {
-    let Some(issue) = db.get_issue(id)? else {
+#[cfg(test)]
+use crate::db::Database;
+
+pub fn run(service: &(impl CommandService + QueryService), id: i64, force: bool) -> Result<()> {
+    let Some(issue) = service.get_issue(id)? else {
         bail!("Issue {} not found", format_issue_id(id));
     };
 
@@ -27,21 +29,15 @@ pub fn run(db: &Database, writer: Option<&SharedWriter>, id: i64, force: bool) -
         }
     }
 
-    if let Some(w) = writer {
-        w.delete_issue(db, id)?;
-        println!("Deleted issue {}", format_issue_id(id));
-    } else if db.delete_issue(id)? {
-        println!("Deleted issue {}", format_issue_id(id));
-    } else {
-        bail!("Failed to delete issue {}", format_issue_id(id));
-    }
+    service.delete_issue(id)?;
+    println!("Deleted issue {}", format_issue_id(id));
 
     Ok(())
 }
 
 #[cfg(test)]
-pub fn run_force(db: &Database, id: i64) -> Result<()> {
-    run(db, None, id, true)
+pub fn run_force(service: &(impl CommandService + QueryService), id: i64) -> Result<()> {
+    run(service, id, true)
 }
 
 #[cfg(test)]

--- a/crosslink/src/commands/deps.rs
+++ b/crosslink/src/commands/deps.rs
@@ -1,34 +1,25 @@
 use anyhow::{bail, Result};
 use serde_json;
 
-use crate::db::Database;
-use crate::shared_writer::SharedWriter;
+use crate::application::{CommandService, QueryService};
 use crate::utils::{format_issue_id, truncate};
 
+#[cfg(test)]
+use crate::db::Database;
+
 pub fn block(
-    db: &Database,
-    writer: Option<&SharedWriter>,
+    service: &(impl CommandService + QueryService),
     issue_id: i64,
     blocker_id: i64,
 ) -> Result<()> {
-    db.require_issue(issue_id)?;
-    db.require_issue(blocker_id)?;
+    service.require_issue(issue_id)?;
+    service.require_issue(blocker_id)?;
 
     if issue_id == blocker_id {
         bail!("An issue cannot block itself");
     }
 
-    if let Some(w) = writer {
-        if w.add_blocker(db, issue_id, blocker_id)? {
-            println!(
-                "Issue {} is now blocked by {}",
-                format_issue_id(issue_id),
-                format_issue_id(blocker_id)
-            );
-        } else {
-            println!("Dependency already exists");
-        }
-    } else if db.add_dependency(issue_id, blocker_id)? {
+    if service.add_dependency(issue_id, blocker_id)? {
         println!(
             "Issue {} is now blocked by {}",
             format_issue_id(issue_id),
@@ -40,23 +31,8 @@ pub fn block(
     Ok(())
 }
 
-pub fn unblock(
-    db: &Database,
-    writer: Option<&SharedWriter>,
-    issue_id: i64,
-    blocker_id: i64,
-) -> Result<()> {
-    if let Some(w) = writer {
-        if w.remove_blocker(db, issue_id, blocker_id)? {
-            println!(
-                "Removed: {} no longer blocked by {}",
-                format_issue_id(issue_id),
-                format_issue_id(blocker_id)
-            );
-        } else {
-            println!("No such dependency found");
-        }
-    } else if db.remove_dependency(issue_id, blocker_id)? {
+pub fn unblock(service: &impl CommandService, issue_id: i64, blocker_id: i64) -> Result<()> {
+    if service.remove_dependency(issue_id, blocker_id)? {
         println!(
             "Removed: {} no longer blocked by {}",
             format_issue_id(issue_id),
@@ -68,7 +44,7 @@ pub fn unblock(
     Ok(())
 }
 
-pub fn list_blocked(db: &Database, json: bool) -> Result<()> {
+pub fn list_blocked(db: &impl QueryService, json: bool) -> Result<()> {
     let issues = db.list_blocked_issues()?;
 
     if json {
@@ -112,7 +88,7 @@ pub fn list_blocked(db: &Database, json: bool) -> Result<()> {
     Ok(())
 }
 
-pub fn list_ready(db: &Database, json: bool) -> Result<()> {
+pub fn list_ready(db: &impl QueryService, json: bool) -> Result<()> {
     let issues = db.list_ready_issues()?;
 
     if json {
@@ -156,7 +132,7 @@ mod tests {
         let issue1 = db.create_issue("Issue 1", None, "medium").unwrap();
         let issue2 = db.create_issue("Issue 2", None, "medium").unwrap();
 
-        block(&db, None, issue1, issue2).unwrap();
+        block(&db, issue1, issue2).unwrap();
         let blockers = db.get_blockers(issue1).unwrap();
         assert!(
             blockers.contains(&issue2),
@@ -169,7 +145,7 @@ mod tests {
         let (db, _dir) = setup_test_db();
         let issue = db.create_issue("Issue", None, "medium").unwrap();
 
-        let result = block(&db, None, 99999, issue);
+        let result = block(&db, 99999, issue);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("not found"));
     }
@@ -179,7 +155,7 @@ mod tests {
         let (db, _dir) = setup_test_db();
         let issue = db.create_issue("Issue", None, "medium").unwrap();
 
-        let result = block(&db, None, issue, 99999);
+        let result = block(&db, issue, 99999);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("not found"));
     }
@@ -189,7 +165,7 @@ mod tests {
         let (db, _dir) = setup_test_db();
         let issue = db.create_issue("Issue", None, "medium").unwrap();
 
-        let result = block(&db, None, issue, issue);
+        let result = block(&db, issue, issue);
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
@@ -203,8 +179,8 @@ mod tests {
         let issue1 = db.create_issue("Issue 1", None, "medium").unwrap();
         let issue2 = db.create_issue("Issue 2", None, "medium").unwrap();
 
-        block(&db, None, issue1, issue2).unwrap();
-        block(&db, None, issue1, issue2).unwrap();
+        block(&db, issue1, issue2).unwrap();
+        block(&db, issue1, issue2).unwrap();
         let blockers = db.get_blockers(issue1).unwrap();
         assert_eq!(
             blockers.len(),
@@ -221,7 +197,7 @@ mod tests {
         let issue2 = db.create_issue("Issue 2", None, "medium").unwrap();
         db.add_dependency(issue1, issue2).unwrap();
 
-        unblock(&db, None, issue1, issue2).unwrap();
+        unblock(&db, issue1, issue2).unwrap();
         let blockers = db.get_blockers(issue1).unwrap();
         assert!(
             blockers.is_empty(),
@@ -235,7 +211,7 @@ mod tests {
         let issue1 = db.create_issue("Issue 1", None, "medium").unwrap();
         let issue2 = db.create_issue("Issue 2", None, "medium").unwrap();
 
-        unblock(&db, None, issue1, issue2).unwrap();
+        unblock(&db, issue1, issue2).unwrap();
         let blockers = db.get_blockers(issue1).unwrap();
         assert!(blockers.is_empty(), "No blockers should exist");
     }
@@ -326,11 +302,11 @@ mod tests {
         let issue1 = db.create_issue("Issue 1", None, "medium").unwrap();
         let issue2 = db.create_issue("Issue 2", None, "medium").unwrap();
 
-        block(&db, None, issue1, issue2).unwrap();
+        block(&db, issue1, issue2).unwrap();
         let blocked = db.list_blocked_issues().unwrap();
         assert!(blocked.iter().any(|i| i.id == issue1));
 
-        unblock(&db, None, issue1, issue2).unwrap();
+        unblock(&db, issue1, issue2).unwrap();
         let blocked = db.list_blocked_issues().unwrap();
         assert!(!blocked.iter().any(|i| i.id == issue1));
     }
@@ -364,7 +340,7 @@ mod tests {
             let issue1 = db.create_issue(&title1, None, "medium").unwrap();
             let issue2 = db.create_issue(&title2, None, "medium").unwrap();
 
-            block(&db, None, issue1, issue2).unwrap();
+            block(&db, issue1, issue2).unwrap();
             let blockers = db.get_blockers(issue1).unwrap();
             prop_assert!(blockers.contains(&issue2));
             let blocked = db.list_blocked_issues().unwrap();

--- a/crosslink/src/commands/export.rs
+++ b/crosslink/src/commands/export.rs
@@ -1,15 +1,12 @@
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use std::fs;
 use std::io::{self, Write};
-use uuid::Uuid;
 
 use crate::application::QueryService;
 
 #[cfg(test)]
 use crate::db::Database;
-use crate::issue_file::{CommentEntry, IssueFile, TimeEntry};
 use crate::models::Issue;
 use crate::utils::format_issue_id;
 use std::fmt::Write as _;
@@ -42,132 +39,8 @@ pub struct ExportData {
     pub issues: Vec<ExportedIssue>,
 }
 
-fn build_uuid_map(db: &impl QueryService, issues: &[Issue]) -> Result<HashMap<i64, Uuid>> {
-    let mut map = HashMap::new();
-    for issue in issues {
-        let (uuid_str, _) = db.get_issue_export_metadata(issue.id)?;
-        let uuid = uuid_str
-            .and_then(|s| Uuid::parse_str(&s).ok())
-            .unwrap_or_else(Uuid::new_v4);
-        map.insert(issue.id, uuid);
-    }
-    Ok(map)
-}
-
-fn resolve_uuid(db: &impl QueryService, uuid_map: &HashMap<i64, Uuid>, id: i64) -> Uuid {
-    if let Some(&uuid) = uuid_map.get(&id) {
-        return uuid;
-    }
-
-    db.get_issue_uuid_by_id(id)
-        .ok()
-        .and_then(|s| Uuid::parse_str(&s).ok())
-        .unwrap_or_else(Uuid::new_v4)
-}
-
-fn build_issue_file(
-    db: &impl QueryService,
-    issue: &Issue,
-    uuid_map: &HashMap<i64, Uuid>,
-) -> Result<IssueFile> {
-    let uuid = *uuid_map
-        .get(&issue.id)
-        .ok_or_else(|| anyhow::anyhow!("issue {} missing from uuid_map", issue.id))?;
-
-    let (_, created_by) = db.get_issue_export_metadata(issue.id)?;
-
-    let parent_uuid = issue.parent_id.map(|pid| resolve_uuid(db, uuid_map, pid));
-
-    let labels = db.get_labels(issue.id)?;
-
-    let comments_raw = db.get_comments_with_author(issue.id)?;
-    let comments: Vec<CommentEntry> = comments_raw
-        .into_iter()
-        .map(
-            |(
-                id,
-                author,
-                content,
-                created_at,
-                kind,
-                trigger_type,
-                intervention_context,
-                driver_key_fingerprint,
-            )| {
-                CommentEntry {
-                    id,
-                    author: author.unwrap_or_else(|| "unknown".to_string()),
-                    content,
-                    created_at,
-                    kind,
-                    trigger_type,
-                    intervention_context,
-                    driver_key_fingerprint,
-                    signed_by: None,
-                    signature: None,
-                }
-            },
-        )
-        .collect();
-
-    let blocker_ids = db.get_blockers(issue.id)?;
-    let blockers: Vec<Uuid> = blocker_ids
-        .iter()
-        .map(|&bid| resolve_uuid(db, uuid_map, bid))
-        .collect();
-
-    let related_ids = db.get_related_issue_ids(issue.id)?;
-    let related: Vec<Uuid> = related_ids
-        .iter()
-        .map(|&rid| resolve_uuid(db, uuid_map, rid))
-        .collect();
-
-    let milestone_uuid = db
-        .get_milestone_uuid_for_issue(issue.id)?
-        .and_then(|s| Uuid::parse_str(&s).ok());
-
-    let time_entries_raw = db.get_time_entries_for_issue(issue.id)?;
-    let time_entries: Vec<TimeEntry> = time_entries_raw
-        .into_iter()
-        .map(|(id, started_at, ended_at, duration_seconds)| TimeEntry {
-            id,
-            started_at,
-            ended_at,
-            duration_seconds,
-        })
-        .collect();
-
-    Ok(IssueFile {
-        uuid,
-        display_id: Some(issue.id),
-        title: issue.title.clone(),
-        description: issue.description.clone(),
-        status: issue.status,
-        priority: issue.priority,
-        parent_uuid,
-        created_by: created_by.unwrap_or_else(|| "unknown".to_string()),
-        created_at: issue.created_at,
-        updated_at: issue.updated_at,
-        closed_at: issue.closed_at,
-        scheduled_at: issue.scheduled_at,
-        due_at: issue.due_at,
-        labels,
-        comments,
-        blockers,
-        related,
-        milestone_uuid,
-        time_entries,
-    })
-}
-
 pub fn run_json(db: &impl QueryService, output_path: Option<&str>) -> Result<()> {
-    let issues = db.list_issues(Some("all"), None, None)?;
-    let uuid_map = build_uuid_map(db, &issues)?;
-
-    let issue_files: Vec<IssueFile> = issues
-        .iter()
-        .map(|i| build_issue_file(db, i, &uuid_map))
-        .collect::<Result<Vec<_>>>()?;
+    let issue_files = db.list_issue_records()?;
 
     let json = serde_json::to_string_pretty(&issue_files)?;
 

--- a/crosslink/src/commands/export.rs
+++ b/crosslink/src/commands/export.rs
@@ -5,6 +5,9 @@ use std::fs;
 use std::io::{self, Write};
 use uuid::Uuid;
 
+use crate::application::QueryService;
+
+#[cfg(test)]
 use crate::db::Database;
 use crate::issue_file::{CommentEntry, IssueFile, TimeEntry};
 use crate::models::Issue;
@@ -39,7 +42,7 @@ pub struct ExportData {
     pub issues: Vec<ExportedIssue>,
 }
 
-fn build_uuid_map(db: &Database, issues: &[Issue]) -> Result<HashMap<i64, Uuid>> {
+fn build_uuid_map(db: &impl QueryService, issues: &[Issue]) -> Result<HashMap<i64, Uuid>> {
     let mut map = HashMap::new();
     for issue in issues {
         let (uuid_str, _) = db.get_issue_export_metadata(issue.id)?;
@@ -51,7 +54,7 @@ fn build_uuid_map(db: &Database, issues: &[Issue]) -> Result<HashMap<i64, Uuid>>
     Ok(map)
 }
 
-fn resolve_uuid(db: &Database, uuid_map: &HashMap<i64, Uuid>, id: i64) -> Uuid {
+fn resolve_uuid(db: &impl QueryService, uuid_map: &HashMap<i64, Uuid>, id: i64) -> Uuid {
     if let Some(&uuid) = uuid_map.get(&id) {
         return uuid;
     }
@@ -63,7 +66,7 @@ fn resolve_uuid(db: &Database, uuid_map: &HashMap<i64, Uuid>, id: i64) -> Uuid {
 }
 
 fn build_issue_file(
-    db: &Database,
+    db: &impl QueryService,
     issue: &Issue,
     uuid_map: &HashMap<i64, Uuid>,
 ) -> Result<IssueFile> {
@@ -157,7 +160,7 @@ fn build_issue_file(
     })
 }
 
-pub fn run_json(db: &Database, output_path: Option<&str>) -> Result<()> {
+pub fn run_json(db: &impl QueryService, output_path: Option<&str>) -> Result<()> {
     let issues = db.list_issues(Some("all"), None, None)?;
     let uuid_map = build_uuid_map(db, &issues)?;
 
@@ -178,7 +181,7 @@ pub fn run_json(db: &Database, output_path: Option<&str>) -> Result<()> {
     Ok(())
 }
 
-pub fn run_markdown(db: &Database, output_path: Option<&str>) -> Result<()> {
+pub fn run_markdown(db: &impl QueryService, output_path: Option<&str>) -> Result<()> {
     let issues = db.list_issues(Some("all"), None, None)?;
     let mut md = String::new();
 
@@ -233,7 +236,7 @@ pub fn run_markdown(db: &Database, output_path: Option<&str>) -> Result<()> {
     Ok(())
 }
 
-fn write_issue_md(md: &mut String, db: &Database, issue: &Issue) -> Result<()> {
+fn write_issue_md(md: &mut String, db: &impl QueryService, issue: &Issue) -> Result<()> {
     let checkbox = if issue.status == crate::models::IssueStatus::Closed {
         "[x]"
     } else {

--- a/crosslink/src/commands/hub_v3_operation_tests.rs
+++ b/crosslink/src/commands/hub_v3_operation_tests.rs
@@ -5,6 +5,7 @@ use std::process::Command;
 
 use tempfile::TempDir;
 
+use crate::application::{CommandService, RepositoryService};
 use crate::db::Database;
 use crate::hub_v3::{self, agent_ref_name, HubMode};
 use crate::identity::{AgentConfig, AgentRole};
@@ -350,6 +351,33 @@ fn v3_mode_resolves_after_migration() {
 }
 
 #[test]
+fn failed_git_publication_cannot_create_sqlite_only_issue() {
+    if !git_ok() {
+        return;
+    }
+    let hub = setup_migrated_v3_hub();
+    let db = Database::open(&hub.crosslink_dir.join("issues.db")).unwrap();
+    let before = db.get_issue_count().unwrap();
+    let missing_remote = hub.work.path().join("missing-authority.git");
+    git(
+        &hub.cache_dir,
+        &[
+            "remote",
+            "set-url",
+            "origin",
+            missing_remote.to_str().unwrap(),
+        ],
+    );
+    let service = RepositoryService::new(&db, &hub.crosslink_dir).unwrap();
+
+    let result = service.create_issue("must not project", None, "medium", None, None);
+
+    assert!(result.is_err());
+    assert_eq!(db.get_issue_count().unwrap(), before);
+    assert!(db.search_issues("must not project").unwrap().is_empty());
+}
+
+#[test]
 fn v3_lifecycle_no_worktree_writes() {
     if !git_ok() {
         return;
@@ -561,28 +589,29 @@ fn v3_lock_release_works_from_fresh_process() {
 }
 
 #[test]
-fn v3_offline_mutation_durable_then_delivered() {
+fn v3_offline_mutation_fails_without_projection_or_ref_drift() {
     if !git_ok() {
         return;
     }
     let hub = setup_migrated_v3_hub();
     let db = Database::open(&hub.crosslink_dir.join("issues.db")).unwrap();
     let writer = SharedWriter::new(&hub.crosslink_dir).unwrap().unwrap();
+    let before_count = db.get_issue_count().unwrap();
+    let before_tip =
+        hub_v3::git_rev_parse_optional(&hub.cache_dir, &agent_ref_name("alpha").unwrap()).unwrap();
 
     git(
         hub.work.path(),
         &["remote", "set-url", "origin", "/nonexistent/remote-xyz.git"],
     );
 
-    let id = writer
-        .create_issue(&db, "Offline issue", None, "medium", None, None)
-        .unwrap();
-    assert!(id > 0);
-    assert!(db.get_issue(id).unwrap().is_some());
-    let local_seq = hub_v3::read_max_event_seq_from_ref(&hub.cache_dir, "alpha").unwrap();
-    assert!(
-        local_seq > 0,
-        "event durable on local ref despite push failure"
+    let result = writer.create_issue(&db, "Offline issue", None, "medium", None, None);
+    assert!(result.is_err());
+    assert_eq!(db.get_issue_count().unwrap(), before_count);
+    assert!(db.search_issues("Offline issue").unwrap().is_empty());
+    assert_eq!(
+        hub_v3::git_rev_parse_optional(&hub.cache_dir, &agent_ref_name("alpha").unwrap()).unwrap(),
+        before_tip
     );
 
     git(
@@ -598,6 +627,7 @@ fn v3_offline_mutation_durable_then_delivered() {
         .create_issue(&db, "Back online", None, "low", None, None)
         .unwrap();
     assert!(id2 > 0);
+    assert!(db.search_issues("Offline issue").unwrap().is_empty());
     let ls = Command::new("git")
         .current_dir(hub.remote.path())
         .args([

--- a/crosslink/src/commands/hub_v3_operation_tests.rs
+++ b/crosslink/src/commands/hub_v3_operation_tests.rs
@@ -1112,7 +1112,11 @@ fn v3_import_issues_promotes_batch_to_hub() {
     let assigned = writer.import_issues(&db, &specs).unwrap();
     assert_eq!(assigned.len(), 2);
     assert_eq!(rev_count(&hub.cache_dir, &agent_ref), commits_before + 1);
-    assert!(loose_object_count(&hub.cache_dir) - objects_before <= 12);
+    let objects_after = loose_object_count(&hub.cache_dir);
+    assert!(
+        objects_after <= objects_before.saturating_add(12),
+        "batched import created too many loose objects: before={objects_before}, after={objects_after}"
+    );
     let (parent_id, child_id) = (assigned[0].1, assigned[1].1);
     assert!(parent_id > 0 && child_id > 0, "reduction-assigned ids");
 

--- a/crosslink/src/commands/import.rs
+++ b/crosslink/src/commands/import.rs
@@ -3,15 +3,18 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 
-use super::export::{ExportData, ExportedIssue};
-use crate::db::Database;
+use super::export::ExportData;
+use crate::application::CommandService;
 use crate::issue_file::IssueFile;
-use crate::shared_writer::{ImportedCommentSpec, ImportedIssueSpec, SharedWriter};
+use crate::shared_writer::{ImportedCommentSpec, ImportedIssueSpec};
 use crate::utils::format_issue_id;
 
 const MAX_IMPORT_SIZE: u64 = 10 * 1024 * 1024;
 
-pub fn run_json(db: &Database, writer: Option<&SharedWriter>, input_path: &Path) -> Result<()> {
+#[cfg(test)]
+use crate::db::Database;
+
+pub fn run_json(service: &impl CommandService, input_path: &Path) -> Result<()> {
     let metadata = fs::metadata(input_path).context("Failed to read import file metadata")?;
     if metadata.len() > MAX_IMPORT_SIZE {
         anyhow::bail!(
@@ -22,21 +25,30 @@ pub fn run_json(db: &Database, writer: Option<&SharedWriter>, input_path: &Path)
     }
     let content = fs::read_to_string(input_path).context("Failed to read import file")?;
 
-    if let Ok(issue_files) = serde_json::from_str::<Vec<IssueFile>>(&content) {
-        if let Some(w) = writer.filter(|w| w.is_v3_public()) {
-            let specs: Vec<ImportedIssueSpec> =
-                issue_files.iter().map(spec_from_issue_file).collect();
-            return import_shared(db, w, &specs, "IssueFile", input_path);
-        }
-        return import_issue_files(db, &issue_files, input_path);
+    let (specs, format) = if let Ok(issue_files) = serde_json::from_str::<Vec<IssueFile>>(&content)
+    {
+        (
+            issue_files
+                .iter()
+                .map(spec_from_issue_file)
+                .collect::<Vec<_>>(),
+            "IssueFile",
+        )
+    } else {
+        let data: ExportData = serde_json::from_str(&content).context("Failed to parse JSON")?;
+        (specs_from_legacy(&data), "legacy")
+    };
+    println!(
+        "Importing {} issues from {} ({format} format)",
+        specs.len(),
+        input_path.display()
+    );
+    let assigned = service.import_issues(&specs)?;
+    for (spec, (_, new_id)) in specs.iter().zip(&assigned) {
+        println!("  Imported: {} {}", format_issue_id(*new_id), spec.title);
     }
-
-    let data: ExportData = serde_json::from_str(&content).context("Failed to parse JSON")?;
-    if let Some(w) = writer.filter(|w| w.is_v3_public()) {
-        let specs = specs_from_legacy(&data);
-        return import_shared(db, w, &specs, "legacy", input_path);
-    }
-    import_legacy(db, &data, input_path)
+    println!("Successfully imported {} issues", assigned.len());
+    Ok(())
 }
 
 fn spec_from_issue_file(issue: &IssueFile) -> ImportedIssueSpec {
@@ -101,164 +113,6 @@ fn specs_from_legacy(data: &ExportData) -> Vec<ImportedIssueSpec> {
         .collect()
 }
 
-fn import_shared(
-    db: &Database,
-    writer: &SharedWriter,
-    specs: &[ImportedIssueSpec],
-    format: &str,
-    input_path: &Path,
-) -> Result<()> {
-    println!(
-        "Importing {} issues from {} ({format} format, promoting to hub)",
-        specs.len(),
-        input_path.display()
-    );
-    let assigned = writer.import_issues(db, specs)?;
-    for (spec, (_uuid, new_id)) in specs.iter().zip(&assigned) {
-        println!("  Imported: {} {}", format_issue_id(*new_id), spec.title);
-    }
-    println!("Successfully imported {} issues", assigned.len());
-    Ok(())
-}
-
-fn import_issue_files(db: &Database, issues: &[IssueFile], input_path: &Path) -> Result<()> {
-    println!(
-        "Importing {} issues from {} (IssueFile format)",
-        issues.len(),
-        input_path.display()
-    );
-
-    let count = db.transaction(|| {
-        let mut uuid_to_new_id: HashMap<uuid::Uuid, i64> = HashMap::new();
-
-        for issue in issues {
-            let new_id = db.create_issue(
-                &issue.title,
-                issue.description.as_deref(),
-                issue.priority.as_str(),
-            )?;
-
-            for label in &issue.labels {
-                db.add_label(new_id, label)?;
-            }
-
-            for comment in &issue.comments {
-                db.add_comment(new_id, &comment.content, "note")?;
-            }
-
-            if issue.status == crate::models::IssueStatus::Closed {
-                db.close_issue(new_id)?;
-            }
-
-            uuid_to_new_id.insert(issue.uuid, new_id);
-
-            println!(
-                "  Imported: {} -> {} {}",
-                issue
-                    .display_id
-                    .map_or_else(|| issue.uuid.to_string(), format_issue_id),
-                format_issue_id(new_id),
-                issue.title
-            );
-        }
-
-        for issue in issues {
-            if let Some(parent_uuid) = issue.parent_uuid {
-                if let (Some(&new_id), Some(&new_parent_id)) = (
-                    uuid_to_new_id.get(&issue.uuid),
-                    uuid_to_new_id.get(&parent_uuid),
-                ) {
-                    db.update_parent(new_id, Some(new_parent_id))?;
-                }
-            }
-        }
-
-        for issue in issues {
-            if let Some(&new_blocked_id) = uuid_to_new_id.get(&issue.uuid) {
-                for blocker_uuid in &issue.blockers {
-                    if let Some(&new_blocker_id) = uuid_to_new_id.get(blocker_uuid) {
-                        let _ = db.add_dependency(new_blocked_id, new_blocker_id);
-                    }
-                }
-            }
-        }
-
-        Ok(issues.len())
-    })?;
-
-    println!("Successfully imported {count} issues");
-    Ok(())
-}
-
-fn import_legacy(db: &Database, data: &ExportData, input_path: &Path) -> Result<()> {
-    println!(
-        "Importing {} issues from {} (legacy format)",
-        data.issues.len(),
-        input_path.display()
-    );
-
-    let count = db.transaction(|| {
-        let mut id_map: HashMap<i64, i64> = HashMap::new();
-
-        for issue in &data.issues {
-            let new_id = import_issue(db, issue, None)?;
-            id_map.insert(issue.id, new_id);
-        }
-
-        for issue in &data.issues {
-            if let Some(old_parent_id) = issue.parent_id {
-                if let Some(&new_parent_id) = id_map.get(&old_parent_id) {
-                    if let Some(&new_id) = id_map.get(&issue.id) {
-                        db.update_parent(new_id, Some(new_parent_id))?;
-                    }
-                }
-            }
-        }
-
-        Ok(data.issues.len())
-    })?;
-
-    println!("Successfully imported {count} issues");
-    Ok(())
-}
-
-fn import_issue(db: &Database, issue: &ExportedIssue, parent_id: Option<i64>) -> Result<i64> {
-    let id = if let Some(pid) = parent_id {
-        db.create_subissue(
-            pid,
-            &issue.title,
-            issue.description.as_deref(),
-            issue.priority.as_str(),
-        )?
-    } else {
-        db.create_issue(
-            &issue.title,
-            issue.description.as_deref(),
-            issue.priority.as_str(),
-        )?
-    };
-
-    for label in &issue.labels {
-        db.add_label(id, label)?;
-    }
-
-    for comment in &issue.comments {
-        db.add_comment(id, &comment.content, "note")?;
-    }
-
-    if issue.status == crate::models::IssueStatus::Closed {
-        db.close_issue(id)?;
-    }
-
-    println!(
-        "  Imported: #{} -> {} {}",
-        issue.id,
-        format_issue_id(id),
-        issue.title
-    );
-    Ok(id)
-}
-
 #[cfg(test)]
 mod tests {
     use super::super::export::{ExportData, ExportedIssue};
@@ -304,7 +158,7 @@ mod tests {
         let json = create_test_export(vec![make_issue(1, "Test issue", None, "open")]);
         let import_path = dir.path().join("import.json");
         fs::write(&import_path, json).unwrap();
-        let result = run_json(&db, None, &import_path);
+        let result = run_json(&db, &import_path);
         assert!(result.is_ok());
         let issues = db.list_issues(Some("all"), None, None).unwrap();
         assert_eq!(issues.len(), 1);
@@ -319,7 +173,7 @@ mod tests {
         ]);
         let import_path = dir.path().join("import.json");
         fs::write(&import_path, json).unwrap();
-        run_json(&db, None, &import_path).unwrap();
+        run_json(&db, &import_path).unwrap();
         let issues = db.list_issues(Some("all"), None, None).unwrap();
         assert_eq!(issues.len(), 2);
     }
@@ -330,7 +184,7 @@ mod tests {
         let json = create_test_export(vec![make_issue(1, "Closed", None, "closed")]);
         let import_path = dir.path().join("import.json");
         fs::write(&import_path, json).unwrap();
-        run_json(&db, None, &import_path).unwrap();
+        run_json(&db, &import_path).unwrap();
         let issues = db.list_issues(Some("closed"), None, None).unwrap();
         assert_eq!(issues.len(), 1);
     }
@@ -343,7 +197,7 @@ mod tests {
         let json = create_test_export(vec![issue]);
         let import_path = dir.path().join("import.json");
         fs::write(&import_path, json).unwrap();
-        run_json(&db, None, &import_path).unwrap();
+        run_json(&db, &import_path).unwrap();
         let issues = db.list_issues(Some("all"), None, None).unwrap();
         let labels = db.get_labels(issues[0].id).unwrap();
         assert!(labels.contains(&"bug".to_string()));
@@ -354,7 +208,7 @@ mod tests {
         let (db, dir) = setup_test_db();
         let import_path = dir.path().join("invalid.json");
         fs::write(&import_path, "not valid json").unwrap();
-        let result = run_json(&db, None, &import_path);
+        let result = run_json(&db, &import_path);
         assert!(result.is_err());
     }
 
@@ -362,7 +216,7 @@ mod tests {
     fn test_import_missing_file() {
         let (db, dir) = setup_test_db();
         let import_path = dir.path().join("nonexistent.json");
-        let result = run_json(&db, None, &import_path);
+        let result = run_json(&db, &import_path);
         assert!(result.is_err());
     }
 
@@ -372,7 +226,7 @@ mod tests {
         let json = create_test_export(vec![]);
         let import_path = dir.path().join("import.json");
         fs::write(&import_path, json).unwrap();
-        let result = run_json(&db, None, &import_path);
+        let result = run_json(&db, &import_path);
         assert!(result.is_ok());
     }
 
@@ -403,7 +257,7 @@ mod tests {
         let json = serde_json::to_string_pretty(&vec![issue]).unwrap();
         let import_path = dir.path().join("import.json");
         fs::write(&import_path, &json).unwrap();
-        run_json(&db, None, &import_path).unwrap();
+        run_json(&db, &import_path).unwrap();
         let issues = db.list_issues(Some("all"), None, None).unwrap();
         assert_eq!(issues.len(), 1);
         assert_eq!(issues[0].title, "New format issue");
@@ -418,7 +272,7 @@ mod tests {
             let json = create_test_export(vec![make_issue(1, &title, None, "open")]);
             let import_path = dir.path().join("import.json");
             fs::write(&import_path, json).unwrap();
-            let result = run_json(&db, None, &import_path);
+            let result = run_json(&db, &import_path);
             prop_assert!(result.is_ok());
         }
     }

--- a/crosslink/src/commands/integrity_cmd.rs
+++ b/crosslink/src/commands/integrity_cmd.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use anyhow::{bail, Context};
 use std::path::PathBuf;
 
+use crate::application::QueryService;
 use crate::checkpoint::CheckpointState;
 use crate::db::{Database, SCHEMA_VERSION};
 use crate::hydration::{hydrate_from_state, hydrate_to_sqlite};
@@ -295,11 +296,11 @@ fn check_hydration(
         });
     }
 
-    let writer = crate::shared_writer::SharedWriter::new(crosslink_dir)?;
+    let service = crate::application::RepositoryService::new(db, crosslink_dir)?;
     let mut re_emit_summary: Option<String> = None;
     if !drift.is_empty() {
-        if let Some(w) = writer.as_ref() {
-            let stats = super::integrity_drift::re_emit(&drift, w, db)?;
+        if service.authority_mode() == crate::application::AuthorityMode::Shared {
+            let stats = super::integrity_drift::re_emit(&drift, &service)?;
             if stats.total() > 0 {
                 re_emit_summary = Some(format!(
                     "re-emitted {} label(s), {} dep(s), {} relation(s), \
@@ -459,9 +460,15 @@ fn check_locks(crosslink_dir: &Path, repair: bool) -> Result<CheckResult> {
 
     let mut released = 0;
     if sync.hub_mode().is_v3() {
-        if let Ok(Some(writer)) = crate::shared_writer::SharedWriter::new(crosslink_dir) {
+        let database = Database::open(&crosslink_dir.join("issues.db"))?;
+        let service = crate::application::RepositoryService::new(&database, crosslink_dir)?;
+        {
             for (id, stale_agent_id) in &stale {
-                match writer.force_release_lock_v2(*id, stale_agent_id) {
+                match crate::application::CommandService::force_release_lock(
+                    &service,
+                    *id,
+                    stale_agent_id,
+                ) {
                     Ok(_) => released += 1,
                     Err(e) => tracing::warn!("Could not release stale lock #{}: {}", id, e),
                 }

--- a/crosslink/src/commands/integrity_cmd.rs
+++ b/crosslink/src/commands/integrity_cmd.rs
@@ -321,7 +321,7 @@ fn check_hydration(
         }
     }
 
-    db.clear_shared_data()?;
+    crate::hydration::clear_shared_projection(db)?;
     let stats = hydrate_to_sqlite(&cache_dir, db)?;
 
     let mut parts: Vec<String> = vec![format!(

--- a/crosslink/src/commands/integrity_drift.rs
+++ b/crosslink/src/commands/integrity_drift.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use std::path::Path;
 
+use crate::application::CommandService;
 use crate::db::Database;
 use crate::hydration::hydrate_to_sqlite;
 
@@ -235,25 +236,24 @@ impl ReEmitStats {
 
 pub fn re_emit(
     drift: &HydrationDriftReport,
-    writer: &crate::shared_writer::SharedWriter,
-    db: &Database,
+    commands: &impl CommandService,
 ) -> Result<ReEmitStats> {
     let mut stats = ReEmitStats::default();
 
     for (issue_id, label) in &drift.sqlite_only_labels {
-        if writer.add_label(db, *issue_id, label)? {
+        if commands.add_label(*issue_id, label)? {
             stats.labels += 1;
         }
     }
 
     for (blocker_id, blocked_id) in &drift.sqlite_only_dependencies {
-        if writer.add_blocker(db, *blocked_id, *blocker_id)? {
+        if commands.add_dependency(*blocked_id, *blocker_id)? {
             stats.dependencies += 1;
         }
     }
 
     for (a, b) in &drift.sqlite_only_relations {
-        if writer.add_relation(db, *a, *b)? {
+        if commands.add_relation(*a, *b)? {
             stats.relations += 1;
         }
     }
@@ -265,7 +265,7 @@ pub fn re_emit(
             by_milestone.entry(*m_id).or_default().push(*i_id);
         }
         for (m_id, issue_ids) in by_milestone {
-            writer.set_milestone_on_issues(db, m_id, &issue_ids)?;
+            commands.assign_milestone(m_id, &issue_ids)?;
             stats.milestone_issues += issue_ids.len();
         }
     }

--- a/crosslink/src/commands/intervene.rs
+++ b/crosslink/src/commands/intervene.rs
@@ -1,11 +1,13 @@
 use anyhow::{bail, Result};
 use std::path::Path;
 
-use crate::db::Database;
+use crate::application::{CommandService, QueryService};
 use crate::identity::resolve_driver_fingerprint;
 use crate::issue_file::validate_trigger_type;
-use crate::shared_writer::SharedWriter;
 use crate::utils::format_issue_id;
+
+#[cfg(test)]
+use crate::db::Database;
 
 fn is_intervention_tracking_enabled(crosslink_dir: &Path) -> bool {
     let config_path = crosslink_dir.join("hook-config.json");
@@ -22,8 +24,7 @@ fn is_intervention_tracking_enabled(crosslink_dir: &Path) -> bool {
 }
 
 pub fn run(
-    db: &Database,
-    writer: Option<&SharedWriter>,
+    service: &(impl CommandService + QueryService),
     issue_id: i64,
     description: &str,
     trigger_type: &str,
@@ -41,23 +42,12 @@ pub fn run(
         );
     }
 
-    db.require_issue(issue_id)?;
+    service.require_issue(issue_id)?;
 
     let driver_fp = resolve_driver_fingerprint(crosslink_dir);
     let driver_fp_ref = driver_fp.as_deref();
 
-    if let Some(w) = writer {
-        w.add_intervention_comment(
-            db,
-            issue_id,
-            description,
-            trigger_type,
-            context,
-            driver_fp_ref,
-        )?;
-    } else {
-        db.add_intervention_comment(issue_id, description, trigger_type, context, driver_fp_ref)?;
-    }
+    service.add_intervention(issue_id, description, trigger_type, context, driver_fp_ref)?;
 
     if let Some(ref fp) = driver_fp {
         println!(
@@ -96,7 +86,6 @@ mod tests {
         let crosslink_dir = dir.path();
         run(
             &db,
-            None,
             id,
             "Blocked: git push",
             "tool_blocked",
@@ -123,7 +112,6 @@ mod tests {
 
         run(
             &db,
-            None,
             id,
             "Driver redirected approach",
             "redirect",
@@ -143,7 +131,7 @@ mod tests {
         let (db, dir) = setup_db();
         let id = db.create_issue("Test", None, "medium").unwrap();
 
-        let result = run(&db, None, id, "test", "invalid_type", None, dir.path());
+        let result = run(&db, id, "test", "invalid_type", None, dir.path());
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
@@ -155,7 +143,7 @@ mod tests {
     fn test_intervene_nonexistent_issue() {
         let (db, dir) = setup_db();
 
-        let result = run(&db, None, 99999, "test", "tool_blocked", None, dir.path());
+        let result = run(&db, 99999, "test", "tool_blocked", None, dir.path());
         assert!(result.is_err());
     }
 
@@ -167,7 +155,7 @@ mod tests {
         let config = r#"{"tracking_mode":"strict","intervention_tracking":false}"#;
         std::fs::write(dir.path().join("hook-config.json"), config).unwrap();
 
-        run(&db, None, id, "test", "tool_blocked", None, dir.path()).unwrap();
+        run(&db, id, "test", "tool_blocked", None, dir.path()).unwrap();
 
         let comments = db.get_comments(id).unwrap();
         assert!(comments.is_empty());
@@ -188,7 +176,6 @@ mod tests {
         ] {
             run(
                 &db,
-                None,
                 id,
                 &format!("Test {trigger}"),
                 trigger,

--- a/crosslink/src/commands/kickoff/mod.rs
+++ b/crosslink/src/commands/kickoff/mod.rs
@@ -24,6 +24,8 @@ pub use cleanup::cleanup;
 pub use graph::graph;
 pub use monitor::{list, logs, report, report_all, status, stop};
 pub use plan::{plan, show_plan};
+#[cfg(test)]
+pub(crate) use run::resolve_kickoff_issue;
 pub use run::run;
 
 pub(crate) use helpers::{
@@ -35,14 +37,12 @@ use anyhow::{bail, Context, Result};
 use std::path::{Path, PathBuf};
 
 use crate::db::Database;
-use crate::shared_writer::SharedWriter;
 use crate::KickoffCommands;
 
 pub fn dispatch(
     command: KickoffCommands,
     crosslink_dir: &Path,
     db: &Database,
-    writer: Option<&SharedWriter>,
     quiet: bool,
     json: bool,
 ) -> Result<()> {
@@ -105,7 +105,7 @@ pub fn dispatch(
                 template: template.as_deref(),
             };
 
-            run(crosslink_dir, db, writer, &opts)?;
+            run(crosslink_dir, db, &opts)?;
             Ok(())
         }
         KickoffCommands::Status { agent } => agent.as_ref().map_or_else(
@@ -201,7 +201,6 @@ pub fn dispatch(
         } => dispatch_launch(
             crosslink_dir,
             db,
-            writer,
             quiet,
             json,
             doc,
@@ -223,7 +222,6 @@ pub fn dispatch(
 fn dispatch_launch(
     crosslink_dir: &Path,
     db: &Database,
-    writer: Option<&SharedWriter>,
     quiet: bool,
     _json: bool,
     doc: Option<PathBuf>,
@@ -328,7 +326,7 @@ fn dispatch_launch(
             template: None,
         };
 
-        run(crosslink_dir, db, writer, &opts)?;
+        run(crosslink_dir, db, &opts)?;
         return Ok(());
     }
 
@@ -432,7 +430,7 @@ fn dispatch_launch(
                 policy,
                 template: None,
             };
-            run(crosslink_dir, db, writer, &opts)?;
+            run(crosslink_dir, db, &opts)?;
             Ok(())
         }
     }

--- a/crosslink/src/commands/kickoff/monitor.rs
+++ b/crosslink/src/commands/kickoff/monitor.rs
@@ -24,6 +24,7 @@ pub(super) fn record_runtime_usage(crosslink_dir: &Path, worktree_dir: &Path, ag
     let Ok(db) = crate::db::Database::open(&crosslink_dir.join("issues.db")) else {
         return;
     };
+    let service = crate::application::RepositoryService::local_state(&db, crosslink_dir);
     let pricing = crate::token_usage::load_pricing_config(crosslink_dir);
     let metadata = std::fs::read_to_string(worktree_dir.join(".kickoff-metadata.json"))
         .ok()
@@ -62,22 +63,24 @@ pub(super) fn record_runtime_usage(crosslink_dir: &Path, worktree_dir: &Path, ag
             &pricing,
             Some(&provider_metadata),
         );
-        if db
-            .create_token_usage_for_provider(
-                &parsed.agent_id,
-                parsed.session_id,
-                parsed.provider.as_str(),
-                parsed.input_tokens,
-                parsed.output_tokens,
-                parsed.cached_input_tokens,
-                parsed.reasoning_output_tokens,
-                parsed.cache_read_tokens,
-                parsed.cache_creation_tokens,
-                &parsed.model,
-                parsed.cost_estimate,
-                parsed.provider_metadata_json.as_deref(),
-            )
-            .is_ok()
+        if crate::application::LocalStateService::record_token_usage(
+            &service,
+            &crate::application::LocalTokenUsage {
+                agent_id: parsed.agent_id,
+                session_id: parsed.session_id,
+                provider: parsed.provider.as_str().to_string(),
+                input_tokens: parsed.input_tokens,
+                output_tokens: parsed.output_tokens,
+                cached_input_tokens: parsed.cached_input_tokens,
+                reasoning_output_tokens: parsed.reasoning_output_tokens,
+                cache_read_tokens: parsed.cache_read_tokens,
+                cache_creation_tokens: parsed.cache_creation_tokens,
+                model: parsed.model,
+                cost_estimate: parsed.cost_estimate,
+                provider_metadata_json: parsed.provider_metadata_json,
+            },
+        )
+        .is_ok()
         {
             recorded.insert(hash);
             changed = true;

--- a/crosslink/src/commands/kickoff/plan.rs
+++ b/crosslink/src/commands/kickoff/plan.rs
@@ -2,7 +2,7 @@ use anyhow::{bail, Context, Result};
 use std::path::Path;
 use std::process::Command;
 
-use crate::db::Database;
+use crate::application::QueryService;
 use crate::identity::AgentConfig;
 
 use super::helpers::*;
@@ -130,7 +130,7 @@ Write a JSON file `.kickoff-plan.json` with exactly this structure:
     prompt
 }
 
-pub fn plan(crosslink_dir: &Path, db: &Database, opts: &PlanOpts) -> Result<()> {
+pub fn plan(crosslink_dir: &Path, db: &impl QueryService, opts: &PlanOpts) -> Result<()> {
     if cfg!(target_os = "windows") && !opts.dry_run {
         bail!(
             "Plan mode requires tmux, which is not available on Windows.\n\

--- a/crosslink/src/commands/kickoff/run.rs
+++ b/crosslink/src/commands/kickoff/run.rs
@@ -1,20 +1,37 @@
 use anyhow::{bail, Context, Result};
 use std::path::{Path, PathBuf};
 
+use crate::application::{CommandService, QueryService, RepositoryService};
 use crate::db::Database;
-use crate::shared_writer::SharedWriter;
 
 use super::helpers::*;
 use super::launch::*;
 use super::prompt::*;
 use super::types::*;
 
-pub fn run(
-    crosslink_dir: &Path,
-    db: &Database,
-    writer: Option<&SharedWriter>,
-    opts: &KickoffOpts,
-) -> Result<String> {
+pub(crate) fn resolve_kickoff_issue(
+    service: &(impl CommandService + QueryService),
+    requested_issue: Option<i64>,
+    description: &str,
+) -> Result<i64> {
+    if let Some(id) = requested_issue {
+        if service.get_issue(id)?.is_none() {
+            bail!("Issue {} not found", crate::utils::format_issue_id(id));
+        }
+        Ok(id)
+    } else {
+        service.create_issue_with_labels(
+            description,
+            Some("Created by crosslink kickoff"),
+            "medium",
+            &["feature".to_string()],
+            None,
+            None,
+        )
+    }
+}
+
+pub fn run(crosslink_dir: &Path, db: &Database, opts: &KickoffOpts) -> Result<String> {
     let preflight = if opts.dry_run {
         None
     } else {
@@ -51,47 +68,27 @@ pub fn run(
     let compact_name = crate::utils::compose_compact_name(&repo_id, &agent_compact, &slug);
     crate::utils::validate_compact_name(&compact_name)?;
 
-    let local_writer = if writer.is_none() && !opts.dry_run {
-        prepare_local_kickoff_writer(crosslink_dir, db)?
+    let service = if opts.dry_run {
+        RepositoryService::projection(db)
     } else {
-        None
+        RepositoryService::for_kickoff(db, crosslink_dir)?
     };
-    let writer = writer.or(local_writer.as_ref());
 
-    let issue_id = if let Some(id) = opts.issue {
-        if db.get_issue(id)?.is_none() {
-            bail!("Issue {} not found", crate::utils::format_issue_id(id));
-        }
-        id
-    } else {
-        let id = if let Some(w) = writer {
-            w.create_issue(
-                db,
-                opts.description,
-                Some("Created by crosslink kickoff"),
-                "medium",
-                None,
-                None,
-            )?
+    let issue_id = if opts.dry_run {
+        if let Some(id) = opts.issue {
+            if service.get_issue(id)?.is_none() {
+                bail!("Issue {} not found", crate::utils::format_issue_id(id));
+            }
+            id
         } else {
-            db.create_issue(
-                opts.description,
-                Some("Created by crosslink kickoff"),
-                "medium",
-            )?
-        };
-        let label_err = writer.map_or_else(
-            || db.add_label(id, "feature").err(),
-            |w| w.add_label(db, id, "feature").err(),
-        );
-        if let Some(e) = label_err {
-            tracing::warn!("could not label issue #{id} with 'feature': {e}");
+            0
         }
-        if !opts.quiet {
-            println!("Created issue #{id}");
-        }
-        id
+    } else {
+        resolve_kickoff_issue(&service, opts.issue, opts.description)?
     };
+    if !opts.dry_run && opts.issue.is_none() && !opts.quiet {
+        println!("Created issue #{issue_id}");
+    }
 
     let (wt_slug, branch_name) = opts.branch.map_or_else(
         || (compact_name.clone(), format!("feature/{compact_name}")),
@@ -289,42 +286,6 @@ pub fn run(
     Ok(compact_name)
 }
 
-fn prepare_local_kickoff_writer(
-    crosslink_dir: &Path,
-    _db: &Database,
-) -> Result<Option<SharedWriter>> {
-    if crate::identity::AgentConfig::load(crosslink_dir)?.is_none() {
-        return Ok(None);
-    }
-
-    let sync = crate::sync::SyncManager::new(crosslink_dir)?;
-    if sync.remote_exists() {
-        return Ok(None);
-    }
-    if !sync.is_initialized() {
-        sync.init_cache()
-            .context("Failed to initialize the local coordination hub for kickoff")?;
-    }
-    if !sync.hub_mode().is_v3() {
-        bail!("Local-only kickoff requires a v3 coordination hub");
-    }
-
-    match crate::reconcile::migration::activate_repository(crosslink_dir)
-        .context("Failed to reconcile local issues before kickoff")?
-    {
-        crate::reconcile::migration::RepositoryActivation::ReadyCurrent { .. }
-        | crate::reconcile::migration::RepositoryActivation::ReadyMigrated { .. }
-        | crate::reconcile::migration::RepositoryActivation::ReadyAdopted { .. } => {}
-        crate::reconcile::migration::RepositoryActivation::WaitingForRemote { reason } => {
-            bail!("Local kickoff reconciliation is waiting for remote: {reason}")
-        }
-        crate::reconcile::migration::RepositoryActivation::BlockedCorrupt { reason } => {
-            bail!("Local kickoff reconciliation is blocked: {reason}")
-        }
-    }
-    SharedWriter::new(crosslink_dir)
-}
-
 fn resolve_worktree_relative_doc(doc_path: Option<&str>, repo_root: &Path) -> Option<PathBuf> {
     let raw = doc_path?;
     let candidate = Path::new(raw);
@@ -403,9 +364,7 @@ mod local_kickoff_tests {
             .create_issue("existing local issue", None, "medium")
             .unwrap();
 
-        let writer = prepare_local_kickoff_writer(&crosslink_dir, &db)
-            .unwrap()
-            .expect("local kickoff writer");
+        let service = RepositoryService::for_kickoff(&db, &crosslink_dir).unwrap();
         assert!(crate::sync::SyncManager::new(&crosslink_dir)
             .unwrap()
             .hub_mode()
@@ -415,8 +374,8 @@ mod local_kickoff_tests {
             "existing local issue"
         );
 
-        let created = writer
-            .create_issue(&db, "kickoff issue", None, "medium", None, None)
+        let created = service
+            .create_issue("kickoff issue", None, "medium", None, None)
             .unwrap();
         assert_eq!(
             db.get_issue(created).unwrap().unwrap().title,

--- a/crosslink/src/commands/label.rs
+++ b/crosslink/src/commands/label.rs
@@ -1,27 +1,19 @@
 use anyhow::Result;
 
-use crate::db::Database;
-use crate::shared_writer::SharedWriter;
+use crate::application::{CommandService, QueryService};
 use crate::utils::format_issue_id;
 
-pub fn add(db: &Database, writer: Option<&SharedWriter>, issue_id: i64, label: &str) -> Result<()> {
-    db.require_issue(issue_id)?;
+#[cfg(test)]
+use crate::db::Database;
 
-    if let Some(w) = writer {
-        if w.add_label(db, issue_id, label)? {
-            println!(
-                "Added label '{}' to issue {}",
-                label,
-                format_issue_id(issue_id)
-            );
-        } else {
-            println!(
-                "Label '{}' already exists on issue {}",
-                label,
-                format_issue_id(issue_id)
-            );
-        }
-    } else if db.add_label(issue_id, label)? {
+pub fn add(
+    service: &(impl CommandService + QueryService),
+    issue_id: i64,
+    label: &str,
+) -> Result<()> {
+    service.require_issue(issue_id)?;
+
+    if service.add_label(issue_id, label)? {
         println!(
             "Added label '{}' to issue {}",
             label,
@@ -38,28 +30,13 @@ pub fn add(db: &Database, writer: Option<&SharedWriter>, issue_id: i64, label: &
 }
 
 pub fn remove(
-    db: &Database,
-    writer: Option<&SharedWriter>,
+    service: &(impl CommandService + QueryService),
     issue_id: i64,
     label: &str,
 ) -> Result<()> {
-    db.require_issue(issue_id)?;
+    service.require_issue(issue_id)?;
 
-    if let Some(w) = writer {
-        if w.remove_label(db, issue_id, label)? {
-            println!(
-                "Removed label '{}' from issue {}",
-                label,
-                format_issue_id(issue_id)
-            );
-        } else {
-            println!(
-                "Label '{}' not found on issue {}",
-                label,
-                format_issue_id(issue_id)
-            );
-        }
-    } else if db.remove_label(issue_id, label)? {
+    if service.remove_label(issue_id, label)? {
         println!(
             "Removed label '{}' from issue {}",
             label,
@@ -92,7 +69,7 @@ mod tests {
         let (db, _dir) = setup_test_db();
         let issue_id = db.create_issue("Test issue", None, "medium").unwrap();
 
-        let result = add(&db, None, issue_id, "bug");
+        let result = add(&db, issue_id, "bug");
         assert!(result.is_ok());
 
         let labels = db.get_labels(issue_id).unwrap();
@@ -103,7 +80,7 @@ mod tests {
     fn test_add_label_to_nonexistent_issue() {
         let (db, _dir) = setup_test_db();
 
-        let result = add(&db, None, 99999, "bug");
+        let result = add(&db, 99999, "bug");
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("not found"));
     }
@@ -113,8 +90,8 @@ mod tests {
         let (db, _dir) = setup_test_db();
         let issue_id = db.create_issue("Test issue", None, "medium").unwrap();
 
-        add(&db, None, issue_id, "bug").unwrap();
-        let result = add(&db, None, issue_id, "bug");
+        add(&db, issue_id, "bug").unwrap();
+        let result = add(&db, issue_id, "bug");
         assert!(result.is_ok());
 
         let labels = db.get_labels(issue_id).unwrap();
@@ -126,9 +103,9 @@ mod tests {
         let (db, _dir) = setup_test_db();
         let issue_id = db.create_issue("Test issue", None, "medium").unwrap();
 
-        add(&db, None, issue_id, "bug").unwrap();
-        add(&db, None, issue_id, "urgent").unwrap();
-        add(&db, None, issue_id, "backend").unwrap();
+        add(&db, issue_id, "bug").unwrap();
+        add(&db, issue_id, "urgent").unwrap();
+        add(&db, issue_id, "backend").unwrap();
 
         let labels = db.get_labels(issue_id).unwrap();
         assert_eq!(labels.len(), 3);
@@ -142,7 +119,7 @@ mod tests {
         let (db, _dir) = setup_test_db();
         let issue_id = db.create_issue("Test issue", None, "medium").unwrap();
 
-        let result = add(&db, None, issue_id, "");
+        let result = add(&db, issue_id, "");
         assert!(result.is_ok());
 
         let labels = db.get_labels(issue_id).unwrap();
@@ -154,7 +131,7 @@ mod tests {
         let (db, _dir) = setup_test_db();
         let issue_id = db.create_issue("Test issue", None, "medium").unwrap();
 
-        let result = add(&db, None, issue_id, "バグ");
+        let result = add(&db, issue_id, "バグ");
         assert!(result.is_ok());
 
         let labels = db.get_labels(issue_id).unwrap();
@@ -166,13 +143,13 @@ mod tests {
         let (db, _dir) = setup_test_db();
         let issue_id = db.create_issue("Test issue", None, "medium").unwrap();
 
-        let result = add(&db, None, issue_id, "high-priority");
+        let result = add(&db, issue_id, "high-priority");
         assert!(result.is_ok());
 
-        let result = add(&db, None, issue_id, "v2.0");
+        let result = add(&db, issue_id, "v2.0");
         assert!(result.is_ok());
 
-        let result = add(&db, None, issue_id, "team:backend");
+        let result = add(&db, issue_id, "team:backend");
         assert!(result.is_ok());
 
         let labels = db.get_labels(issue_id).unwrap();
@@ -185,7 +162,7 @@ mod tests {
         let issue_id = db.create_issue("Test issue", None, "medium").unwrap();
 
         let malicious = "'; DROP TABLE labels; --";
-        let result = add(&db, None, issue_id, malicious);
+        let result = add(&db, issue_id, malicious);
         assert!(result.is_ok());
 
         let labels = db.get_labels(issue_id).unwrap();
@@ -200,8 +177,8 @@ mod tests {
         let (db, _dir) = setup_test_db();
         let issue_id = db.create_issue("Test issue", None, "medium").unwrap();
 
-        add(&db, None, issue_id, "bug").unwrap();
-        let result = remove(&db, None, issue_id, "bug");
+        add(&db, issue_id, "bug").unwrap();
+        let result = remove(&db, issue_id, "bug");
         assert!(result.is_ok());
 
         let labels = db.get_labels(issue_id).unwrap();
@@ -213,7 +190,7 @@ mod tests {
         let (db, _dir) = setup_test_db();
         let issue_id = db.create_issue("Test issue", None, "medium").unwrap();
 
-        let result = remove(&db, None, issue_id, "nonexistent");
+        let result = remove(&db, issue_id, "nonexistent");
         assert!(result.is_ok());
     }
 
@@ -221,7 +198,7 @@ mod tests {
     fn test_remove_label_from_nonexistent_issue() {
         let (db, _dir) = setup_test_db();
 
-        let result = remove(&db, None, 99999, "bug");
+        let result = remove(&db, 99999, "bug");
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("not found"));
     }
@@ -231,11 +208,11 @@ mod tests {
         let (db, _dir) = setup_test_db();
         let issue_id = db.create_issue("Test issue", None, "medium").unwrap();
 
-        add(&db, None, issue_id, "bug").unwrap();
-        add(&db, None, issue_id, "urgent").unwrap();
-        add(&db, None, issue_id, "backend").unwrap();
+        add(&db, issue_id, "bug").unwrap();
+        add(&db, issue_id, "urgent").unwrap();
+        add(&db, issue_id, "backend").unwrap();
 
-        remove(&db, None, issue_id, "urgent").unwrap();
+        remove(&db, issue_id, "urgent").unwrap();
 
         let labels = db.get_labels(issue_id).unwrap();
         assert_eq!(labels.len(), 2);
@@ -250,7 +227,7 @@ mod tests {
         let issue_id = db.create_issue("Test issue", None, "medium").unwrap();
         db.close_issue(issue_id).unwrap();
 
-        let result = add(&db, None, issue_id, "bug");
+        let result = add(&db, issue_id, "bug");
         assert!(result.is_ok());
 
         let labels = db.get_labels(issue_id).unwrap();
@@ -263,7 +240,7 @@ mod tests {
             let (db, _dir) = setup_test_db();
             let issue_id = db.create_issue("Test", None, "medium").unwrap();
 
-            add(&db, None, issue_id, &label).unwrap();
+            add(&db, issue_id, &label).unwrap();
 
             let labels = db.get_labels(issue_id).unwrap();
             prop_assert!(labels.contains(&label));
@@ -274,8 +251,8 @@ mod tests {
             let (db, _dir) = setup_test_db();
             let issue_id = db.create_issue("Test", None, "medium").unwrap();
 
-            add(&db, None, issue_id, &label).unwrap();
-            remove(&db, None, issue_id, &label).unwrap();
+            add(&db, issue_id, &label).unwrap();
+            remove(&db, issue_id, &label).unwrap();
 
             let labels = db.get_labels(issue_id).unwrap();
             prop_assert!(!labels.contains(&label));
@@ -285,10 +262,10 @@ mod tests {
         fn prop_nonexistent_issue_fails(issue_id in 1000i64..10000) {
             let (db, _dir) = setup_test_db();
 
-            let add_result = add(&db, None, issue_id, "label");
+            let add_result = add(&db, issue_id, "label");
             prop_assert!(add_result.is_err());
 
-            let remove_result = remove(&db, None, issue_id, "label");
+            let remove_result = remove(&db, issue_id, "label");
             prop_assert!(remove_result.is_err());
         }
 
@@ -301,12 +278,12 @@ mod tests {
 
 
             for label in &labels {
-                add(&db, None, issue_id, label).unwrap();
+                add(&db, issue_id, label).unwrap();
             }
 
 
             if !labels.is_empty() {
-                remove(&db, None, issue_id, &labels[0]).unwrap();
+                remove(&db, issue_id, &labels[0]).unwrap();
 
                 let remaining = db.get_labels(issue_id).unwrap();
                 prop_assert!(!remaining.contains(&labels[0]));
@@ -327,7 +304,7 @@ mod tests {
             let (db, _dir) = setup_test_db();
             let issue_id = db.create_issue("Test", None, "medium").unwrap();
 
-            let result = add(&db, None, issue_id, &label);
+            let result = add(&db, issue_id, &label);
             prop_assert!(result.is_ok());
 
             let labels = db.get_labels(issue_id).unwrap();

--- a/crosslink/src/commands/lifecycle.rs
+++ b/crosslink/src/commands/lifecycle.rs
@@ -3,9 +3,11 @@ use std::fmt::Write as _;
 use std::fs;
 use std::path::Path;
 
-use crate::db::Database;
-use crate::shared_writer::SharedWriter;
+use crate::application::{AuthorityMode, CommandService, LocalStateService, QueryService};
 use crate::utils::format_issue_id;
+
+#[cfg(test)]
+use crate::db::Database;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OutputMode {
@@ -15,15 +17,13 @@ pub enum OutputMode {
 }
 
 pub fn close(
-    db: &Database,
-    writer: Option<&SharedWriter>,
+    service: &(impl CommandService + LocalStateService + QueryService),
     id: i64,
     update_changelog: bool,
     crosslink_dir: &Path,
 ) -> Result<()> {
     close_inner(
-        db,
-        writer,
+        service,
         id,
         update_changelog,
         crosslink_dir,
@@ -32,15 +32,13 @@ pub fn close(
 }
 
 pub fn close_quiet(
-    db: &Database,
-    writer: Option<&SharedWriter>,
+    service: &(impl CommandService + LocalStateService + QueryService),
     id: i64,
     update_changelog: bool,
     crosslink_dir: &Path,
 ) -> Result<()> {
     close_inner(
-        db,
-        writer,
+        service,
         id,
         update_changelog,
         crosslink_dir,
@@ -49,8 +47,7 @@ pub fn close_quiet(
 }
 
 fn close_inner(
-    db: &Database,
-    writer: Option<&SharedWriter>,
+    service: &(impl CommandService + LocalStateService + QueryService),
     id: i64,
     update_changelog: bool,
     crosslink_dir: &Path,
@@ -58,36 +55,33 @@ fn close_inner(
 ) -> Result<()> {
     let quiet = output == OutputMode::Quiet;
 
-    let issue = db.get_issue(id)?;
+    let issue = service.get_issue(id)?;
     let Some(issue) = issue else {
         bail!("Issue {} not found", format_issue_id(id));
     };
-    let labels = db.get_labels(id)?;
+    let labels = service.get_labels(id)?;
 
-    if let Some(w) = writer {
-        w.close_issue(db, id)?;
-        if !quiet {
-            println!("Closed issue {}", format_issue_id(id));
-        }
-    } else if db.close_issue(id)? {
-        if !quiet {
-            println!("Closed issue {}", format_issue_id(id));
-        }
-    } else {
-        bail!("Issue {} not found", format_issue_id(id));
+    service.close_issue(id)?;
+    if !quiet {
+        println!("Closed issue {}", format_issue_id(id));
     }
 
     let agent_id = crate::identity::AgentConfig::load(crosslink_dir)
         .ok()
         .flatten()
         .map(|a| a.agent_id);
-    if let Ok(Some(session)) = db.get_current_session_for_agent(agent_id.as_deref()) {
+    if let Ok(Some(session)) = service.get_current_session_for_agent(agent_id.as_deref()) {
         if session.active_issue_id == Some(id) {
-            let _ = db.clear_session_issue(session.id);
+            let _ = service.clear_session_issue(session.id);
         }
     }
 
-    match crate::lock_check::try_release_lock(crosslink_dir, id) {
+    let release = if service.authority_mode() == AuthorityMode::Shared {
+        service.release_lock(id)
+    } else {
+        Ok(false)
+    };
+    match release {
         Ok(true) if !quiet => {
             println!("Released lock on issue {}", format_issue_id(id));
         }
@@ -206,14 +200,13 @@ fn append_to_changelog(path: &Path, category: &str, entry: &str) -> Result<()> {
 }
 
 pub fn close_all(
-    db: &Database,
-    writer: Option<&SharedWriter>,
+    service: &(impl CommandService + LocalStateService + QueryService),
     label_filter: Option<&str>,
     priority_filter: Option<&str>,
     update_changelog: bool,
     crosslink_dir: &Path,
 ) -> Result<()> {
-    let issues = db.list_issues(Some("open"), label_filter, priority_filter)?;
+    let issues = service.list_issues(Some("open"), label_filter, priority_filter)?;
 
     if issues.is_empty() {
         println!("No matching open issues found.");
@@ -222,7 +215,7 @@ pub fn close_all(
 
     let mut closed_count = 0;
     for issue in &issues {
-        match close(db, writer, issue.id, update_changelog, crosslink_dir) {
+        match close(service, issue.id, update_changelog, crosslink_dir) {
             Ok(()) => closed_count += 1,
             Err(e) => tracing::warn!("Failed to close {}: {}", format_issue_id(issue.id), e),
         }
@@ -232,15 +225,9 @@ pub fn close_all(
     Ok(())
 }
 
-pub fn reopen(db: &Database, writer: Option<&SharedWriter>, id: i64) -> Result<()> {
-    if let Some(w) = writer {
-        w.reopen_issue(db, id)?;
-        println!("Reopened issue {}", format_issue_id(id));
-    } else if db.reopen_issue(id)? {
-        println!("Reopened issue {}", format_issue_id(id));
-    } else {
-        bail!("Issue {} not found", format_issue_id(id));
-    }
+pub fn reopen(service: &impl CommandService, id: i64) -> Result<()> {
+    service.reopen_issue(id)?;
+    println!("Reopened issue {}", format_issue_id(id));
     Ok(())
 }
 
@@ -264,7 +251,7 @@ mod tests {
 
         let issue_id = db.create_issue("Test issue", None, "medium").unwrap();
 
-        let result = close(&db, None, issue_id, false, &crosslink_dir);
+        let result = close(&db, issue_id, false, &crosslink_dir);
         assert!(result.is_ok());
 
         let issue = db.get_issue(issue_id).unwrap().unwrap();
@@ -278,7 +265,7 @@ mod tests {
         let crosslink_dir = dir.path().join(".crosslink");
         std::fs::create_dir_all(&crosslink_dir).unwrap();
 
-        let result = close(&db, None, 99999, false, &crosslink_dir);
+        let result = close(&db, 99999, false, &crosslink_dir);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("not found"));
     }
@@ -292,7 +279,7 @@ mod tests {
         let issue_id = db.create_issue("Test issue", None, "medium").unwrap();
         db.close_issue(issue_id).unwrap();
 
-        let result = close(&db, None, issue_id, false, &crosslink_dir);
+        let result = close(&db, issue_id, false, &crosslink_dir);
         assert!(result.is_ok());
     }
 
@@ -303,7 +290,7 @@ mod tests {
         let issue_id = db.create_issue("Test issue", None, "medium").unwrap();
         db.close_issue(issue_id).unwrap();
 
-        let result = reopen(&db, None, issue_id);
+        let result = reopen(&db, issue_id);
         assert!(result.is_ok());
 
         let issue = db.get_issue(issue_id).unwrap().unwrap();
@@ -315,7 +302,7 @@ mod tests {
     fn test_reopen_nonexistent_issue() {
         let (db, _dir) = setup_test_db();
 
-        let result = reopen(&db, None, 99999);
+        let result = reopen(&db, 99999);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("not found"));
     }
@@ -326,7 +313,7 @@ mod tests {
 
         let issue_id = db.create_issue("Test issue", None, "medium").unwrap();
 
-        let result = reopen(&db, None, issue_id);
+        let result = reopen(&db, issue_id);
         assert!(result.is_ok());
 
         let issue = db.get_issue(issue_id).unwrap().unwrap();
@@ -417,15 +404,15 @@ mod tests {
 
         let issue_id = db.create_issue("Test issue", None, "medium").unwrap();
 
-        close(&db, None, issue_id, false, &crosslink_dir).unwrap();
+        close(&db, issue_id, false, &crosslink_dir).unwrap();
         let issue = db.get_issue(issue_id).unwrap().unwrap();
         assert_eq!(issue.status, "closed");
 
-        reopen(&db, None, issue_id).unwrap();
+        reopen(&db, issue_id).unwrap();
         let issue = db.get_issue(issue_id).unwrap().unwrap();
         assert_eq!(issue.status, "open");
 
-        close(&db, None, issue_id, false, &crosslink_dir).unwrap();
+        close(&db, issue_id, false, &crosslink_dir).unwrap();
         let issue = db.get_issue(issue_id).unwrap().unwrap();
         assert_eq!(issue.status, "closed");
     }
@@ -438,7 +425,7 @@ mod tests {
             std::fs::create_dir_all(&crosslink_dir).unwrap();
 
             let issue_id = db.create_issue(&title, None, "medium").unwrap();
-            close(&db, None, issue_id, false, &crosslink_dir).unwrap();
+            close(&db, issue_id, false, &crosslink_dir).unwrap();
 
             let issue = db.get_issue(issue_id).unwrap().unwrap();
             prop_assert_eq!(issue.status, "closed");
@@ -451,7 +438,7 @@ mod tests {
             let issue_id = db.create_issue(&title, None, "medium").unwrap();
             db.close_issue(issue_id).unwrap();
 
-            reopen(&db, None, issue_id).unwrap();
+            reopen(&db, issue_id).unwrap();
 
             let issue = db.get_issue(issue_id).unwrap().unwrap();
             prop_assert_eq!(issue.status, "open");
@@ -463,7 +450,7 @@ mod tests {
             let crosslink_dir = dir.path().join(".crosslink");
             std::fs::create_dir_all(&crosslink_dir).unwrap();
 
-            let result = close(&db, None, issue_id, false, &crosslink_dir);
+            let result = close(&db, issue_id, false, &crosslink_dir);
             prop_assert!(result.is_err());
         }
 
@@ -471,7 +458,7 @@ mod tests {
         fn prop_nonexistent_issue_reopen_fails(issue_id in 1000i64..10000) {
             let (db, _dir) = setup_test_db();
 
-            let result = reopen(&db, None, issue_id);
+            let result = reopen(&db, issue_id);
             prop_assert!(result.is_err());
         }
 

--- a/crosslink/src/commands/list.rs
+++ b/crosslink/src/commands/list.rs
@@ -1,11 +1,14 @@
 use anyhow::Result;
 use serde_json;
 
+use crate::application::QueryService;
+
+#[cfg(test)]
 use crate::db::Database;
 use crate::utils::{format_issue_id, truncate};
 
 pub fn run_json(
-    db: &Database,
+    db: &impl QueryService,
     status: Option<&str>,
     label: Option<&str>,
     priority: Option<&str>,
@@ -16,7 +19,7 @@ pub fn run_json(
 }
 
 pub fn run(
-    db: &Database,
+    db: &impl QueryService,
     status: Option<&str>,
     label: Option<&str>,
     priority: Option<&str>,

--- a/crosslink/src/commands/locks_cmd.rs
+++ b/crosslink/src/commands/locks_cmd.rs
@@ -1,25 +1,37 @@
 use anyhow::Result;
 use std::path::Path;
 
+use crate::application::{CommandService, QueryService, RepositoryService};
 use crate::db::Database;
 use crate::hydration::hydrate_to_sqlite;
 use crate::identity::AgentConfig;
-use crate::shared_writer::SharedWriter;
 use crate::sync::SyncManager;
 use crate::utils::{format_issue_id, truncate};
 use crate::LocksCommands;
 
 pub fn run(command: LocksCommands, crosslink_dir: &Path, db: &Database, json: bool) -> Result<()> {
     match command {
-        LocksCommands::List => list(crosslink_dir, db, json),
+        LocksCommands::List => {
+            let queries = RepositoryService::projection(db);
+            list(crosslink_dir, &queries, json)
+        }
         LocksCommands::Check { id } => check(crosslink_dir, id),
-        LocksCommands::Claim { id, branch } => claim(crosslink_dir, id, branch.as_deref()),
-        LocksCommands::Release { id } => release(crosslink_dir, id),
-        LocksCommands::Steal { id } => steal(crosslink_dir, id),
+        LocksCommands::Claim { id, branch } => {
+            let service = RepositoryService::new(db, crosslink_dir)?;
+            claim(&service, crosslink_dir, id, branch.as_deref())
+        }
+        LocksCommands::Release { id } => {
+            let service = RepositoryService::new(db, crosslink_dir)?;
+            release(&service, crosslink_dir, id)
+        }
+        LocksCommands::Steal { id } => {
+            let service = RepositoryService::new(db, crosslink_dir)?;
+            steal(&service, crosslink_dir, id)
+        }
     }
 }
 
-pub fn list(crosslink_dir: &Path, db: &Database, json_output: bool) -> Result<()> {
+pub fn list(crosslink_dir: &Path, db: &impl QueryService, json_output: bool) -> Result<()> {
     let sync = SyncManager::new(crosslink_dir)?;
     anyhow::ensure!(
         sync.is_initialized(),
@@ -105,7 +117,12 @@ pub fn check(crosslink_dir: &Path, issue_id: i64) -> Result<()> {
     Ok(())
 }
 
-pub fn claim(crosslink_dir: &Path, issue_id: i64, branch: Option<&str>) -> Result<()> {
+pub fn claim(
+    commands: &impl CommandService,
+    crosslink_dir: &Path,
+    issue_id: i64,
+    branch: Option<&str>,
+) -> Result<()> {
     let agent = AgentConfig::load(crosslink_dir)?.ok_or_else(|| {
         anyhow::anyhow!("No agent configured. Run 'crosslink agent init <id>' first.")
     })?;
@@ -115,10 +132,8 @@ pub fn claim(crosslink_dir: &Path, issue_id: i64, branch: Option<&str>) -> Resul
     sync.fetch()?;
     let _ = &agent;
 
-    let writer = SharedWriter::new(crosslink_dir)?
-        .ok_or_else(|| anyhow::anyhow!("SharedWriter not available — is agent configured?"))?;
     use crate::shared_writer::LockClaimResult;
-    match writer.claim_lock_v2(issue_id, branch)? {
+    match commands.claim_lock(issue_id, branch)? {
         LockClaimResult::Claimed => {
             println!("Claimed lock on issue {}", format_issue_id(issue_id));
             if let Some(b) = branch {
@@ -142,7 +157,7 @@ pub fn claim(crosslink_dir: &Path, issue_id: i64, branch: Option<&str>) -> Resul
     Ok(())
 }
 
-pub fn release(crosslink_dir: &Path, issue_id: i64) -> Result<()> {
+pub fn release(commands: &impl CommandService, crosslink_dir: &Path, issue_id: i64) -> Result<()> {
     let agent = AgentConfig::load(crosslink_dir)?.ok_or_else(|| {
         anyhow::anyhow!("No agent configured. Run 'crosslink agent init <id>' first.")
     })?;
@@ -152,9 +167,7 @@ pub fn release(crosslink_dir: &Path, issue_id: i64) -> Result<()> {
     sync.fetch()?;
     let _ = &agent;
 
-    let writer = SharedWriter::new(crosslink_dir)?
-        .ok_or_else(|| anyhow::anyhow!("SharedWriter not available — is agent configured?"))?;
-    if writer.release_lock_v2(issue_id)? {
+    if commands.release_lock(issue_id)? {
         println!("Released lock on issue {}", format_issue_id(issue_id));
     } else {
         println!("Issue {} was not locked.", format_issue_id(issue_id));
@@ -162,7 +175,7 @@ pub fn release(crosslink_dir: &Path, issue_id: i64) -> Result<()> {
     Ok(())
 }
 
-pub fn steal(crosslink_dir: &Path, issue_id: i64) -> Result<()> {
+pub fn steal(commands: &impl CommandService, crosslink_dir: &Path, issue_id: i64) -> Result<()> {
     let agent = AgentConfig::load(crosslink_dir)?.ok_or_else(|| {
         anyhow::anyhow!("No agent configured. Run 'crosslink agent init <id>' first.")
     })?;
@@ -192,19 +205,15 @@ pub fn steal(crosslink_dir: &Path, issue_id: i64) -> Result<()> {
             );
         }
 
-        let writer = SharedWriter::new(crosslink_dir)?
-            .ok_or_else(|| anyhow::anyhow!("SharedWriter not available"))?;
-        writer.steal_lock_v2(issue_id, &existing.agent_id, None)?;
+        commands.steal_lock(issue_id, &existing.agent_id, None)?;
         println!(
             "Stole lock on issue {} from '{}'",
             format_issue_id(issue_id),
             existing.agent_id
         );
     } else {
-        let writer = SharedWriter::new(crosslink_dir)?
-            .ok_or_else(|| anyhow::anyhow!("SharedWriter not available"))?;
         use crate::shared_writer::LockClaimResult;
-        match writer.claim_lock_v2(issue_id, None)? {
+        match commands.claim_lock(issue_id, None)? {
             LockClaimResult::Claimed | LockClaimResult::AlreadyHeld => {}
             LockClaimResult::Contended { winner_agent_id } => {
                 anyhow::bail!("Lock contended — won by '{winner_agent_id}'");
@@ -248,11 +257,11 @@ pub fn sync_cmd(crosslink_dir: &Path, db: &Database) -> Result<()> {
         );
     }
 
-    if let (Ok(Some(writer)), Ok(Some(cfg))) = (
-        SharedWriter::new(crosslink_dir),
+    if let (Ok(service), Ok(Some(cfg))) = (
+        RepositoryService::new(db, crosslink_dir),
         crate::identity::AgentConfig::load(crosslink_dir),
     ) {
-        match crate::agent_requests::poll::process_pending(&writer, crosslink_dir, &cfg.agent_id) {
+        match crate::agent_requests::poll::process_pending(&service, crosslink_dir, &cfg.agent_id) {
             Ok(result) if !result.acted.is_empty() => {
                 println!(
                     "Processed {} agent request(s) for {}.",

--- a/crosslink/src/commands/milestone.rs
+++ b/crosslink/src/commands/milestone.rs
@@ -1,55 +1,35 @@
-use anyhow::{bail, Result};
-use std::path::Path;
-
-use crate::db::Database;
-use crate::shared_writer::SharedWriter;
+use crate::application::{CommandService, QueryService};
 use crate::utils::format_issue_id;
 use crate::MilestoneCommands;
+use anyhow::{bail, Result};
 
-pub fn run(command: MilestoneCommands, db: &Database, crosslink_dir: &Path) -> Result<()> {
+#[cfg(test)]
+use crate::db::Database;
+
+pub fn run(
+    command: MilestoneCommands,
+    service: &(impl CommandService + QueryService),
+) -> Result<()> {
     match command {
-        MilestoneCommands::List { status } => list(db, Some(&status)),
-        MilestoneCommands::Show { id } => show(db, id),
+        MilestoneCommands::List { status } => list(service, Some(&status)),
+        MilestoneCommands::Show { id } => show(service, id),
         MilestoneCommands::Create { name, description } => {
-            let shared = SharedWriter::new(crosslink_dir)?;
-            create(db, shared.as_ref(), &name, description.as_deref())
+            create(service, &name, description.as_deref())
         }
-        MilestoneCommands::Add { id, issues } => {
-            let shared = SharedWriter::new(crosslink_dir)?;
-            add(db, shared.as_ref(), id, &issues)
-        }
-        MilestoneCommands::Remove { id, issue } => {
-            let shared = SharedWriter::new(crosslink_dir)?;
-            remove(db, shared.as_ref(), id, issue)
-        }
-        MilestoneCommands::Close { id } => {
-            let shared = SharedWriter::new(crosslink_dir)?;
-            close(db, shared.as_ref(), id)
-        }
-        MilestoneCommands::Delete { id } => {
-            let shared = SharedWriter::new(crosslink_dir)?;
-            delete(db, shared.as_ref(), id)
-        }
+        MilestoneCommands::Add { id, issues } => add(service, id, &issues),
+        MilestoneCommands::Remove { id, issue } => remove(service, id, issue),
+        MilestoneCommands::Close { id } => close(service, id),
+        MilestoneCommands::Delete { id } => delete(service, id),
     }
 }
 
-pub fn create(
-    db: &Database,
-    shared: Option<&SharedWriter>,
-    name: &str,
-    description: Option<&str>,
-) -> Result<()> {
-    if let Some(sw) = shared {
-        let id = sw.create_milestone(db, name, description)?;
-        println!("Created milestone #{id}: {name}");
-    } else {
-        let id = db.create_milestone(name, description)?;
-        println!("Created milestone #{id}: {name}");
-    }
+pub fn create(service: &impl CommandService, name: &str, description: Option<&str>) -> Result<()> {
+    let id = service.create_milestone(name, description)?;
+    println!("Created milestone #{id}: {name}");
     Ok(())
 }
 
-pub fn list(db: &Database, status: Option<&str>) -> Result<()> {
+pub fn list(db: &impl QueryService, status: Option<&str>) -> Result<()> {
     let milestones = db.list_milestones(status)?;
 
     if milestones.is_empty() {
@@ -81,7 +61,7 @@ pub fn list(db: &Database, status: Option<&str>) -> Result<()> {
     Ok(())
 }
 
-pub fn show(db: &Database, id: i64) -> Result<()> {
+pub fn show(db: &impl QueryService, id: i64) -> Result<()> {
     let Some(m) = db.get_milestone(id)? else {
         bail!("Milestone #{id} not found");
     };
@@ -133,19 +113,18 @@ pub fn show(db: &Database, id: i64) -> Result<()> {
 }
 
 pub fn add(
-    db: &Database,
-    shared: Option<&SharedWriter>,
+    service: &(impl CommandService + QueryService),
     milestone_id: i64,
     issue_ids: &[i64],
 ) -> Result<()> {
-    let milestone = db.get_milestone(milestone_id)?;
+    let milestone = service.get_milestone(milestone_id)?;
     if milestone.is_none() {
         bail!("Milestone #{milestone_id} not found");
     }
 
     let mut valid_ids = Vec::new();
     for &issue_id in issue_ids {
-        if db.get_issue(issue_id)?.is_none() {
+        if service.get_issue(issue_id)?.is_none() {
             println!(
                 "Warning: Issue {} not found, skipping",
                 format_issue_id(issue_id)
@@ -155,50 +134,20 @@ pub fn add(
         valid_ids.push(issue_id);
     }
 
-    if let Some(sw) = shared {
-        sw.set_milestone_on_issues(db, milestone_id, &valid_ids)?;
-        for &issue_id in &valid_ids {
-            println!(
-                "Added {} to milestone #{}",
-                format_issue_id(issue_id),
-                milestone_id
-            );
-        }
-    } else {
-        for &issue_id in &valid_ids {
-            if db.add_issue_to_milestone(milestone_id, issue_id)? {
-                println!(
-                    "Added {} to milestone #{}",
-                    format_issue_id(issue_id),
-                    milestone_id
-                );
-            } else {
-                println!(
-                    "Issue {} already in milestone #{}",
-                    format_issue_id(issue_id),
-                    milestone_id
-                );
-            }
-        }
+    service.assign_milestone(milestone_id, &valid_ids)?;
+    for &issue_id in &valid_ids {
+        println!(
+            "Added {} to milestone #{}",
+            format_issue_id(issue_id),
+            milestone_id
+        );
     }
 
     Ok(())
 }
 
-pub fn remove(
-    db: &Database,
-    shared: Option<&SharedWriter>,
-    milestone_id: i64,
-    issue_id: i64,
-) -> Result<()> {
-    if let Some(sw) = shared {
-        sw.clear_milestone_on_issue(db, issue_id)?;
-        println!(
-            "Removed {} from milestone #{}",
-            format_issue_id(issue_id),
-            milestone_id
-        );
-    } else if db.remove_issue_from_milestone(milestone_id, issue_id)? {
+pub fn remove(service: &impl CommandService, milestone_id: i64, issue_id: i64) -> Result<()> {
+    if service.clear_milestone(milestone_id, issue_id)? {
         println!(
             "Removed {} from milestone #{}",
             format_issue_id(issue_id),
@@ -215,32 +164,18 @@ pub fn remove(
     Ok(())
 }
 
-pub fn close(db: &Database, shared: Option<&SharedWriter>, id: i64) -> Result<()> {
-    if let Some(sw) = shared {
-        sw.close_milestone(db, id)?;
-        println!("Closed milestone #{id}");
-    } else if db.close_milestone(id)? {
-        println!("Closed milestone #{id}");
-    } else {
-        println!("Milestone #{id} not found");
-    }
+pub fn close(service: &impl CommandService, id: i64) -> Result<()> {
+    service.close_milestone(id)?;
+    println!("Closed milestone #{id}");
 
     Ok(())
 }
 
-pub fn delete(db: &Database, shared: Option<&SharedWriter>, id: i64) -> Result<()> {
-    if let Some(sw) = shared {
-        if db.get_milestone(id)?.is_none() {
-            println!("Milestone #{id} not found");
-            return Ok(());
-        }
-        sw.delete_milestone(db, id)?;
-        println!("Deleted milestone #{id}");
-    } else if db.delete_milestone(id)? {
-        println!("Deleted milestone #{id}");
-    } else {
-        println!("Milestone #{id} not found");
+pub fn delete(service: &(impl CommandService + QueryService), id: i64) -> Result<()> {
+    if service.get_milestone(id)?.is_some() {
+        service.delete_milestone(id)?;
     }
+    println!("Deleted milestone #{id}");
 
     Ok(())
 }
@@ -260,7 +195,7 @@ mod tests {
     #[test]
     fn test_create_milestone() {
         let (db, _dir) = setup_test_db();
-        create(&db, None, "v1.0", None).unwrap();
+        create(&db, "v1.0", None).unwrap();
         let milestones = db.list_milestones(None).unwrap();
         assert_eq!(milestones.len(), 1);
         assert_eq!(milestones[0].name, "v1.0");
@@ -269,7 +204,7 @@ mod tests {
     #[test]
     fn test_create_milestone_with_description() {
         let (db, _dir) = setup_test_db();
-        create(&db, None, "v1.0", Some("First release")).unwrap();
+        create(&db, "v1.0", Some("First release")).unwrap();
         let milestones = db.list_milestones(None).unwrap();
         assert_eq!(milestones[0].description, Some("First release".to_string()));
     }
@@ -315,7 +250,7 @@ mod tests {
         let (db, _dir) = setup_test_db();
         let milestone_id = db.create_milestone("v1.0", None).unwrap();
         let issue_id = db.create_issue("Test issue", None, "medium").unwrap();
-        add(&db, None, milestone_id, &[issue_id]).unwrap();
+        add(&db, milestone_id, &[issue_id]).unwrap();
         let issues = db.get_milestone_issues(milestone_id).unwrap();
         assert_eq!(issues.len(), 1);
         assert_eq!(issues[0].id, issue_id);
@@ -325,7 +260,7 @@ mod tests {
     fn test_add_to_nonexistent_milestone() {
         let (db, _dir) = setup_test_db();
         let issue_id = db.create_issue("Test issue", None, "medium").unwrap();
-        let result = add(&db, None, 99999, &[issue_id]);
+        let result = add(&db, 99999, &[issue_id]);
         assert!(result.is_err());
     }
 
@@ -335,7 +270,7 @@ mod tests {
         let milestone_id = db.create_milestone("v1.0", None).unwrap();
         let issue_id = db.create_issue("Test issue", None, "medium").unwrap();
         db.add_issue_to_milestone(milestone_id, issue_id).unwrap();
-        remove(&db, None, milestone_id, issue_id).unwrap();
+        remove(&db, milestone_id, issue_id).unwrap();
         let issues = db.get_milestone_issues(milestone_id).unwrap();
         assert!(issues.is_empty(), "Issue should be removed from milestone");
     }
@@ -344,7 +279,7 @@ mod tests {
     fn test_close_milestone() {
         let (db, _dir) = setup_test_db();
         let id = db.create_milestone("v1.0", None).unwrap();
-        close(&db, None, id).unwrap();
+        close(&db, id).unwrap();
         let m = db.get_milestone(id).unwrap().unwrap();
         assert_eq!(m.status, "closed");
         assert!(m.closed_at.is_some());
@@ -354,7 +289,7 @@ mod tests {
     fn test_delete_milestone() {
         let (db, _dir) = setup_test_db();
         let id = db.create_milestone("v1.0", None).unwrap();
-        delete(&db, None, id).unwrap();
+        delete(&db, id).unwrap();
         let m = db.get_milestone(id).unwrap();
         assert!(m.is_none(), "Milestone should be deleted");
     }
@@ -382,7 +317,7 @@ mod tests {
         #[test]
         fn prop_create_milestone_persists(name in "[a-zA-Z0-9 ]{1,30}") {
             let (db, _dir) = setup_test_db();
-            create(&db, None, &name, None).unwrap();
+            create(&db, &name, None).unwrap();
             let milestones = db.list_milestones(None).unwrap();
             prop_assert_eq!(milestones.len(), 1);
             prop_assert_eq!(&milestones[0].name, &name);

--- a/crosslink/src/commands/next.rs
+++ b/crosslink/src/commands/next.rs
@@ -2,6 +2,9 @@ use anyhow::Result;
 use chrono::{DateTime, Duration, Utc};
 use std::path::Path;
 
+use crate::application::QueryService;
+
+#[cfg(test)]
 use crate::db::Database;
 use crate::locks::LocksFile;
 use crate::models::Issue;
@@ -56,7 +59,7 @@ fn format_remaining(remaining: Duration) -> Option<String> {
 }
 
 fn effective_schedule(
-    db: &Database,
+    db: &impl QueryService,
     issue: &Issue,
 ) -> (Option<DateTime<Utc>>, Option<DateTime<Utc>>) {
     if issue.scheduled_at.is_some() || issue.due_at.is_some() {
@@ -70,7 +73,7 @@ fn effective_schedule(
     (None, None)
 }
 
-fn calculate_progress(db: &Database, issue: &Issue) -> Result<Option<SubissueProgress>> {
+fn calculate_progress(db: &impl QueryService, issue: &Issue) -> Result<Option<SubissueProgress>> {
     let subissues = db.get_subissues(issue.id)?;
     if subissues.is_empty() {
         return Ok(None);
@@ -84,7 +87,7 @@ fn calculate_progress(db: &Database, issue: &Issue) -> Result<Option<SubissuePro
     Ok(Some(SubissueProgress { completed, total }))
 }
 
-pub fn run(db: &Database, crosslink_dir: &std::path::Path) -> Result<()> {
+pub fn run(db: &impl QueryService, crosslink_dir: &std::path::Path) -> Result<()> {
     let all_ready = db.list_ready_issues()?;
 
     if all_ready.is_empty() {

--- a/crosslink/src/commands/relate.rs
+++ b/crosslink/src/commands/relate.rs
@@ -1,33 +1,20 @@
 use anyhow::Result;
 
-use crate::db::Database;
-use crate::shared_writer::SharedWriter;
+use crate::application::{CommandService, QueryService};
 use crate::utils::format_issue_id;
 
+#[cfg(test)]
+use crate::db::Database;
+
 pub fn add(
-    db: &Database,
-    writer: Option<&SharedWriter>,
+    service: &(impl CommandService + QueryService),
     issue_id: i64,
     related_id: i64,
 ) -> Result<()> {
-    db.require_issue(issue_id)?;
-    db.require_issue(related_id)?;
+    service.require_issue(issue_id)?;
+    service.require_issue(related_id)?;
 
-    if let Some(w) = writer {
-        if w.add_relation(db, issue_id, related_id)? {
-            println!(
-                "Linked {} ↔ {}",
-                format_issue_id(issue_id),
-                format_issue_id(related_id)
-            );
-        } else {
-            println!(
-                "Issues {} and {} are already related",
-                format_issue_id(issue_id),
-                format_issue_id(related_id)
-            );
-        }
-    } else if db.add_relation(issue_id, related_id)? {
+    if service.add_relation(issue_id, related_id)? {
         println!(
             "Linked {} ↔ {}",
             format_issue_id(issue_id),
@@ -44,27 +31,8 @@ pub fn add(
     Ok(())
 }
 
-pub fn remove(
-    db: &Database,
-    writer: Option<&SharedWriter>,
-    issue_id: i64,
-    related_id: i64,
-) -> Result<()> {
-    if let Some(w) = writer {
-        if w.remove_relation(db, issue_id, related_id)? {
-            println!(
-                "Unlinked {} ↔ {}",
-                format_issue_id(issue_id),
-                format_issue_id(related_id)
-            );
-        } else {
-            println!(
-                "No relation found between {} and {}",
-                format_issue_id(issue_id),
-                format_issue_id(related_id)
-            );
-        }
-    } else if db.remove_relation(issue_id, related_id)? {
+pub fn remove(service: &impl CommandService, issue_id: i64, related_id: i64) -> Result<()> {
+    if service.remove_relation(issue_id, related_id)? {
         println!(
             "Unlinked {} ↔ {}",
             format_issue_id(issue_id),
@@ -81,7 +49,7 @@ pub fn remove(
     Ok(())
 }
 
-pub fn list(db: &Database, issue_id: i64) -> Result<()> {
+pub fn list(db: &impl QueryService, issue_id: i64) -> Result<()> {
     db.require_issue(issue_id)?;
 
     let related = db.get_related_issues(issue_id)?;
@@ -129,7 +97,7 @@ mod tests {
         let id1 = db.create_issue("Issue 1", None, "medium").unwrap();
         let id2 = db.create_issue("Issue 2", None, "medium").unwrap();
 
-        let result = add(&db, None, id1, id2);
+        let result = add(&db, id1, id2);
         assert!(result.is_ok());
 
         let related = db.get_related_issues(id1).unwrap();
@@ -143,7 +111,7 @@ mod tests {
         let id1 = db.create_issue("Issue 1", None, "medium").unwrap();
         let id2 = db.create_issue("Issue 2", None, "medium").unwrap();
 
-        add(&db, None, id1, id2).unwrap();
+        add(&db, id1, id2).unwrap();
 
         let related1 = db.get_related_issues(id1).unwrap();
         let related2 = db.get_related_issues(id2).unwrap();
@@ -156,7 +124,7 @@ mod tests {
         let (db, _dir) = setup_test_db();
         let id = db.create_issue("Issue 1", None, "medium").unwrap();
 
-        let result = add(&db, None, id, 99999);
+        let result = add(&db, id, 99999);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("not found"));
     }
@@ -167,8 +135,8 @@ mod tests {
         let id1 = db.create_issue("Issue 1", None, "medium").unwrap();
         let id2 = db.create_issue("Issue 2", None, "medium").unwrap();
 
-        add(&db, None, id1, id2).unwrap();
-        let result = add(&db, None, id1, id2);
+        add(&db, id1, id2).unwrap();
+        let result = add(&db, id1, id2);
         assert!(result.is_ok());
 
         let related = db.get_related_issues(id1).unwrap();
@@ -181,8 +149,8 @@ mod tests {
         let id1 = db.create_issue("Issue 1", None, "medium").unwrap();
         let id2 = db.create_issue("Issue 2", None, "medium").unwrap();
 
-        add(&db, None, id1, id2).unwrap();
-        let result = remove(&db, None, id1, id2);
+        add(&db, id1, id2).unwrap();
+        let result = remove(&db, id1, id2);
         assert!(result.is_ok());
 
         let related = db.get_related_issues(id1).unwrap();
@@ -195,7 +163,7 @@ mod tests {
         let id1 = db.create_issue("Issue 1", None, "medium").unwrap();
         let id2 = db.create_issue("Issue 2", None, "medium").unwrap();
 
-        let result = remove(&db, None, id1, id2);
+        let result = remove(&db, id1, id2);
         assert!(result.is_ok());
     }
 
@@ -206,8 +174,8 @@ mod tests {
         let id2 = db.create_issue("Issue 2", None, "medium").unwrap();
         let id3 = db.create_issue("Issue 3", None, "medium").unwrap();
 
-        add(&db, None, id1, id2).unwrap();
-        add(&db, None, id1, id3).unwrap();
+        add(&db, id1, id2).unwrap();
+        add(&db, id1, id3).unwrap();
 
         let result = list(&db, id1);
         assert!(result.is_ok());
@@ -240,11 +208,11 @@ mod tests {
                 let id1 = ids[a as usize % ids.len()];
                 let id2 = ids[b as usize % ids.len()];
 
-                add(&db, None, id1, id2).unwrap();
+                add(&db, id1, id2).unwrap();
                 let related = db.get_related_issues(id1).unwrap();
                 prop_assert!(!related.is_empty());
 
-                remove(&db, None, id1, id2).unwrap();
+                remove(&db, id1, id2).unwrap();
                 let related = db.get_related_issues(id1).unwrap();
                 prop_assert!(related.is_empty());
             }

--- a/crosslink/src/commands/search.rs
+++ b/crosslink/src/commands/search.rs
@@ -1,16 +1,19 @@
 use anyhow::Result;
 use serde_json;
 
+use crate::application::QueryService;
+
+#[cfg(test)]
 use crate::db::Database;
 use crate::utils::{format_issue_id, truncate};
 
-pub fn run_json(db: &Database, query: &str) -> Result<()> {
+pub fn run_json(db: &impl QueryService, query: &str) -> Result<()> {
     let results = db.search_issues(query)?;
     println!("{}", serde_json::to_string_pretty(&results)?);
     Ok(())
 }
 
-pub fn run(db: &Database, query: &str) -> Result<()> {
+pub fn run(db: &impl QueryService, query: &str) -> Result<()> {
     let results = db.search_issues(query)?;
 
     if results.is_empty() {

--- a/crosslink/src/commands/sentinel/collect.rs
+++ b/crosslink/src/commands/sentinel/collect.rs
@@ -2,8 +2,7 @@ use anyhow::{Context, Result};
 use std::path::Path;
 use std::process::Command;
 
-use crate::db::Database;
-use crate::shared_writer::SharedWriter;
+use crate::application::{CommandService, LocalStateService, QueryService};
 
 use super::config::SentinelConfig;
 use super::engine;
@@ -35,12 +34,11 @@ struct TemplateContext<'a> {
 }
 
 pub fn collect_completed(
-    db: &Database,
+    service: &(impl CommandService + LocalStateService + QueryService),
     crosslink_dir: &Path,
     config: Option<&SentinelConfig>,
-    writer: Option<&SharedWriter>,
 ) -> Result<CollectStats> {
-    let pending = db.get_pending_dispatches()?;
+    let pending = service.get_pending_dispatches()?;
     let mut stats = CollectStats::default();
 
     let root = repo_root(crosslink_dir)?;
@@ -52,7 +50,7 @@ pub fn collect_completed(
 
         let wt_path = root.join(".worktrees").join(agent_id);
         if !wt_path.exists() {
-            db.update_dispatch_outcome(dispatch.id, "orphaned", "worktree removed")?;
+            service.update_dispatch_outcome(dispatch.id, "orphaned", "worktree removed")?;
             stats.orphaned += 1;
             continue;
         }
@@ -70,7 +68,9 @@ pub fn collect_completed(
 
         let findings = dispatch
             .crosslink_issue_id
-            .map_or_else(String::new, |issue_id| read_agent_findings(db, issue_id));
+            .map_or_else(String::new, |issue_id| {
+                read_agent_findings(service, issue_id)
+            });
 
         let duration = format_elapsed(&dispatch.created_at);
 
@@ -115,8 +115,7 @@ pub fn collect_completed(
                 findings,
             );
             if let Err(e) = engine::create_triage_issue(
-                db,
-                writer,
+                service,
                 reference,
                 &title,
                 &description,
@@ -127,7 +126,7 @@ pub fn collect_completed(
             }
         }
 
-        db.update_dispatch_outcome(dispatch.id, outcome, &findings)?;
+        service.update_dispatch_outcome(dispatch.id, outcome, &findings)?;
 
         if let Some(cfg) = config {
             super::notify::notify_dispatch_completed(
@@ -325,7 +324,7 @@ fn classify_status(status_content: &str, attempt_number: i32) -> Option<&'static
     }
 }
 
-fn read_agent_findings(db: &Database, issue_id: i64) -> String {
+fn read_agent_findings(db: &impl QueryService, issue_id: i64) -> String {
     let Ok(comments) = db.get_comments(issue_id) else {
         return String::new();
     };

--- a/crosslink/src/commands/sentinel/engine.rs
+++ b/crosslink/src/commands/sentinel/engine.rs
@@ -2,8 +2,11 @@ use anyhow::Result;
 use std::path::Path;
 use uuid::Uuid;
 
+use crate::application::{
+    CommandService, DateTimeChange, DescriptionChange, LocalStateService, OwnedIssueUpdate,
+    QueryService,
+};
 use crate::db::Database;
-use crate::shared_writer::SharedWriter;
 
 use super::collect;
 use super::config::SentinelConfig;
@@ -30,7 +33,7 @@ pub(super) struct CycleOptions<'a> {
 pub(super) fn run_oneshot(
     crosslink_dir: &Path,
     db: &Database,
-    writer: Option<&SharedWriter>,
+    service: &(impl CommandService + LocalStateService + QueryService),
     config: &SentinelConfig,
     dry_run: bool,
     label_filter: Option<&str>,
@@ -52,7 +55,7 @@ pub(super) fn run_oneshot(
     process_signal_batch(
         crosslink_dir,
         db,
-        writer,
+        service,
         config,
         &all_signals,
         "oneshot",
@@ -123,19 +126,19 @@ fn poll_all_sources(
 pub(super) fn process_signal_batch(
     crosslink_dir: &Path,
     db: &Database,
-    writer: Option<&SharedWriter>,
+    service: &(impl CommandService + LocalStateService + QueryService),
     config: &SentinelConfig,
     all_signals: &[Signal],
     mode: &str,
     options: CycleOptions<'_>,
 ) -> Result<CycleStats> {
     let run_id = Uuid::new_v4().to_string();
-    db.insert_sentinel_run(&run_id, mode)?;
+    service.insert_sentinel_run(&run_id, mode)?;
 
-    let seen = SeenSet::load(db)?;
+    let seen = SeenSet::load(service)?;
 
     let tuning = if config.escalation.enabled {
-        super::tuning::TuningOverride::from_history(db, config).unwrap_or_else(|e| {
+        super::tuning::TuningOverride::from_history(service, config).unwrap_or_else(|e| {
             tracing::warn!("self-tuning load failed: {e}");
             super::tuning::TuningOverride::none()
         })
@@ -165,7 +168,7 @@ pub(super) fn process_signal_batch(
         let label_suffix = super::seen_set::parse_signal_label_suffix(&signal.reference);
         if let (Some(num), Some(label)) = (gh_number, label_suffix) {
             let full_label = format!("agent-todo: {label}");
-            let db_decision = db_dedup_check(db, num, &full_label, config)?;
+            let db_decision = db_dedup_check(service, num, &full_label, config)?;
             if let SignalDecision::Skip(reason) = &db_decision {
                 if !options.quiet {
                     println!("  skip: {} ({})", signal.reference, reason);
@@ -184,7 +187,7 @@ pub(super) fn process_signal_batch(
         );
 
         if matches!(disposition, super::dispatch::Disposition::Dispatch { .. }) {
-            let in_flight = db.count_pending_dispatches()?;
+            let in_flight = service.count_pending_dispatches()?;
             if in_flight >= config.max_concurrent_agents as i64 {
                 disposition = super::dispatch::Disposition::Defer {
                     reason: format!(
@@ -212,7 +215,7 @@ pub(super) fn process_signal_batch(
                     );
                 }
 
-                let issue_id = create_sentinel_issue(db, writer, signal)?;
+                let issue_id = create_sentinel_issue(service, signal)?;
 
                 let source_str = format!("{:?}", signal.source);
                 let label_str = signal
@@ -221,9 +224,9 @@ pub(super) fn process_signal_batch(
                     .and_then(|v| v.as_str())
                     .unwrap_or("unknown");
 
-                match spawn_agent(crosslink_dir, db, writer, &description, issue_id, &scope) {
+                match spawn_agent(crosslink_dir, db, &description, issue_id, &scope) {
                     Ok(agent_id) => {
-                        db.insert_sentinel_dispatch(&crate::db::sentinel::NewDispatch {
+                        service.insert_sentinel_dispatch(&crate::db::sentinel::NewDispatch {
                             run_id: &run_id,
                             signal_ref: &signal.reference,
                             signal_title: &signal.title,
@@ -240,8 +243,8 @@ pub(super) fn process_signal_batch(
                     }
                     Err(e) => {
                         tracing::error!("agent spawn failed for {}: {e}", signal.reference);
-                        let dispatch_id =
-                            db.insert_sentinel_dispatch(&crate::db::sentinel::NewDispatch {
+                        let dispatch_id = service.insert_sentinel_dispatch(
+                            &crate::db::sentinel::NewDispatch {
                                 run_id: &run_id,
                                 signal_ref: &signal.reference,
                                 signal_title: &signal.title,
@@ -253,8 +256,9 @@ pub(super) fn process_signal_batch(
                                 label: label_str,
                                 attempt_number: attempt as i32,
                                 model_used: Some(&scope.model),
-                            })?;
-                        db.update_dispatch_outcome(
+                            },
+                        )?;
+                        service.update_dispatch_outcome(
                             dispatch_id,
                             "failure",
                             &format!("spawn failed: {e}"),
@@ -275,14 +279,20 @@ pub(super) fn process_signal_batch(
                 stats.deferred += 1;
             }
             super::dispatch::Disposition::Triage { priority, labels } => {
-                let issue_id = create_sentinel_issue(db, writer, signal)?;
-                let _ = db.update_issue(issue_id, None, None, Some(&priority));
+                let issue_id = create_sentinel_issue(service, signal)?;
+                let _ = service.update_issue(
+                    issue_id,
+                    OwnedIssueUpdate {
+                        title: None,
+                        description: DescriptionChange::Unchanged,
+                        status: None,
+                        priority: Some(priority.clone()),
+                        scheduled_at: DateTimeChange::Unchanged,
+                        due_at: DateTimeChange::Unchanged,
+                    },
+                );
                 for l in &labels {
-                    if let Some(w) = writer {
-                        let _ = w.add_label(db, issue_id, l);
-                    } else {
-                        let _ = db.add_label(issue_id, l);
-                    }
+                    let _ = service.add_label(issue_id, l);
                 }
                 if !options.quiet {
                     println!(
@@ -297,12 +307,12 @@ pub(super) fn process_signal_batch(
         }
     }
 
-    match collect::collect_completed(db, crosslink_dir, Some(config), writer) {
+    match collect::collect_completed(service, crosslink_dir, Some(config)) {
         Ok(collect_stats) => stats.collected = collect_stats.collected,
         Err(e) => tracing::warn!("result collection failed: {e}"),
     }
 
-    db.complete_sentinel_run(
+    service.complete_sentinel_run(
         &run_id,
         &crate::db::sentinel::RunCounters {
             signals_found: i64::from(stats.signals_found),
@@ -343,19 +353,14 @@ fn run_dry(config: &SentinelConfig, quiet: bool) -> CycleStats {
     CycleStats::default()
 }
 
-fn create_sentinel_issue(
-    db: &Database,
-    writer: Option<&SharedWriter>,
-    signal: &Signal,
-) -> Result<i64> {
+fn create_sentinel_issue(service: &impl CommandService, signal: &Signal) -> Result<i64> {
     let description = format!(
         "Sentinel signal: {}\n\n{}",
         signal.reference,
         &signal.body[..signal.body.len().min(2000)]
     );
     create_triage_issue(
-        db,
-        writer,
+        service,
         &signal.reference,
         &signal.title,
         &description,
@@ -365,26 +370,25 @@ fn create_sentinel_issue(
 }
 
 pub fn create_triage_issue(
-    db: &Database,
-    writer: Option<&SharedWriter>,
+    service: &impl CommandService,
     reference: &str,
     title: &str,
     description: &str,
     priority: &str,
     labels: &[&str],
 ) -> Result<i64> {
-    let issue_id = if let Some(w) = writer {
-        w.create_issue(db, title, Some(description), priority, None, None)?
-    } else {
-        db.create_issue(title, Some(description), priority)?
-    };
-    for label in labels {
-        if let Some(w) = writer {
-            w.add_label(db, issue_id, label)?;
-        } else {
-            db.add_label(issue_id, label)?;
-        }
-    }
+    let labels = labels
+        .iter()
+        .map(|label| (*label).to_string())
+        .collect::<Vec<_>>();
+    let issue_id = service.create_issue_with_labels(
+        title,
+        Some(description),
+        priority,
+        &labels,
+        None,
+        None,
+    )?;
     let _ = reference;
     Ok(issue_id)
 }
@@ -392,7 +396,6 @@ pub fn create_triage_issue(
 fn spawn_agent(
     crosslink_dir: &Path,
     db: &Database,
-    writer: Option<&SharedWriter>,
     description: &str,
     issue_id: i64,
     scope: &super::dispatch::AgentScope,
@@ -460,7 +463,7 @@ fn spawn_agent(
         template: None,
     };
 
-    run(crosslink_dir, db, writer, &opts)
+    run(crosslink_dir, db, &opts)
 }
 
 fn resolve_repo_root(crosslink_dir: &Path) -> Result<std::path::PathBuf> {

--- a/crosslink/src/commands/sentinel/history.rs
+++ b/crosslink/src/commands/sentinel/history.rs
@@ -1,8 +1,8 @@
 use anyhow::Result;
 use serde::Serialize;
 
+use crate::application::LocalStateService;
 use crate::db::sentinel::{SentinelDispatch, SentinelRun};
-use crate::db::Database;
 
 #[derive(Serialize)]
 struct RunWithDispatches {
@@ -11,7 +11,12 @@ struct RunWithDispatches {
     dispatches: Vec<SentinelDispatch>,
 }
 
-pub fn show_history(db: &Database, limit: usize, detail: bool, json: bool) -> Result<()> {
+pub fn show_history(
+    db: &impl LocalStateService,
+    limit: usize,
+    detail: bool,
+    json: bool,
+) -> Result<()> {
     let runs = db.list_sentinel_runs(limit)?;
 
     if runs.is_empty() {

--- a/crosslink/src/commands/sentinel/metrics.rs
+++ b/crosslink/src/commands/sentinel/metrics.rs
@@ -1,8 +1,8 @@
 use anyhow::Result;
 
-use crate::db::Database;
+use crate::application::LocalStateService;
 
-pub fn show_metrics(db: &Database, json: bool) -> Result<()> {
+pub fn show_metrics(db: &impl LocalStateService, json: bool) -> Result<()> {
     let metrics = db.get_dispatch_metrics()?;
 
     if metrics.is_empty() {

--- a/crosslink/src/commands/sentinel/mod.rs
+++ b/crosslink/src/commands/sentinel/mod.rs
@@ -15,8 +15,8 @@ pub mod webhook;
 use anyhow::Result;
 use std::path::Path;
 
+use crate::application::RepositoryService;
 use crate::db::Database;
-use crate::shared_writer::SharedWriter;
 use crate::SentinelCommands;
 
 use config::SentinelConfig;
@@ -25,18 +25,19 @@ pub fn dispatch_cmd(
     command: SentinelCommands,
     crosslink_dir: &Path,
     db: &Database,
-    writer: Option<&SharedWriter>,
     quiet: bool,
     json: bool,
     model: Option<String>,
 ) -> Result<()> {
+    let local_service = RepositoryService::projection(db);
     match command {
         SentinelCommands::Run { dry_run, label, .. } => {
             let config = SentinelConfig::load(crosslink_dir)?;
+            let service = RepositoryService::new(db, crosslink_dir)?;
             engine::run_oneshot(
                 crosslink_dir,
                 db,
-                writer,
+                &service,
                 &config,
                 dry_run,
                 label.as_deref(),
@@ -50,23 +51,23 @@ pub fn dispatch_cmd(
         SentinelCommands::Watch { interval, .. } => {
             watch::start(crosslink_dir, interval, model.as_deref())
         }
-        SentinelCommands::Status => watch::status(crosslink_dir, db),
+        SentinelCommands::Status => watch::status(crosslink_dir, &local_service),
         SentinelCommands::History {
             limit,
             detail,
             json: json_flag,
         } => {
             let use_json = json || json_flag;
-            history::show_history(db, limit, detail, use_json)
+            history::show_history(&local_service, limit, detail, use_json)
         }
         SentinelCommands::Stop => watch::stop(crosslink_dir),
         SentinelCommands::Metrics { json: json_flag } => {
             let use_json = json || json_flag;
-            metrics::show_metrics(db, use_json)
+            metrics::show_metrics(&local_service, use_json)
         }
         SentinelCommands::Patterns { json: json_flag } => {
             let use_json = json || json_flag;
-            patterns::detect_patterns(db, use_json)
+            patterns::detect_patterns(&local_service, use_json)
         }
         SentinelCommands::RunDaemon { dir, interval, .. } => {
             watch::run_watch_loop(&dir, interval, model)

--- a/crosslink/src/commands/sentinel/patterns.rs
+++ b/crosslink/src/commands/sentinel/patterns.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 
-use crate::db::Database;
+use crate::application::LocalStateService;
 
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct Pattern {
@@ -11,7 +11,7 @@ pub struct Pattern {
     pub severity: String,
 }
 
-pub fn detect_patterns(db: &Database, json: bool) -> Result<()> {
+pub fn detect_patterns(db: &impl LocalStateService, json: bool) -> Result<()> {
     let mut patterns: Vec<Pattern> = Vec::new();
 
     patterns.extend(find_repeat_failures(db)?);
@@ -57,21 +57,8 @@ pub fn detect_patterns(db: &Database, json: bool) -> Result<()> {
     Ok(())
 }
 
-fn find_repeat_failures(db: &Database) -> Result<Vec<Pattern>> {
-    let mut stmt = db.conn.prepare(
-        "SELECT signal_ref, COUNT(*) as fail_count
-         FROM sentinel_dispatches
-         WHERE outcome IN ('failure', 'exhausted')
-         GROUP BY signal_ref
-         HAVING fail_count >= 2
-         ORDER BY fail_count DESC
-         LIMIT 10",
-    )?;
-
-    let rows: Vec<(String, i64)> = stmt
-        .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))?
-        .filter_map(Result::ok)
-        .collect();
+fn find_repeat_failures(db: &impl LocalStateService) -> Result<Vec<Pattern>> {
+    let rows = db.get_repeat_failure_counts()?;
 
     if rows.is_empty() {
         return Ok(Vec::new());
@@ -89,7 +76,7 @@ fn find_repeat_failures(db: &Database) -> Result<Vec<Pattern>> {
     }])
 }
 
-fn find_label_success_imbalance(db: &Database) -> Result<Vec<Pattern>> {
+fn find_label_success_imbalance(db: &impl LocalStateService) -> Result<Vec<Pattern>> {
     let metrics = db.get_dispatch_metrics()?;
 
     let mut patterns = Vec::new();
@@ -119,24 +106,8 @@ fn find_label_success_imbalance(db: &Database) -> Result<Vec<Pattern>> {
     Ok(patterns)
 }
 
-fn find_escalation_heavy_signals(db: &Database) -> Result<Vec<Pattern>> {
-    let mut stmt = db.conn.prepare(
-        "SELECT label,
-                SUM(CASE WHEN attempt_number = 1 AND outcome = 'failure' THEN 1 ELSE 0 END) as standard_fails,
-                SUM(CASE WHEN attempt_number = 2 THEN 1 ELSE 0 END) as advanced_attempts,
-                COUNT(*) as total
-         FROM sentinel_dispatches
-         WHERE disposition = 'dispatch'
-         GROUP BY label
-         HAVING total >= 4 AND standard_fails > advanced_attempts * 0.8",
-    )?;
-
-    let rows: Vec<(String, i64, i64, i64)> = stmt
-        .query_map([], |row| {
-            Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))
-        })?
-        .filter_map(Result::ok)
-        .collect();
+fn find_escalation_heavy_signals(db: &impl LocalStateService) -> Result<Vec<Pattern>> {
+    let rows = db.get_escalation_heavy_counts()?;
 
     let mut patterns = Vec::new();
     for (label, standard_fails, advanced_attempts, _total) in &rows {

--- a/crosslink/src/commands/sentinel/seen_set.rs
+++ b/crosslink/src/commands/sentinel/seen_set.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 
-use crate::db::Database;
+use crate::application::LocalStateService;
 
 use super::config::SentinelConfig;
 use super::sources::SignalDecision;
@@ -19,7 +19,7 @@ pub struct SeenSet {
 }
 
 impl SeenSet {
-    pub fn load(db: &Database) -> Result<Self> {
+    pub fn load(db: &impl LocalStateService) -> Result<Self> {
         let dispatches = db.load_dispatch_seen_set()?;
         let mut seen = HashMap::with_capacity(dispatches.len());
 
@@ -76,7 +76,7 @@ impl SeenSet {
 }
 
 pub fn db_dedup_check(
-    db: &Database,
+    db: &impl LocalStateService,
     gh_issue_number: i64,
     label: &str,
     config: &SentinelConfig,

--- a/crosslink/src/commands/sentinel/sources/cpitd.rs
+++ b/crosslink/src/commands/sentinel/sources/cpitd.rs
@@ -24,14 +24,16 @@ pub struct CpitdSource {
 
 impl CpitdSource {
     pub fn new(crosslink_dir: &Path, interval_hours: u64, min_tokens: u32) -> Self {
+        let service_dir = crosslink_dir.to_path_buf();
         Self {
             interval_hours,
             min_tokens,
             db_path: crosslink_dir.join("issues.db"),
             state_file: crosslink_dir.join(LAST_SCAN_FILE),
             available: Box::new(crate::commands::cpitd::cpitd_available),
-            scan: Box::new(|db, min_tokens| {
-                crate::commands::cpitd::scan_and_file(db, &[], min_tokens, &[])
+            scan: Box::new(move |db, min_tokens| {
+                let service = crate::application::RepositoryService::new(db, &service_dir)?;
+                crate::commands::cpitd::scan_and_file(&service, &[], min_tokens, &[])
             }),
         }
     }

--- a/crosslink/src/commands/sentinel/sources/internal.rs
+++ b/crosslink/src/commands/sentinel/sources/internal.rs
@@ -1,6 +1,8 @@
 use anyhow::Result;
 use chrono::Utc;
 
+use crate::application::{QueryService, RepositoryService};
+
 use super::{Signal, SignalKind, Source, SourceKind};
 
 pub struct InternalHygieneConfig {
@@ -30,33 +32,27 @@ impl InternalHygieneSource {
 
     fn find_stale_issues(&self) -> Result<Vec<Signal>> {
         let db = crate::db::Database::open(&self.db_path)?;
+        let service = RepositoryService::projection(&db);
         let threshold = Utc::now() - chrono::Duration::days(self.config.stale_threshold_days);
-        let threshold_str = threshold.to_rfc3339();
-
-        let mut stmt = db.conn.prepare(
-            "SELECT id, title, updated_at FROM issues
-             WHERE status = 'open' AND updated_at < ?1
-             ORDER BY updated_at ASC LIMIT 20",
-        )?;
-
         let now = Utc::now();
-        let signals = stmt
-            .query_map([&threshold_str], |row| {
-                let id: i64 = row.get(0)?;
-                let title: String = row.get(1)?;
-                let updated_at: String = row.get(2)?;
-                Ok((id, title, updated_at))
-            })?
-            .filter_map(std::result::Result::ok)
-            .map(|(id, title, updated_at)| Signal {
+        let mut issues = service.list_issues(Some("open"), None, None)?;
+        issues.retain(|issue| issue.updated_at < threshold);
+        issues.sort_by_key(|issue| issue.updated_at);
+        let signals = issues
+            .into_iter()
+            .take(20)
+            .map(|issue| Signal {
                 source: SourceKind::Internal,
                 kind: SignalKind::StaleIssue,
-                reference: format!("CL#{id}:stale"),
-                title: format!("Stale issue: {title}"),
-                body: format!("Issue #{id} has not been updated since {updated_at}."),
+                reference: format!("CL#{}:stale", issue.id),
+                title: format!("Stale issue: {}", issue.title),
+                body: format!(
+                    "Issue #{} has not been updated since {}.",
+                    issue.id, issue.updated_at
+                ),
                 metadata: serde_json::json!({
-                    "issue_id": id,
-                    "last_updated": updated_at,
+                    "issue_id": issue.id,
+                    "last_updated": issue.updated_at,
                     "stale_days": self.config.stale_threshold_days,
                 }),
                 detected_at: now,
@@ -68,72 +64,67 @@ impl InternalHygieneSource {
 
     fn find_orphaned_subissues(&self) -> Result<Vec<Signal>> {
         let db = crate::db::Database::open(&self.db_path)?;
-
-        let mut stmt = db.conn.prepare(
-            "SELECT c.id, c.title, c.parent_id, p.status
-             FROM issues c
-             JOIN issues p ON c.parent_id = p.id
-             WHERE c.status = 'open' AND p.status = 'closed'
-             LIMIT 20",
-        )?;
-
+        let service = RepositoryService::projection(&db);
         let now = Utc::now();
-        let signals = stmt
-            .query_map([], |row| {
-                let id: i64 = row.get(0)?;
-                let title: String = row.get(1)?;
-                let parent_id: i64 = row.get(2)?;
-                Ok((id, title, parent_id))
-            })?
-            .filter_map(std::result::Result::ok)
-            .map(|(id, title, parent_id)| Signal {
+        let issues = service.list_issues(Some("open"), None, None)?;
+        let mut orphaned = Vec::new();
+        for issue in issues {
+            let Some(parent_id) = issue.parent_id else {
+                continue;
+            };
+            let Some(parent) = service.get_issue(parent_id)? else {
+                continue;
+            };
+            if parent.status != crate::models::IssueStatus::Closed {
+                continue;
+            }
+            orphaned.push(Signal {
                 source: SourceKind::Internal,
                 kind: SignalKind::StaleIssue,
-                reference: format!("CL#{id}:orphan"),
-                title: format!("Orphaned subissue: {title}"),
-                body: format!("Issue #{id} is open but its parent #{parent_id} is closed."),
+                reference: format!("CL#{}:orphan", issue.id),
+                title: format!("Orphaned subissue: {}", issue.title),
+                body: format!(
+                    "Issue #{} is open but its parent #{} is closed.",
+                    issue.id, parent_id
+                ),
                 metadata: serde_json::json!({
-                    "issue_id": id,
+                    "issue_id": issue.id,
                     "parent_id": parent_id,
                 }),
                 detected_at: now,
-            })
-            .collect();
-
-        Ok(signals)
+            });
+            if orphaned.len() == 20 {
+                break;
+            }
+        }
+        Ok(orphaned)
     }
 
     fn find_unlabeled_issues(&self) -> Result<Vec<Signal>> {
         let db = crate::db::Database::open(&self.db_path)?;
-
-        let mut stmt = db.conn.prepare(
-            "SELECT i.id, i.title FROM issues i
-             WHERE i.status = 'open'
-             AND NOT EXISTS (SELECT 1 FROM labels l WHERE l.issue_id = i.id)
-             LIMIT 20",
-        )?;
-
+        let service = RepositoryService::projection(&db);
         let now = Utc::now();
-        let signals = stmt
-            .query_map([], |row| {
-                let id: i64 = row.get(0)?;
-                let title: String = row.get(1)?;
-                Ok((id, title))
-            })?
-            .filter_map(std::result::Result::ok)
-            .map(|(id, title)| Signal {
+        let issues = service.list_issues(Some("open"), None, None)?;
+        let mut signals = Vec::new();
+        for issue in issues {
+            if !service.get_labels(issue.id)?.is_empty() {
+                continue;
+            }
+            signals.push(Signal {
                 source: SourceKind::Internal,
                 kind: SignalKind::StaleIssue,
-                reference: format!("CL#{id}:unlabeled"),
-                title: format!("Unlabeled issue: {title}"),
-                body: format!("Issue #{id} has no labels."),
+                reference: format!("CL#{}:unlabeled", issue.id),
+                title: format!("Unlabeled issue: {}", issue.title),
+                body: format!("Issue #{} has no labels.", issue.id),
                 metadata: serde_json::json!({
-                    "issue_id": id,
+                    "issue_id": issue.id,
                 }),
                 detected_at: now,
-            })
-            .collect();
-
+            });
+            if signals.len() == 20 {
+                break;
+            }
+        }
         Ok(signals)
     }
 }

--- a/crosslink/src/commands/sentinel/tuning.rs
+++ b/crosslink/src/commands/sentinel/tuning.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use std::collections::HashMap;
 
-use crate::db::Database;
+use crate::application::LocalStateService;
 
 use super::config::SentinelConfig;
 
@@ -11,7 +11,7 @@ pub struct TuningOverride {
 }
 
 impl TuningOverride {
-    pub fn from_history(db: &Database, config: &SentinelConfig) -> Result<Self> {
+    pub fn from_history(db: &impl LocalStateService, config: &SentinelConfig) -> Result<Self> {
         let metrics = db.get_dispatch_metrics()?;
         let mut overrides = HashMap::new();
 

--- a/crosslink/src/commands/sentinel/watch.rs
+++ b/crosslink/src/commands/sentinel/watch.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
+use crate::application::LocalStateService;
 use crate::db::Database;
 
 use super::config::SentinelConfig;
@@ -82,7 +83,7 @@ pub fn stop(crosslink_dir: &Path) -> Result<()> {
     Ok(())
 }
 
-pub fn status(crosslink_dir: &Path, db: &Database) -> Result<()> {
+pub fn status(crosslink_dir: &Path, db: &impl LocalStateService) -> Result<()> {
     let pid_file = crosslink_dir.join("sentinel.pid");
 
     let running = read_pid(&pid_file).map_or_else(
@@ -356,12 +357,12 @@ fn run_polling_cycle(
 ) -> Result<()> {
     let _permit = crate::reconcile::readiness::acquire_mutation_operation_permit(crosslink_dir)?;
     let db = Database::open(&crosslink_dir.join("issues.db"))?;
-    let writer = crate::shared_writer::SharedWriter::new(crosslink_dir)?;
+    let service = crate::application::RepositoryService::new(&db, crosslink_dir)?;
 
     let stats = engine::run_oneshot(
         crosslink_dir,
         &db,
-        writer.as_ref(),
+        &service,
         config,
         false,
         None,
@@ -394,13 +395,13 @@ fn run_webhook_cycle(
 ) -> Result<()> {
     let _permit = crate::reconcile::readiness::acquire_mutation_operation_permit(crosslink_dir)?;
     let db = Database::open(&crosslink_dir.join("issues.db"))?;
-    let writer = crate::shared_writer::SharedWriter::new(crosslink_dir)?;
+    let service = crate::application::RepositoryService::new(&db, crosslink_dir)?;
 
     let signal_ref = signal.reference.clone();
     let stats = engine::process_signal_batch(
         crosslink_dir,
         &db,
-        writer.as_ref(),
+        &service,
         config,
         &[signal],
         "webhook",

--- a/crosslink/src/commands/session.rs
+++ b/crosslink/src/commands/session.rs
@@ -2,6 +2,7 @@ use anyhow::{bail, Result};
 use chrono::Utc;
 use std::path::Path;
 
+use crate::application::{CommandService, LocalStateService, QueryService, RepositoryService};
 use crate::db::Database;
 use crate::lock_check::{release_lock_best_effort, try_claim_lock, try_release_lock, ClaimResult};
 use crate::utils::format_issue_id;
@@ -13,13 +14,14 @@ pub fn run(
     crosslink_dir: &Path,
     json: bool,
 ) -> Result<()> {
+    let service = RepositoryService::new(db, crosslink_dir)?;
     match command {
-        SessionCommands::Start => start(db, crosslink_dir),
-        SessionCommands::End { notes } => end(db, notes.as_deref(), crosslink_dir),
-        SessionCommands::Status => status(db, crosslink_dir, json),
-        SessionCommands::Work { id } => work(db, id, crosslink_dir),
-        SessionCommands::LastHandoff => last_handoff(db, crosslink_dir),
-        SessionCommands::Action { text } => action(db, &text, crosslink_dir),
+        SessionCommands::Start => start(&service, crosslink_dir),
+        SessionCommands::End { notes } => end(&service, notes.as_deref(), crosslink_dir),
+        SessionCommands::Status => status(&service, crosslink_dir, json),
+        SessionCommands::Work { id } => work(&service, id, crosslink_dir),
+        SessionCommands::LastHandoff => last_handoff(&service, crosslink_dir),
+        SessionCommands::Action { text } => action(&service, &text, crosslink_dir),
     }
 }
 
@@ -42,10 +44,13 @@ fn load_agent_id(crosslink_dir: &std::path::Path) -> Option<String> {
         .map(|a| a.agent_id)
 }
 
-pub fn start(db: &Database, crosslink_dir: &std::path::Path) -> Result<()> {
+pub fn start(
+    service: &(impl LocalStateService + QueryService),
+    crosslink_dir: &std::path::Path,
+) -> Result<()> {
     let agent_id = load_agent_id(crosslink_dir);
 
-    if let Some(current) = db.get_current_session_for_agent(agent_id.as_deref())? {
+    if let Some(current) = service.get_current_session_for_agent(agent_id.as_deref())? {
         println!(
             "Session #{} is already active (started {})",
             current.id,
@@ -54,7 +59,7 @@ pub fn start(db: &Database, crosslink_dir: &std::path::Path) -> Result<()> {
         return Ok(());
     }
 
-    if let Some(last) = db.get_last_session_for_agent(agent_id.as_deref())? {
+    if let Some(last) = service.get_last_session_for_agent(agent_id.as_deref())? {
         if let Some(ended) = last.ended_at {
             println!("Previous session ended: {}", ended.format("%Y-%m-%d %H:%M"));
         }
@@ -69,19 +74,23 @@ pub fn start(db: &Database, crosslink_dir: &std::path::Path) -> Result<()> {
         }
     }
 
-    let id = db.start_session_with_agent(agent_id.as_deref())?;
+    let id = service.start_session(agent_id.as_deref())?;
     println!("Session #{id} started.");
     Ok(())
 }
 
-pub fn end(db: &Database, notes: Option<&str>, crosslink_dir: &std::path::Path) -> Result<()> {
+pub fn end(
+    service: &(impl CommandService + LocalStateService + QueryService),
+    notes: Option<&str>,
+    crosslink_dir: &std::path::Path,
+) -> Result<()> {
     let agent_id = load_agent_id(crosslink_dir);
-    let Some(session) = db.get_current_session_for_agent(agent_id.as_deref())? else {
+    let Some(session) = service.get_current_session_for_agent(agent_id.as_deref())? else {
         bail!("No active session");
     };
 
     if let Some(issue_id) = session.active_issue_id {
-        match try_release_lock(crosslink_dir, issue_id) {
+        match try_release_lock(service, issue_id) {
             Ok(true) => println!("Released lock on issue {}", format_issue_id(issue_id)),
             Ok(false) => {}
             Err(e) => tracing::warn!("Could not release lock: {}", e),
@@ -89,25 +98,10 @@ pub fn end(db: &Database, notes: Option<&str>, crosslink_dir: &std::path::Path) 
     }
 
     if let (Some(notes_text), Some(issue_id)) = (notes, session.active_issue_id) {
-        let saved = match crate::shared_writer::SharedWriter::new(crosslink_dir) {
-            Ok(Some(w)) => match w.add_comment(db, issue_id, notes_text, "handoff") {
-                Ok(_) => true,
-                Err(e) => {
-                    tracing::warn!(
-                        "Handoff notes could not be synced to hub: {}, saving locally",
-                        e
-                    );
-                    false
-                }
-            },
-            _ => false,
-        };
-        if !saved {
-            db.add_comment(issue_id, notes_text, "handoff")?;
-        }
+        service.add_comment(issue_id, notes_text, "handoff")?;
     }
 
-    db.end_session(session.id, notes)?;
+    service.end_session(session.id, notes)?;
 
     clear_active_issue_sentinel(crosslink_dir);
 
@@ -119,7 +113,11 @@ pub fn end(db: &Database, notes: Option<&str>, crosslink_dir: &std::path::Path) 
     Ok(())
 }
 
-pub fn status(db: &Database, crosslink_dir: &std::path::Path, json: bool) -> Result<()> {
+pub fn status(
+    db: &(impl LocalStateService + QueryService),
+    crosslink_dir: &std::path::Path,
+    json: bool,
+) -> Result<()> {
     let agent_id = load_agent_id(crosslink_dir);
     let Some(session) = db.get_current_session_for_agent(agent_id.as_deref())? else {
         if json {
@@ -213,19 +211,23 @@ pub fn status(db: &Database, crosslink_dir: &std::path::Path, json: bool) -> Res
     Ok(())
 }
 
-pub fn work(db: &Database, issue_id: i64, crosslink_dir: &std::path::Path) -> Result<()> {
+pub fn work(
+    service: &(impl CommandService + LocalStateService + QueryService),
+    issue_id: i64,
+    crosslink_dir: &std::path::Path,
+) -> Result<()> {
     let agent_id = load_agent_id(crosslink_dir);
-    let Some(session) = db.get_current_session_for_agent(agent_id.as_deref())? else {
+    let Some(session) = service.get_current_session_for_agent(agent_id.as_deref())? else {
         bail!("No active session. Use 'crosslink session start' first.");
     };
 
-    let Some(issue) = db.get_issue(issue_id)? else {
+    let Some(issue) = service.get_issue(issue_id)? else {
         bail!("Issue {} not found", format_issue_id(issue_id));
     };
 
-    crate::lock_check::enforce_lock(crosslink_dir, issue_id, db)?;
+    crate::lock_check::enforce_lock(crosslink_dir, issue_id, service)?;
 
-    let freshly_claimed = match try_claim_lock(crosslink_dir, issue_id, None)? {
+    let freshly_claimed = match try_claim_lock(service, issue_id, None)? {
         ClaimResult::Claimed => {
             println!("Claimed lock on issue {}", format_issue_id(issue_id));
             true
@@ -242,9 +244,9 @@ pub fn work(db: &Database, issue_id: i64, crosslink_dir: &std::path::Path) -> Re
         }
     };
 
-    if let Err(e) = db.set_session_issue(session.id, issue_id) {
+    if let Err(e) = service.set_session_issue(session.id, issue_id) {
         if freshly_claimed {
-            release_lock_best_effort(crosslink_dir, issue_id);
+            release_lock_best_effort(service, issue_id);
         }
         return Err(e);
     }
@@ -259,34 +261,28 @@ pub fn work(db: &Database, issue_id: i64, crosslink_dir: &std::path::Path) -> Re
     Ok(())
 }
 
-pub fn action(db: &Database, text: &str, crosslink_dir: &std::path::Path) -> Result<()> {
+pub fn action(
+    service: &(impl CommandService + LocalStateService + QueryService),
+    text: &str,
+    crosslink_dir: &std::path::Path,
+) -> Result<()> {
     let agent_id = load_agent_id(crosslink_dir);
-    let Some(session) = db.get_current_session_for_agent(agent_id.as_deref())? else {
+    let Some(session) = service.get_current_session_for_agent(agent_id.as_deref())? else {
         bail!("No active session. Use 'crosslink session start' first.");
     };
 
-    db.set_session_action(session.id, text)?;
+    service.set_session_action(session.id, text)?;
     println!("Action recorded: {text}");
 
     if let Some(issue_id) = session.active_issue_id {
         let comment_text = format!("[action] {text}");
-        match crate::shared_writer::SharedWriter::new(crosslink_dir) {
-            Ok(Some(w)) => {
-                if let Err(e) = w.add_comment(db, issue_id, &comment_text, "note") {
-                    tracing::warn!("action comment sync failed, saving locally: {}", e);
-                    db.add_comment(issue_id, &comment_text, "note")?;
-                }
-            }
-            _ => {
-                db.add_comment(issue_id, &comment_text, "note")?;
-            }
-        }
+        service.add_comment(issue_id, &comment_text, "note")?;
     }
 
     Ok(())
 }
 
-pub fn last_handoff(db: &Database, crosslink_dir: &std::path::Path) -> Result<()> {
+pub fn last_handoff(db: &impl LocalStateService, crosslink_dir: &std::path::Path) -> Result<()> {
     let agent_id = load_agent_id(crosslink_dir);
     match db.get_last_session_for_agent(agent_id.as_deref())? {
         Some(session) => {

--- a/crosslink/src/commands/show.rs
+++ b/crosslink/src/commands/show.rs
@@ -2,6 +2,9 @@ use anyhow::{bail, Result};
 use serde::Serialize;
 use serde_json;
 
+use crate::application::QueryService;
+
+#[cfg(test)]
 use crate::db::Database;
 use crate::utils::format_issue_id;
 
@@ -18,7 +21,7 @@ struct IssueDetail {
     related: Vec<crate::models::Issue>,
 }
 
-pub fn run_json(db: &Database, id: i64) -> Result<()> {
+pub fn run_json(db: &impl QueryService, id: i64) -> Result<()> {
     let Some(issue) = db.get_issue(id)? else {
         bail!("Issue {} not found", format_issue_id(id));
     };
@@ -38,7 +41,7 @@ pub fn run_json(db: &Database, id: i64) -> Result<()> {
     Ok(())
 }
 
-pub fn run(db: &Database, id: i64) -> Result<()> {
+pub fn run(db: &impl QueryService, id: i64) -> Result<()> {
     let Some(issue) = db.get_issue(id)? else {
         bail!("Issue {} not found", format_issue_id(id));
     };
@@ -75,7 +78,7 @@ fn print_header(issue: &crate::models::Issue) {
     }
 }
 
-fn print_labels(db: &Database, id: i64) -> Result<()> {
+fn print_labels(db: &impl QueryService, id: i64) -> Result<()> {
     let labels = db.get_labels(id)?;
     if !labels.is_empty() {
         println!("Labels: {}", labels.join(", "));
@@ -83,7 +86,7 @@ fn print_labels(db: &Database, id: i64) -> Result<()> {
     Ok(())
 }
 
-fn print_milestone(db: &Database, id: i64) -> Result<()> {
+fn print_milestone(db: &impl QueryService, id: i64) -> Result<()> {
     if let Some(milestone) = db.get_issue_milestone(id)? {
         println!("Milestone: #{} {}", milestone.id, milestone.name);
     }
@@ -101,7 +104,7 @@ fn print_description(issue: &crate::models::Issue) {
     }
 }
 
-fn print_comments(db: &Database, id: i64) -> Result<()> {
+fn print_comments(db: &impl QueryService, id: i64) -> Result<()> {
     let comments = db.get_comments(id)?;
     if !comments.is_empty() {
         println!("\nComments:");
@@ -128,7 +131,7 @@ fn print_comments(db: &Database, id: i64) -> Result<()> {
     Ok(())
 }
 
-fn print_dependencies(db: &Database, id: i64) -> Result<()> {
+fn print_dependencies(db: &impl QueryService, id: i64) -> Result<()> {
     let blockers = db.get_blockers(id)?;
     let blocking = db.get_blocking(id)?;
 
@@ -149,7 +152,7 @@ fn print_dependencies(db: &Database, id: i64) -> Result<()> {
     Ok(())
 }
 
-fn print_subissues(db: &Database, id: i64) -> Result<()> {
+fn print_subissues(db: &impl QueryService, id: i64) -> Result<()> {
     let subissues = db.get_subissues(id)?;
     if !subissues.is_empty() {
         println!("\nSubissues:");
@@ -166,7 +169,7 @@ fn print_subissues(db: &Database, id: i64) -> Result<()> {
     Ok(())
 }
 
-fn print_related(db: &Database, id: i64) -> Result<()> {
+fn print_related(db: &impl QueryService, id: i64) -> Result<()> {
     let related = db.get_related_issues(id)?;
     if !related.is_empty() {
         println!("\nRelated:");

--- a/crosslink/src/commands/swarm/budget.rs
+++ b/crosslink/src/commands/swarm/budget.rs
@@ -6,7 +6,6 @@ use super::lifecycle::launch;
 use super::types::*;
 use crate::commands::kickoff;
 use crate::db::Database;
-use crate::shared_writer::SharedWriter;
 use crate::sync::SyncManager;
 
 pub fn config_budget(
@@ -216,7 +215,6 @@ pub fn estimate(crosslink_dir: &Path, phase_slug: &str) -> Result<()> {
 pub fn launch_budget_aware(
     crosslink_dir: &Path,
     db: &Database,
-    writer: Option<&SharedWriter>,
     phase_slug: &str,
     quiet: bool,
 ) -> Result<()> {
@@ -264,7 +262,7 @@ pub fn launch_budget_aware(
         BudgetRecommendation::Proceed => {}
     }
 
-    launch(crosslink_dir, db, writer, phase_slug, quiet)
+    launch(crosslink_dir, db, phase_slug, quiet)
 }
 
 pub fn harvest_costs(crosslink_dir: &Path) -> Result<()> {

--- a/crosslink/src/commands/swarm/lifecycle.rs
+++ b/crosslink/src/commands/swarm/lifecycle.rs
@@ -6,7 +6,6 @@ use super::status::{probe_agent_status, resolve_agents};
 use super::types::*;
 use crate::commands::kickoff::{self, ContainerMode, KickoffOpts, VerifyLevel};
 use crate::db::Database;
-use crate::shared_writer::SharedWriter;
 use crate::sync::SyncManager;
 
 pub fn archive(crosslink_dir: &Path) -> Result<()> {
@@ -244,7 +243,6 @@ pub fn list_swarms(crosslink_dir: &Path) -> Result<()> {
 pub fn launch_retry_failed(
     crosslink_dir: &Path,
     db: &Database,
-    writer: Option<&SharedWriter>,
     phase_slug: &str,
     quiet: bool,
 ) -> Result<()> {
@@ -289,7 +287,7 @@ pub fn launch_retry_failed(
 
     println!("Reset {retry_count} failed agent(s) to planned. Launching...");
 
-    launch(crosslink_dir, db, writer, phase_slug, quiet)
+    launch(crosslink_dir, db, phase_slug, quiet)
 }
 
 pub fn adopt(crosslink_dir: &Path, agent_slug: &str, slot_slug: &str) -> Result<()> {
@@ -638,13 +636,7 @@ pub(super) fn resolve_phase_template(crosslink_dir: &Path, phase_slug: &str) -> 
     candidate.is_file().then_some(candidate)
 }
 
-pub fn launch(
-    crosslink_dir: &Path,
-    db: &Database,
-    writer: Option<&SharedWriter>,
-    phase_slug: &str,
-    quiet: bool,
-) -> Result<()> {
+pub fn launch(crosslink_dir: &Path, db: &Database, phase_slug: &str, quiet: bool) -> Result<()> {
     let sync = SyncManager::new(crosslink_dir)?;
     if !sync.is_initialized() {
         bail!("Hub cache not initialized. Run `crosslink sync` first.");
@@ -725,7 +717,7 @@ pub fn launch(
             template: phase_template.as_deref(),
         };
 
-        match kickoff::run(crosslink_dir, db, writer, &opts) {
+        match kickoff::run(crosslink_dir, db, &opts) {
             Ok(compact_name) => {
                 phase.agents[*idx].status = AgentStatus::Running;
                 phase.agents[*idx].started_at = Some(now.clone());

--- a/crosslink/src/commands/timer.rs
+++ b/crosslink/src/commands/timer.rs
@@ -1,15 +1,17 @@
 use anyhow::{bail, Result};
 use chrono::Utc;
 
+use crate::application::{LocalStateService, QueryService};
+#[cfg(test)]
 use crate::db::Database;
 use crate::utils::format_issue_id;
 
-pub fn start(db: &Database, issue_id: i64) -> Result<()> {
-    let Some(issue) = db.get_issue(issue_id)? else {
+pub fn start(service: &(impl LocalStateService + QueryService), issue_id: i64) -> Result<()> {
+    let Some(issue) = service.get_issue(issue_id)? else {
         bail!("Issue {} not found", format_issue_id(issue_id));
     };
 
-    if let Some((active_id, _)) = db.get_active_timer()? {
+    if let Some((active_id, _)) = service.get_active_timer()? {
         if active_id == issue_id {
             bail!(
                 "Timer already running for issue {}",
@@ -22,7 +24,7 @@ pub fn start(db: &Database, issue_id: i64) -> Result<()> {
         );
     }
 
-    db.start_timer(issue_id)?;
+    service.start_timer(issue_id)?;
     println!(
         "Started timer for {}: {}",
         format_issue_id(issue_id),
@@ -33,15 +35,15 @@ pub fn start(db: &Database, issue_id: i64) -> Result<()> {
     Ok(())
 }
 
-pub fn stop(db: &Database) -> Result<()> {
-    let Some((issue_id, started_at)) = db.get_active_timer()? else {
+pub fn stop(service: &(impl LocalStateService + QueryService)) -> Result<()> {
+    let Some((issue_id, started_at)) = service.get_active_timer()? else {
         bail!("No timer running. Start one with 'crosslink start <id>'.");
     };
     let duration = Utc::now().signed_duration_since(started_at);
 
-    db.stop_timer(issue_id)?;
+    service.stop_timer(issue_id)?;
 
-    let issue = db.get_issue(issue_id)?;
+    let issue = service.get_issue(issue_id)?;
     let title = issue.map_or_else(|| "(deleted)".to_string(), |i| i.title);
 
     let hours = duration.num_hours();
@@ -51,7 +53,7 @@ pub fn stop(db: &Database) -> Result<()> {
     println!("Stopped timer for {}: {}", format_issue_id(issue_id), title);
     println!("Time spent: {hours}h {minutes}m {seconds}s");
 
-    let total = db.get_total_time(issue_id)?;
+    let total = service.get_total_time(issue_id)?;
     let total_hours = total / 3600;
     let total_minutes = (total % 3600) / 60;
     println!("Total time on this issue: {total_hours}h {total_minutes}m");
@@ -59,8 +61,8 @@ pub fn stop(db: &Database) -> Result<()> {
     Ok(())
 }
 
-pub fn status(db: &Database) -> Result<()> {
-    let active = db.get_active_timer()?;
+pub fn status(service: &(impl LocalStateService + QueryService)) -> Result<()> {
+    let active = service.get_active_timer()?;
 
     match active {
         Some((issue_id, started_at)) => {
@@ -69,7 +71,7 @@ pub fn status(db: &Database) -> Result<()> {
             let minutes = duration.num_minutes() % 60;
             let seconds = duration.num_seconds() % 60;
 
-            let issue = db.get_issue(issue_id)?;
+            let issue = service.get_issue(issue_id)?;
             let title = issue.map_or_else(|| "(deleted)".to_string(), |i| i.title);
 
             println!("Timer running: {} {}", format_issue_id(issue_id), title);

--- a/crosslink/src/commands/tree.rs
+++ b/crosslink/src/commands/tree.rs
@@ -2,6 +2,9 @@ use anyhow::Result;
 use serde::Serialize;
 use serde_json;
 
+use crate::application::QueryService;
+
+#[cfg(test)]
 use crate::db::Database;
 use crate::models::Issue;
 use crate::utils::format_issue_id;
@@ -29,7 +32,7 @@ fn print_issue(issue: &Issue, indent: usize) {
 }
 
 fn print_tree_recursive(
-    db: &Database,
+    db: &impl QueryService,
     parent_id: i64,
     indent: usize,
     status_filter: Option<&str>,
@@ -60,7 +63,11 @@ struct TreeNode {
     children: Vec<TreeNode>,
 }
 
-fn build_tree_node(db: &Database, issue: &Issue, status_filter: Option<&str>) -> Result<TreeNode> {
+fn build_tree_node(
+    db: &impl QueryService,
+    issue: &Issue,
+    status_filter: Option<&str>,
+) -> Result<TreeNode> {
     let subissues = db.get_subissues(issue.id)?;
     let children: Vec<TreeNode> = subissues
         .iter()
@@ -81,7 +88,7 @@ fn build_tree_node(db: &Database, issue: &Issue, status_filter: Option<&str>) ->
     })
 }
 
-pub fn run(db: &Database, status_filter: Option<&str>, json: bool) -> Result<()> {
+pub fn run(db: &impl QueryService, status_filter: Option<&str>, json: bool) -> Result<()> {
     let all_issues = db.list_issues(status_filter, None, None)?;
     let top_level: Vec<_> = all_issues
         .into_iter()

--- a/crosslink/src/commands/update.rs
+++ b/crosslink/src/commands/update.rs
@@ -1,16 +1,14 @@
 use anyhow::{bail, Result};
 
+use crate::application::{CommandService, DateTimeChange, DescriptionChange, OwnedIssueUpdate};
 use crate::commands::create::validate_priority;
-use crate::db::Database;
-use crate::shared_writer::{DescriptionUpdate, FieldUpdate, IssueUpdate, SharedWriter};
+use crate::shared_writer::{DescriptionUpdate, FieldUpdate, IssueUpdate};
 use crate::utils::format_issue_id;
 
-pub fn run(
-    db: &Database,
-    writer: Option<&SharedWriter>,
-    id: i64,
-    update: IssueUpdate<'_>,
-) -> Result<()> {
+#[cfg(test)]
+use crate::db::Database;
+
+pub fn run(service: &impl CommandService, id: i64, update: IssueUpdate<'_>) -> Result<()> {
     let scheduling_touched = !matches!(update.scheduled_at, FieldUpdate::Unchanged)
         || !matches!(update.due_at, FieldUpdate::Unchanged);
     let metadata_touched = update.title.is_some()
@@ -30,27 +28,28 @@ pub fn run(
         }
     }
 
-    if let Some(w) = writer {
-        w.update_issue(db, id, update)?;
-        println!("Updated issue {}", format_issue_id(id));
-    } else {
-        if scheduling_touched {
-            bail!(
-                "Updating scheduling dates requires the shared-writer path. \
-                 Run `crosslink agent init <id>` first to enable it."
-            );
-        }
-
-        let desc_for_db = match update.description {
-            DescriptionUpdate::Set(s) => Some(s),
-            _ => None,
-        };
-        if db.update_issue(id, update.title, desc_for_db, update.priority)? {
-            println!("Updated issue {}", format_issue_id(id));
-        } else {
-            bail!("Issue {} not found", format_issue_id(id));
-        }
-    }
+    let description = match update.description {
+        DescriptionUpdate::Unchanged => DescriptionChange::Unchanged,
+        DescriptionUpdate::Clear => DescriptionChange::Clear,
+        DescriptionUpdate::Set(value) => DescriptionChange::Set(value.to_string()),
+    };
+    let map_datetime = |value| match value {
+        FieldUpdate::Unchanged => DateTimeChange::Unchanged,
+        FieldUpdate::Clear => DateTimeChange::Clear,
+        FieldUpdate::Set(value) => DateTimeChange::Set(value),
+    };
+    service.update_issue(
+        id,
+        OwnedIssueUpdate {
+            title: update.title.map(str::to_string),
+            description,
+            status: update.status.map(str::to_string),
+            priority: update.priority.map(str::to_string),
+            scheduled_at: map_datetime(update.scheduled_at),
+            due_at: map_datetime(update.due_at),
+        },
+    )?;
+    println!("Updated issue {}", format_issue_id(id));
 
     Ok(())
 }
@@ -74,7 +73,6 @@ mod tests {
 
         let result = run(
             &db,
-            None,
             issue_id,
             IssueUpdate {
                 title: Some("New title"),
@@ -94,7 +92,6 @@ mod tests {
 
         let result = run(
             &db,
-            None,
             issue_id,
             IssueUpdate {
                 description: DescriptionUpdate::Set("New description"),
@@ -114,7 +111,6 @@ mod tests {
 
         let result = run(
             &db,
-            None,
             issue_id,
             IssueUpdate {
                 priority: Some("critical"),
@@ -136,7 +132,6 @@ mod tests {
 
         let result = run(
             &db,
-            None,
             issue_id,
             IssueUpdate {
                 title: Some("New title"),
@@ -158,7 +153,7 @@ mod tests {
         let (db, _dir) = setup_test_db();
         let issue_id = db.create_issue("Test", None, "medium").unwrap();
 
-        let result = run(&db, None, issue_id, IssueUpdate::default());
+        let result = run(&db, issue_id, IssueUpdate::default());
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
@@ -172,7 +167,6 @@ mod tests {
 
         let result = run(
             &db,
-            None,
             99999,
             IssueUpdate {
                 title: Some("New title"),
@@ -190,7 +184,6 @@ mod tests {
 
         let result = run(
             &db,
-            None,
             issue_id,
             IssueUpdate {
                 priority: Some("urgent"),
@@ -210,7 +203,6 @@ mod tests {
 
         run(
             &db,
-            None,
             issue_id,
             IssueUpdate {
                 title: Some("New title"),
@@ -232,7 +224,6 @@ mod tests {
 
         let result = run(
             &db,
-            None,
             issue_id,
             IssueUpdate {
                 title: Some("新しいタイトル 🎉"),
@@ -254,7 +245,6 @@ mod tests {
 
         let result = run(
             &db,
-            None,
             issue_id,
             IssueUpdate {
                 description: DescriptionUpdate::Set(""),
@@ -275,7 +265,6 @@ mod tests {
         let malicious = "'; DROP TABLE issues; --";
         let result = run(
             &db,
-            None,
             issue_id,
             IssueUpdate {
                 title: Some(malicious),
@@ -299,7 +288,6 @@ mod tests {
 
         let result = run(
             &db,
-            None,
             issue_id,
             IssueUpdate {
                 title: Some("Updated closed issue"),
@@ -322,7 +310,7 @@ mod tests {
             let (db, _dir) = setup_test_db();
             let issue_id = db.create_issue(&original, None, "medium").unwrap();
 
-            run(&db, None, issue_id, IssueUpdate { title: Some(&new_title), ..Default::default() }).unwrap();
+            run(&db, issue_id, IssueUpdate { title: Some(&new_title), ..Default::default() }).unwrap();
 
             let issue = db.get_issue(issue_id).unwrap().unwrap();
             prop_assert_eq!(issue.title, new_title);
@@ -333,7 +321,7 @@ mod tests {
             let (db, _dir) = setup_test_db();
             let issue_id = db.create_issue("Test", None, "medium").unwrap();
 
-            let result = run(&db, None, issue_id, IssueUpdate { priority: Some(&priority), ..Default::default() });
+            let result = run(&db, issue_id, IssueUpdate { priority: Some(&priority), ..Default::default() });
             prop_assert!(result.is_ok());
 
             let issue = db.get_issue(issue_id).unwrap().unwrap();
@@ -350,7 +338,7 @@ mod tests {
             let (db, _dir) = setup_test_db();
             let issue_id = db.create_issue("Test", None, "medium").unwrap();
 
-            let result = run(&db, None, issue_id, IssueUpdate { priority: Some(&priority), ..Default::default() });
+            let result = run(&db, issue_id, IssueUpdate { priority: Some(&priority), ..Default::default() });
             prop_assert!(result.is_err());
         }
 
@@ -358,7 +346,7 @@ mod tests {
         fn prop_nonexistent_issue_fails(issue_id in 1000i64..10000) {
             let (db, _dir) = setup_test_db();
 
-            let result = run(&db, None, issue_id, IssueUpdate { title: Some("New title"), ..Default::default() });
+            let result = run(&db, issue_id, IssueUpdate { title: Some("New title"), ..Default::default() });
             prop_assert!(result.is_err());
         }
 
@@ -367,7 +355,7 @@ mod tests {
             let (db, _dir) = setup_test_db();
             let issue_id = db.create_issue("Test", None, "medium").unwrap();
 
-            run(&db, None, issue_id, IssueUpdate { description: DescriptionUpdate::Set(&desc), ..Default::default() }).unwrap();
+            run(&db, issue_id, IssueUpdate { description: DescriptionUpdate::Set(&desc), ..Default::default() }).unwrap();
 
             let issue = db.get_issue(issue_id).unwrap().unwrap();
             prop_assert_eq!(issue.description, Some(desc));

--- a/crosslink/src/commands/workflow.rs
+++ b/crosslink/src/commands/workflow.rs
@@ -3,6 +3,7 @@ use std::fs;
 use std::path::Path;
 
 use super::init;
+use crate::application::{QueryService, RepositoryService};
 use crate::db::Database;
 use crate::utils::format_issue_id;
 use crate::WorkflowCommands;
@@ -24,7 +25,8 @@ pub fn run(
         }
         WorkflowCommands::Trail { id, kind, json } => {
             let db = get_db()?;
-            trail(&db, id, kind.as_deref(), json)
+            let service = RepositoryService::projection(&db);
+            trail(&service, id, kind.as_deref(), json)
         }
     }
 }
@@ -227,7 +229,7 @@ pub fn diff(crosslink_dir: &Path, integrations_dir: &Path, section: Option<&str>
     }
 }
 
-pub fn trail(db: &Database, id: i64, kind_filter: Option<&str>, json: bool) -> Result<()> {
+pub fn trail(db: &impl QueryService, id: i64, kind_filter: Option<&str>, json: bool) -> Result<()> {
     db.require_issue(id)?;
 
     let comments = db.get_comments(id)?;

--- a/crosslink/src/daemon.rs
+++ b/crosslink/src/daemon.rs
@@ -655,11 +655,17 @@ fn run_normal_loop(crosslink_dir: &Path, should_exit: &AtomicBool) -> Result<()>
         let mut active_issue_id = None;
         match Database::open_read_only(&db_path) {
             Ok(db) => {
+                let service = crate::application::RepositoryService::projection(&db);
                 let agent_id = crate::identity::AgentConfig::load(crosslink_dir)
                     .ok()
                     .flatten()
                     .map(|agent| agent.agent_id);
-                if let Ok(Some(session)) = db.get_current_session_for_agent(agent_id.as_deref()) {
+                if let Ok(Some(session)) =
+                    crate::application::LocalStateService::get_current_session_for_agent(
+                        &service,
+                        agent_id.as_deref(),
+                    )
+                {
                     active_issue_id = session.active_issue_id;
                     let data = serde_json::json!({
                         "session_id": session.id,

--- a/crosslink/src/dashboard/alerts.rs
+++ b/crosslink/src/dashboard/alerts.rs
@@ -41,6 +41,8 @@ pub fn derive_alerts(
     now: DateTime<Utc>,
 ) -> Vec<DerivedAlert> {
     let mut out = Vec::new();
+    let issue_records = crate::application::QueryService::list_issue_records(snapshot)
+        .unwrap_or_else(|_| Vec::new());
 
     if project.status == "error" {
         out.push(DerivedAlert {
@@ -91,7 +93,7 @@ pub fn derive_alerts(
         }
     }
 
-    for issue in &snapshot.issues {
+    for issue in &issue_records {
         if !matches!(issue.status, crate::models::IssueStatus::Open) {
             continue;
         }
@@ -146,8 +148,8 @@ pub fn derive_alerts(
     }
 
     let by_uuid: std::collections::HashMap<Uuid, &crate::issue_file::IssueFile> =
-        snapshot.issues.iter().map(|i| (i.uuid, i)).collect();
-    for issue in &snapshot.issues {
+        issue_records.iter().map(|i| (i.uuid, i)).collect();
+    for issue in &issue_records {
         if !matches!(issue.status, crate::models::IssueStatus::Open) {
             continue;
         }
@@ -211,6 +213,7 @@ mod tests {
             hub_sha: None,
             layout_version: 2,
             issues: vec![],
+            milestones: vec![],
             agents: vec![],
             locks: vec![],
             agent_requests: vec![],

--- a/crosslink/src/dashboard/api.rs
+++ b/crosslink/src/dashboard/api.rs
@@ -320,6 +320,7 @@ fn load_project_detail(db_path: &std::path::Path, slug: &str) -> Result<ProjectD
             hub_sha: None,
             layout_version: 1,
             issues: vec![],
+            milestones: vec![],
             agents: vec![],
             locks: vec![],
             agent_requests: vec![],
@@ -332,6 +333,7 @@ fn load_project_detail(db_path: &std::path::Path, slug: &str) -> Result<ProjectD
             hub_sha: None,
             layout_version: 1,
             issues: vec![],
+            milestones: vec![],
             agents: vec![],
             locks: vec![],
             agent_requests: vec![],
@@ -341,7 +343,8 @@ fn load_project_detail(db_path: &std::path::Path, slug: &str) -> Result<ProjectD
         }
     };
 
-    let mut issues = snapshot.issues;
+    let mut issues = crate::application::QueryService::list_issue_records(&snapshot)
+        .map_err(|error| ApiError::internal(format!("query project issues: {error}")))?;
     issues.sort_by(|a, b| {
         use std::cmp::Ordering;
         let by_status = match (a.status, b.status) {

--- a/crosslink/src/dashboard/reader.rs
+++ b/crosslink/src/dashboard/reader.rs
@@ -13,6 +13,8 @@ pub struct HubSnapshot {
 
     pub issues: Vec<crate::issue_file::IssueFile>,
 
+    pub milestones: Vec<crate::issue_file::MilestoneEntry>,
+
     pub agents: Vec<crate::locks::Heartbeat>,
 
     pub locks: Vec<LockRecord>,
@@ -97,6 +99,15 @@ pub fn read_snapshot(clone_path: &Path) -> Result<HubSnapshot> {
     } else {
         Vec::new()
     };
+    let mut milestones =
+        crate::issue_file::read_all_milestone_files(&hub_root.join("meta").join("milestones"))
+            .unwrap_or_default();
+    if milestones.is_empty() {
+        milestones =
+            crate::issue_file::read_milestones_file(&hub_root.join("meta").join("milestones.json"))
+                .map(|file| file.milestones.into_values().collect())
+                .unwrap_or_default();
+    }
 
     let agents = read_agent_heartbeats(&hub_root);
     let locks = read_locks(&hub_root);
@@ -108,6 +119,7 @@ pub fn read_snapshot(clone_path: &Path) -> Result<HubSnapshot> {
         hub_sha,
         layout_version,
         issues,
+        milestones,
         agents,
         locks,
         agent_requests,
@@ -126,6 +138,21 @@ fn read_snapshot_v3(
 
     let issues: Vec<crate::issue_file::IssueFile> =
         state.issues.values().map(compact_issue_to_file).collect();
+    let milestones = state
+        .milestones
+        .values()
+        .filter_map(|milestone| {
+            Some(crate::issue_file::MilestoneEntry {
+                uuid: milestone.uuid,
+                display_id: milestone.display_id?,
+                name: milestone.name.clone(),
+                description: milestone.description.clone(),
+                status: milestone.status,
+                created_at: milestone.created_at,
+                closed_at: milestone.closed_at,
+            })
+        })
+        .collect();
 
     let locks: Vec<LockRecord> = state
         .locks
@@ -161,6 +188,7 @@ fn read_snapshot_v3(
 
         layout_version: 3,
         issues,
+        milestones,
         agents,
         locks,
         agent_requests,
@@ -438,6 +466,414 @@ fn git_last_commit_at(clone_path: &Path, revision: &str) -> Option<DateTime<Utc>
         .map(|dt| dt.with_timezone(&Utc))
 }
 
+impl HubSnapshot {
+    fn issue_file(&self, id: i64) -> Option<&crate::issue_file::IssueFile> {
+        self.issues
+            .iter()
+            .find(|issue| issue.display_id == Some(id))
+    }
+
+    fn issue_id(&self, uuid: uuid::Uuid) -> Option<i64> {
+        self.issues
+            .iter()
+            .find(|issue| issue.uuid == uuid)
+            .and_then(|issue| issue.display_id)
+    }
+
+    fn issue_model(&self, issue: &crate::issue_file::IssueFile) -> Option<crate::models::Issue> {
+        Some(crate::models::Issue {
+            id: issue.display_id?,
+            title: issue.title.clone(),
+            description: issue.description.clone(),
+            status: issue.status,
+            priority: issue.priority,
+            parent_id: issue.parent_uuid.and_then(|uuid| self.issue_id(uuid)),
+            created_at: issue.created_at,
+            updated_at: issue.updated_at,
+            closed_at: issue.closed_at,
+            scheduled_at: issue.scheduled_at,
+            due_at: issue.due_at,
+        })
+    }
+
+    fn milestone_model(milestone: &crate::issue_file::MilestoneEntry) -> crate::models::Milestone {
+        crate::models::Milestone {
+            id: milestone.display_id,
+            name: milestone.name.clone(),
+            description: milestone.description.clone(),
+            status: milestone.status,
+            created_at: milestone.created_at,
+            closed_at: milestone.closed_at,
+        }
+    }
+}
+
+impl crate::application::QueryService for HubSnapshot {
+    fn list_issue_records(&self) -> Result<Vec<crate::issue_file::IssueFile>> {
+        Ok(self.issues.clone())
+    }
+
+    fn get_issue(&self, id: i64) -> Result<Option<crate::models::Issue>> {
+        Ok(self
+            .issue_file(id)
+            .and_then(|issue| self.issue_model(issue)))
+    }
+
+    fn require_issue(&self, id: i64) -> Result<crate::models::Issue> {
+        self.get_issue(id)?
+            .ok_or_else(|| anyhow::anyhow!("issue #{id} not found"))
+    }
+
+    fn list_issues(
+        &self,
+        status: Option<&str>,
+        label: Option<&str>,
+        priority: Option<&str>,
+    ) -> Result<Vec<crate::models::Issue>> {
+        let status = status
+            .filter(|value| *value != "all")
+            .map(str::parse::<crate::models::IssueStatus>)
+            .transpose()?;
+        let priority = priority
+            .map(str::parse::<crate::models::Priority>)
+            .transpose()?;
+        let mut issues = self
+            .issues
+            .iter()
+            .filter(|issue| status.is_none_or(|value| issue.status == value))
+            .filter(|issue| label.is_none_or(|value| issue.labels.iter().any(|item| item == value)))
+            .filter(|issue| priority.is_none_or(|value| issue.priority == value))
+            .filter_map(|issue| self.issue_model(issue))
+            .collect::<Vec<_>>();
+        issues.sort_by_key(|issue| std::cmp::Reverse(issue.id));
+        Ok(issues)
+    }
+
+    fn search_issues(&self, query: &str) -> Result<Vec<crate::models::Issue>> {
+        let query = query.to_lowercase();
+        let mut issues = self
+            .issues
+            .iter()
+            .filter(|issue| {
+                issue.title.to_lowercase().contains(&query)
+                    || issue
+                        .description
+                        .as_deref()
+                        .is_some_and(|description| description.to_lowercase().contains(&query))
+            })
+            .filter_map(|issue| self.issue_model(issue))
+            .collect::<Vec<_>>();
+        issues.sort_by_key(|issue| std::cmp::Reverse(issue.updated_at));
+        Ok(issues)
+    }
+
+    fn get_subissues(&self, parent_id: i64) -> Result<Vec<crate::models::Issue>> {
+        let parent = self.require_issue(parent_id)?;
+        let parent_uuid: uuid::Uuid = self.get_issue_uuid_by_id(parent.id)?.parse()?;
+        let mut issues = self
+            .issues
+            .iter()
+            .filter(|issue| issue.parent_uuid == Some(parent_uuid))
+            .filter_map(|issue| self.issue_model(issue))
+            .collect::<Vec<_>>();
+        issues.sort_by_key(|issue| issue.id);
+        Ok(issues)
+    }
+
+    fn get_labels(&self, issue_id: i64) -> Result<Vec<String>> {
+        Ok(self
+            .issue_file(issue_id)
+            .map_or_else(Vec::new, |issue| issue.labels.clone()))
+    }
+
+    fn get_labels_batch(
+        &self,
+        issue_ids: &[i64],
+    ) -> Result<std::collections::HashMap<i64, Vec<String>>> {
+        Ok(issue_ids
+            .iter()
+            .map(|id| (*id, self.get_labels(*id).unwrap_or_default()))
+            .collect())
+    }
+
+    fn get_comments(&self, issue_id: i64) -> Result<Vec<crate::models::Comment>> {
+        Ok(self.issue_file(issue_id).map_or_else(Vec::new, |issue| {
+            issue
+                .comments
+                .iter()
+                .map(|comment| crate::models::Comment {
+                    id: comment.id,
+                    issue_id,
+                    content: comment.content.clone(),
+                    created_at: comment.created_at,
+                    kind: comment.kind.clone(),
+                    trigger_type: comment.trigger_type.clone(),
+                    intervention_context: comment.intervention_context.clone(),
+                    driver_key_fingerprint: comment.driver_key_fingerprint.clone(),
+                })
+                .collect()
+        }))
+    }
+
+    fn search_comments(&self, query: &str) -> Result<Vec<(crate::models::Comment, i64, String)>> {
+        let query = query.to_lowercase();
+        let mut rows = Vec::new();
+        for issue in &self.issues {
+            let Some(issue_id) = issue.display_id else {
+                continue;
+            };
+            rows.extend(
+                self.get_comments(issue_id)?
+                    .into_iter()
+                    .filter(|comment| comment.content.to_lowercase().contains(&query))
+                    .map(|comment| (comment, issue_id, issue.title.clone())),
+            );
+        }
+        rows.sort_by_key(|(comment, _, _)| std::cmp::Reverse(comment.created_at));
+        Ok(rows)
+    }
+
+    fn get_blockers(&self, issue_id: i64) -> Result<Vec<i64>> {
+        Ok(self.issue_file(issue_id).map_or_else(Vec::new, |issue| {
+            issue
+                .blockers
+                .iter()
+                .filter_map(|uuid| self.issue_id(*uuid))
+                .collect()
+        }))
+    }
+
+    fn get_blocking(&self, issue_id: i64) -> Result<Vec<i64>> {
+        let uuid: uuid::Uuid = self.get_issue_uuid_by_id(issue_id)?.parse()?;
+        Ok(self
+            .issues
+            .iter()
+            .filter(|issue| issue.blockers.contains(&uuid))
+            .filter_map(|issue| issue.display_id)
+            .collect())
+    }
+
+    fn get_blocker_counts_batch(
+        &self,
+        issue_ids: &[i64],
+    ) -> Result<std::collections::HashMap<i64, usize>> {
+        issue_ids
+            .iter()
+            .map(|id| Ok((*id, self.get_blockers(*id)?.len())))
+            .collect()
+    }
+
+    fn list_blocked_issues(&self) -> Result<Vec<crate::models::Issue>> {
+        let open = self
+            .issues
+            .iter()
+            .filter(|issue| issue.status == crate::models::IssueStatus::Open)
+            .map(|issue| issue.uuid)
+            .collect::<std::collections::HashSet<_>>();
+        let mut issues = self
+            .issues
+            .iter()
+            .filter(|issue| issue.status == crate::models::IssueStatus::Open)
+            .filter(|issue| issue.blockers.iter().any(|uuid| open.contains(uuid)))
+            .filter_map(|issue| self.issue_model(issue))
+            .collect::<Vec<_>>();
+        issues.sort_by_key(|issue| issue.id);
+        Ok(issues)
+    }
+
+    fn list_ready_issues(&self) -> Result<Vec<crate::models::Issue>> {
+        let blocked = self
+            .list_blocked_issues()?
+            .into_iter()
+            .map(|issue| issue.id)
+            .collect::<std::collections::HashSet<_>>();
+        let mut issues = self
+            .issues
+            .iter()
+            .filter(|issue| issue.status == crate::models::IssueStatus::Open)
+            .filter_map(|issue| self.issue_model(issue))
+            .filter(|issue| !blocked.contains(&issue.id))
+            .collect::<Vec<_>>();
+        issues.sort_by_key(|issue| issue.id);
+        Ok(issues)
+    }
+
+    fn list_archived_issues(&self) -> Result<Vec<crate::models::Issue>> {
+        Ok(self
+            .issues
+            .iter()
+            .filter(|issue| issue.status == crate::models::IssueStatus::Archived)
+            .filter_map(|issue| self.issue_model(issue))
+            .collect())
+    }
+
+    fn get_related_issues(&self, issue_id: i64) -> Result<Vec<crate::models::Issue>> {
+        Ok(self
+            .get_related_issue_ids(issue_id)?
+            .into_iter()
+            .filter_map(|id| self.get_issue(id).ok().flatten())
+            .collect())
+    }
+
+    fn get_related_issue_ids(&self, issue_id: i64) -> Result<Vec<i64>> {
+        Ok(self.issue_file(issue_id).map_or_else(Vec::new, |issue| {
+            issue
+                .related
+                .iter()
+                .filter_map(|uuid| self.issue_id(*uuid))
+                .collect()
+        }))
+    }
+
+    fn get_milestone(&self, id: i64) -> Result<Option<crate::models::Milestone>> {
+        Ok(self
+            .milestones
+            .iter()
+            .find(|milestone| milestone.display_id == id)
+            .map(Self::milestone_model))
+    }
+
+    fn list_milestones(&self, status: Option<&str>) -> Result<Vec<crate::models::Milestone>> {
+        let status = status
+            .filter(|value| *value != "all")
+            .map(str::parse::<crate::models::IssueStatus>)
+            .transpose()?;
+        let mut milestones = self
+            .milestones
+            .iter()
+            .filter(|milestone| status.is_none_or(|value| milestone.status == value))
+            .map(Self::milestone_model)
+            .collect::<Vec<_>>();
+        milestones.sort_by_key(|milestone| std::cmp::Reverse(milestone.id));
+        Ok(milestones)
+    }
+
+    fn get_milestone_issues(&self, milestone_id: i64) -> Result<Vec<crate::models::Issue>> {
+        let Some(milestone) = self
+            .milestones
+            .iter()
+            .find(|milestone| milestone.display_id == milestone_id)
+        else {
+            return Ok(Vec::new());
+        };
+        let mut issues = self
+            .issues
+            .iter()
+            .filter(|issue| issue.milestone_uuid == Some(milestone.uuid))
+            .filter_map(|issue| self.issue_model(issue))
+            .collect::<Vec<_>>();
+        issues.sort_by_key(|issue| issue.id);
+        Ok(issues)
+    }
+
+    fn get_issue_milestone(&self, issue_id: i64) -> Result<Option<crate::models::Milestone>> {
+        let Some(uuid) = self
+            .issue_file(issue_id)
+            .and_then(|issue| issue.milestone_uuid)
+        else {
+            return Ok(None);
+        };
+        Ok(self
+            .milestones
+            .iter()
+            .find(|milestone| milestone.uuid == uuid)
+            .map(Self::milestone_model))
+    }
+
+    fn get_milestone_uuid_for_issue(&self, issue_id: i64) -> Result<Option<String>> {
+        Ok(self
+            .issue_file(issue_id)
+            .and_then(|issue| issue.milestone_uuid)
+            .map(|uuid| uuid.to_string()))
+    }
+
+    fn count_issues_since(&self, since: &str) -> Result<i64> {
+        let since = DateTime::parse_from_rfc3339(since)?.with_timezone(&Utc);
+        Ok(self
+            .issues
+            .iter()
+            .filter(|issue| issue.created_at >= since)
+            .count() as i64)
+    }
+
+    fn count_comments_since(&self, since: &str) -> Result<i64> {
+        let since = DateTime::parse_from_rfc3339(since)?.with_timezone(&Utc);
+        Ok(self
+            .issues
+            .iter()
+            .flat_map(|issue| &issue.comments)
+            .filter(|comment| comment.created_at >= since)
+            .count() as i64)
+    }
+
+    fn get_issue_count(&self) -> Result<i64> {
+        Ok(self
+            .issues
+            .iter()
+            .filter(|issue| issue.display_id.is_some())
+            .count() as i64)
+    }
+
+    fn get_milestone_count(&self) -> Result<i64> {
+        Ok(self.milestones.len() as i64)
+    }
+
+    fn get_issue_uuid_by_id(&self, id: i64) -> Result<String> {
+        self.issue_file(id)
+            .map(|issue| issue.uuid.to_string())
+            .ok_or_else(|| anyhow::anyhow!("issue #{id} not found"))
+    }
+
+    fn get_issue_export_metadata(&self, id: i64) -> Result<(Option<String>, Option<String>)> {
+        let issue = self
+            .issue_file(id)
+            .ok_or_else(|| anyhow::anyhow!("issue #{id} not found"))?;
+        Ok((Some(issue.uuid.to_string()), Some(issue.created_by.clone())))
+    }
+
+    fn get_comments_with_author(&self, issue_id: i64) -> Result<Vec<crate::db::CommentAuthorRow>> {
+        Ok(self.issue_file(issue_id).map_or_else(Vec::new, |issue| {
+            issue
+                .comments
+                .iter()
+                .map(|comment| {
+                    (
+                        comment.id,
+                        Some(comment.author.clone()),
+                        comment.content.clone(),
+                        comment.created_at,
+                        comment.kind.clone(),
+                        comment.trigger_type.clone(),
+                        comment.intervention_context.clone(),
+                        comment.driver_key_fingerprint.clone(),
+                    )
+                })
+                .collect()
+        }))
+    }
+
+    fn get_time_entries_for_issue(&self, issue_id: i64) -> Result<Vec<crate::db::TimeEntryRow>> {
+        Ok(self.issue_file(issue_id).map_or_else(Vec::new, |issue| {
+            issue
+                .time_entries
+                .iter()
+                .map(|entry| {
+                    (
+                        entry.id,
+                        entry.started_at,
+                        entry.ended_at,
+                        entry.duration_seconds,
+                    )
+                })
+                .collect()
+        }))
+    }
+
+    fn authority_mode(&self) -> crate::application::AuthorityMode {
+        crate::application::AuthorityMode::Shared
+    }
+}
+
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct ProjectCounters {
     pub open_issues: i64,
@@ -458,8 +894,9 @@ impl HubSnapshot {
     ) -> ProjectCounters {
         use std::collections::HashSet;
 
-        let open: Vec<&crate::issue_file::IssueFile> = self
-            .issues
+        let records = crate::application::QueryService::list_issue_records(self)
+            .unwrap_or_else(|_| Vec::new());
+        let open: Vec<&crate::issue_file::IssueFile> = records
             .iter()
             .filter(|i| matches!(i.status, crate::models::IssueStatus::Open))
             .collect();
@@ -593,6 +1030,57 @@ mod tests {
     }
 
     #[test]
+    fn snapshot_query_service_preserves_issue_records() {
+        let mut issue = make_issue(
+            Uuid::new_v4(),
+            42,
+            crate::models::IssueStatus::Open,
+            None,
+            vec![],
+        );
+        issue.labels.push("dashboard".to_string());
+        issue.comments.push(crate::issue_file::CommentEntry {
+            id: 7,
+            author: "agent".to_string(),
+            content: "query parity".to_string(),
+            created_at: now_fixed(),
+            kind: "note".to_string(),
+            trigger_type: None,
+            intervention_context: None,
+            driver_key_fingerprint: None,
+            signed_by: None,
+            signature: None,
+        });
+        let snap = HubSnapshot {
+            hub_sha: None,
+            layout_version: 3,
+            issues: vec![issue.clone()],
+            milestones: vec![],
+            agents: vec![],
+            locks: vec![],
+            agent_requests: vec![],
+            ci_status: None,
+            signature_state: SignatureState::Unknown,
+            last_commit_at: None,
+        };
+
+        assert_eq!(
+            crate::application::QueryService::list_issue_records(&snap).unwrap(),
+            vec![issue]
+        );
+        assert_eq!(
+            crate::application::QueryService::get_labels(&snap, 42).unwrap(),
+            vec!["dashboard"]
+        );
+        assert_eq!(
+            crate::application::QueryService::get_comments(&snap, 42)
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[test]
     fn test_read_snapshot_parses_heartbeats() {
         let dir = tempdir().unwrap();
         let agents_dir = dir.path().join("agents").join("jus4");
@@ -680,6 +1168,7 @@ mod tests {
                     vec![],
                 ),
             ],
+            milestones: vec![],
             agents: vec![],
             locks: vec![],
             agent_requests: vec![],
@@ -725,6 +1214,7 @@ mod tests {
                     vec![],
                 ),
             ],
+            milestones: vec![],
             agents: vec![],
             locks: vec![],
             agent_requests: vec![],
@@ -775,6 +1265,7 @@ mod tests {
                     vec![blocker_closed],
                 ),
             ],
+            milestones: vec![],
             agents: vec![],
             locks: vec![],
             agent_requests: vec![],
@@ -806,6 +1297,7 @@ mod tests {
             hub_sha: None,
             layout_version: 2,
             issues: vec![],
+            milestones: vec![],
             agents: vec![fresh, stale],
             locks: vec![],
             agent_requests: vec![],
@@ -842,6 +1334,7 @@ mod tests {
             hub_sha: None,
             layout_version: 2,
             issues: vec![],
+            milestones: vec![],
             agents: vec![],
             locks: vec![fresh, stale],
             agent_requests: vec![],

--- a/crosslink/src/db/sentinel.rs
+++ b/crosslink/src/db/sentinel.rs
@@ -293,6 +293,43 @@ impl Database {
         Ok(rows)
     }
 
+    pub fn get_repeat_failure_counts(&self) -> Result<Vec<(String, i64)>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT signal_ref, COUNT(*) as fail_count
+             FROM sentinel_dispatches
+             WHERE outcome IN ('failure', 'exhausted')
+             GROUP BY signal_ref
+             HAVING fail_count >= 2
+             ORDER BY fail_count DESC
+             LIMIT 10",
+        )?;
+        let rows = stmt
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+
+    pub fn get_escalation_heavy_counts(&self) -> Result<Vec<(String, i64, i64, i64)>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT label,
+                    SUM(CASE WHEN attempt_number = 1 AND outcome = 'failure' THEN 1 ELSE 0 END),
+                    SUM(CASE WHEN attempt_number = 2 THEN 1 ELSE 0 END),
+                    COUNT(*)
+             FROM sentinel_dispatches
+             WHERE disposition = 'dispatch'
+             GROUP BY label
+             HAVING COUNT(*) >= 4
+                AND SUM(CASE WHEN attempt_number = 1 AND outcome = 'failure' THEN 1 ELSE 0 END)
+                    > SUM(CASE WHEN attempt_number = 2 THEN 1 ELSE 0 END) * 0.8",
+        )?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+
     fn map_dispatch_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<SentinelDispatch> {
         Ok(SentinelDispatch {
             id: row.get(0)?,

--- a/crosslink/src/hub_v3.rs
+++ b/crosslink/src/hub_v3.rs
@@ -1484,6 +1484,28 @@ pub(crate) fn git_rev_parse_optional(repo_dir: &Path, ref_name: &str) -> Result<
     }
 }
 
+pub(crate) fn restore_ref_after_failed_publication(
+    repo_dir: &Path,
+    ref_name: &str,
+    failed_tip: &str,
+    previous_tip: Option<&str>,
+) -> Result<()> {
+    if let Some(previous_tip) = previous_tip {
+        return git_update_ref_cas(repo_dir, ref_name, previous_tip, Some(failed_tip));
+    }
+    let output = Command::new("git")
+        .current_dir(repo_dir)
+        .args(["update-ref", "-d", ref_name, failed_tip])
+        .output()
+        .with_context(|| format!("failed to delete unpublished ref '{ref_name}'"))?;
+    anyhow::ensure!(
+        output.status.success(),
+        "failed to delete unpublished ref '{ref_name}': {}",
+        String::from_utf8_lossy(&output.stderr).trim()
+    );
+    Ok(())
+}
+
 pub(crate) fn git_cat_file_blob_optional(
     repo_dir: &Path,
     blob_spec: &str,

--- a/crosslink/src/hydration.rs
+++ b/crosslink/src/hydration.rs
@@ -230,6 +230,10 @@ pub fn hydrate_to_sqlite(cache_dir: &Path, db: &Database) -> Result<HydrationSta
     result
 }
 
+pub fn clear_shared_projection(db: &Database) -> Result<()> {
+    db.clear_shared_data()
+}
+
 pub fn hydrate_from_state(
     state: &crate::checkpoint::CheckpointState,
     db: &Database,

--- a/crosslink/src/lib.rs
+++ b/crosslink/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod agent_flags;
 pub mod agent_requests;
 pub mod agents;
+pub mod application;
 pub mod checkpoint;
 pub mod clock_skew;
 pub mod compaction;

--- a/crosslink/src/lock_check.rs
+++ b/crosslink/src/lock_check.rs
@@ -1,7 +1,7 @@
 use anyhow::{bail, Result};
 use std::path::Path;
 
-use crate::db::Database;
+use crate::application::{CommandService, QueryService};
 use crate::identity::AgentConfig;
 use crate::sync::SyncManager;
 
@@ -69,7 +69,7 @@ fn auto_steal_if_configured(
     crosslink_dir: &Path,
     issue_id: i64,
     stale_agent_id: &str,
-    db: &Database,
+    service: &(impl CommandService + QueryService),
 ) -> Result<bool> {
     let Some(multiplier) = read_auto_steal_config(crosslink_dir) else {
         return Ok(false);
@@ -102,16 +102,14 @@ fn auto_steal_if_configured(
     }
 
     if sync.hub_mode().is_v3() {
-        if let Ok(Some(writer)) = crate::shared_writer::SharedWriter::new(crosslink_dir) {
-            writer.steal_lock_v2(issue_id, stale_agent_id, None)?;
+        {
+            service.steal_lock(issue_id, stale_agent_id, None)?;
             let comment = format!(
                 "[auto-steal] Lock auto-stolen from agent '{stale_agent_id}' (stale for {stale_minutes} min, threshold: {auto_steal_threshold} min)"
             );
-            if let Err(e) = writer.add_comment(db, issue_id, &comment, "system") {
+            if let Err(e) = service.add_comment(issue_id, &comment, "system") {
                 tracing::warn!("could not add audit comment for lock steal: {e}");
             }
-        } else {
-            return Ok(false);
         }
     } else {
         return Ok(false);
@@ -120,13 +118,17 @@ fn auto_steal_if_configured(
     Ok(true)
 }
 
-pub fn enforce_lock(crosslink_dir: &Path, issue_id: i64, db: &Database) -> Result<()> {
+pub fn enforce_lock(
+    crosslink_dir: &Path,
+    issue_id: i64,
+    service: &(impl CommandService + QueryService),
+) -> Result<()> {
     let _operation = crate::reconcile::readiness::acquire_mutation_operation_permit(crosslink_dir)?;
     match check_lock(crosslink_dir, issue_id)? {
         LockStatus::NotConfigured | LockStatus::Available | LockStatus::LockedBySelf => Ok(()),
         LockStatus::LockedByOther { agent_id, stale } => {
             if stale {
-                match auto_steal_if_configured(crosslink_dir, issue_id, &agent_id, db) {
+                match auto_steal_if_configured(crosslink_dir, issue_id, &agent_id, service) {
                     Ok(true) => {
                         tracing::info!(
                             "Auto-stole stale lock on issue #{} from '{}'.",
@@ -165,24 +167,13 @@ pub fn enforce_lock(crosslink_dir: &Path, issue_id: i64, db: &Database) -> Resul
     }
 }
 
-pub fn release_lock_best_effort(crosslink_dir: &Path, issue_id: i64) {
-    let Ok(Some(_agent)) = AgentConfig::load(crosslink_dir) else {
-        return;
-    };
-    let Ok(sync) = SyncManager::new(crosslink_dir) else {
-        return;
-    };
-    if !sync.is_initialized() || !sync.hub_mode().is_v3() {
-        return;
-    }
-    if let Ok(Some(writer)) = crate::shared_writer::SharedWriter::new(crosslink_dir) {
-        if let Err(e) = writer.release_lock_v2(issue_id) {
-            tracing::warn!(
-                "Could not release lock on {}: {}",
-                crate::utils::format_issue_id(issue_id),
-                e
-            );
-        }
+pub fn release_lock_best_effort(service: &impl CommandService, issue_id: i64) {
+    if let Err(e) = service.release_lock(issue_id) {
+        tracing::warn!(
+            "Could not release lock on {}: {}",
+            crate::utils::format_issue_id(issue_id),
+            e
+        );
     }
 }
 
@@ -198,56 +189,34 @@ pub enum ClaimResult {
 }
 
 pub fn try_claim_lock(
-    crosslink_dir: &Path,
+    service: &impl CommandService,
     issue_id: i64,
     branch: Option<&str>,
 ) -> Result<ClaimResult> {
-    let Some(_agent) = AgentConfig::load(crosslink_dir)? else {
-        return Ok(ClaimResult::NotConfigured);
-    };
-    let sync = match SyncManager::new(crosslink_dir) {
-        Ok(s) if s.is_initialized() => s,
-        _ => return Ok(ClaimResult::NotConfigured),
-    };
-
-    if sync.hub_mode().is_v3() {
-        let Some(writer) = crate::shared_writer::SharedWriter::new(crosslink_dir)? else {
-            return Ok(ClaimResult::NotConfigured);
-        };
-        match writer.claim_lock_v2(issue_id, branch)? {
+    match service.claim_lock(issue_id, branch) {
+        Ok(result) => match result {
             crate::shared_writer::LockClaimResult::Claimed => Ok(ClaimResult::Claimed),
             crate::shared_writer::LockClaimResult::AlreadyHeld => Ok(ClaimResult::AlreadyHeld),
             crate::shared_writer::LockClaimResult::Contended { winner_agent_id } => {
                 Ok(ClaimResult::Contended { winner_agent_id })
             }
+        },
+        Err(error) if error.to_string().contains("locks require configured") => {
+            Ok(ClaimResult::NotConfigured)
         }
-    } else {
-        Ok(ClaimResult::NotConfigured)
+        Err(error) => Err(error),
     }
 }
 
-pub fn try_release_lock(crosslink_dir: &Path, issue_id: i64) -> Result<bool> {
-    let Some(_agent) = AgentConfig::load(crosslink_dir)? else {
-        return Ok(false);
-    };
-    let sync = match SyncManager::new(crosslink_dir) {
-        Ok(s) if s.is_initialized() => s,
-        _ => return Ok(false),
-    };
-
-    if sync.hub_mode().is_v3() {
-        let Some(writer) = crate::shared_writer::SharedWriter::new(crosslink_dir)? else {
-            return Ok(false);
-        };
-        writer.release_lock_v2(issue_id)
-    } else {
-        Ok(false)
-    }
+pub fn try_release_lock(service: &impl CommandService, issue_id: i64) -> Result<bool> {
+    service.release_lock(issue_id)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::application::RepositoryService;
+    use crate::db::Database;
     use tempfile::tempdir;
 
     fn temp_db() -> Database {
@@ -288,6 +257,24 @@ mod tests {
                 .args(["config", cfg[0], cfg[1]])
                 .current_dir(repo_root)
                 .status();
+        }
+        let authority = repo_root.join("authority.git");
+        std::fs::create_dir(&authority).ok()?;
+        let remote_ready = std::process::Command::new("git")
+            .args(["init", "--bare", "-q"])
+            .current_dir(&authority)
+            .status()
+            .is_ok_and(|status| status.success());
+        if !remote_ready {
+            return None;
+        }
+        let remote_added = std::process::Command::new("git")
+            .args(["remote", "add", "origin", authority.to_str()?])
+            .current_dir(repo_root)
+            .status()
+            .is_ok_and(|status| status.success());
+        if !remote_added {
+            return None;
         }
 
         let crosslink_dir = repo_root.join(".crosslink");
@@ -924,7 +911,8 @@ mod tests {
         .unwrap();
 
         let db = temp_db();
-        let result = auto_steal_if_configured(&crosslink_dir, 55, "other-agent", &db);
+        let service = RepositoryService::new(&db, &crosslink_dir).unwrap();
+        let result = auto_steal_if_configured(&crosslink_dir, 55, "other-agent", &service);
 
         assert!(matches!(result, Ok(true)), "expected steal, got {result:?}");
     }

--- a/crosslink/src/main.rs
+++ b/crosslink/src/main.rs
@@ -25,6 +25,9 @@
 mod agent_flags;
 mod agent_requests;
 mod agents;
+mod application;
+#[cfg(test)]
+mod application_boundary_tests;
 mod checkpoint;
 mod clock_skew;
 mod commands;
@@ -2369,8 +2372,11 @@ fn get_service_db() -> Result<ServiceDatabase> {
     open_service_db(&find_crosslink_dir()?)
 }
 
-fn get_writer(crosslink_dir: &std::path::Path) -> Result<Option<shared_writer::SharedWriter>> {
-    shared_writer::SharedWriter::new(crosslink_dir)
+fn get_repository_service<'a>(
+    database: &'a db::Database,
+    crosslink_dir: &std::path::Path,
+) -> Result<application::RepositoryService<'a>> {
+    application::RepositoryService::new(database, crosslink_dir)
 }
 
 fn parse_issue_id_clap(s: &str) -> std::result::Result<i64, String> {
@@ -2428,7 +2434,7 @@ fn dispatch_issue(action: IssueCommands, quiet: bool, json: bool) -> Result<()> 
         } => {
             let db = get_db()?;
             let crosslink_dir = find_crosslink_dir()?;
-            let writer = get_writer(&crosslink_dir)?;
+            let service = get_repository_service(&db, &crosslink_dir)?;
             let opts = commands::create::CreateOpts {
                 labels: &label,
                 work,
@@ -2443,8 +2449,7 @@ fn dispatch_issue(action: IssueCommands, quiet: bool, json: bool) -> Result<()> 
                     anyhow::bail!("Scheduling dates apply to parent issues, not subissues.");
                 }
                 commands::create::run_subissue(
-                    &db,
-                    writer.as_ref(),
+                    &service,
                     parent_id,
                     &title,
                     description.as_deref(),
@@ -2454,8 +2459,7 @@ fn dispatch_issue(action: IssueCommands, quiet: bool, json: bool) -> Result<()> 
                 )
             } else {
                 commands::create::run(
-                    &db,
-                    writer.as_ref(),
+                    &service,
                     &title,
                     description.as_deref(),
                     &priority,
@@ -2480,7 +2484,7 @@ fn dispatch_issue(action: IssueCommands, quiet: bool, json: bool) -> Result<()> 
         } => {
             let db = get_db()?;
             let crosslink_dir = find_crosslink_dir()?;
-            let writer = get_writer(&crosslink_dir)?;
+            let service = get_repository_service(&db, &crosslink_dir)?;
             let opts = commands::create::CreateOpts {
                 labels: &label,
                 work: true,
@@ -2494,8 +2498,7 @@ fn dispatch_issue(action: IssueCommands, quiet: bool, json: bool) -> Result<()> 
                     anyhow::bail!("Scheduling dates apply to parent issues, not subissues.");
                 }
                 commands::create::run_subissue(
-                    &db,
-                    writer.as_ref(),
+                    &service,
                     parent_id,
                     &title,
                     description.as_deref(),
@@ -2505,8 +2508,7 @@ fn dispatch_issue(action: IssueCommands, quiet: bool, json: bool) -> Result<()> 
                 )
             } else {
                 commands::create::run(
-                    &db,
-                    writer.as_ref(),
+                    &service,
                     &title,
                     description.as_deref(),
                     &priority,
@@ -2610,7 +2612,7 @@ fn dispatch_issue(action: IssueCommands, quiet: bool, json: bool) -> Result<()> 
         } => {
             let db = get_db()?;
             let crosslink_dir = find_crosslink_dir()?;
-            let writer = get_writer(&crosslink_dir)?;
+            let service = get_repository_service(&db, &crosslink_dir)?;
             let update = shared_writer::IssueUpdate {
                 title: title.as_deref(),
                 description: description
@@ -2623,23 +2625,17 @@ fn dispatch_issue(action: IssueCommands, quiet: bool, json: bool) -> Result<()> 
                 scheduled_at: scheduled_update(scheduled, no_scheduled),
                 due_at: scheduled_update(due, no_due),
             };
-            commands::update::run(&db, writer.as_ref(), id, update)
+            commands::update::run(&service, id, update)
         }
 
         IssueCommands::Close { id, no_changelog } => {
             let db = get_db()?;
             let crosslink_dir = find_crosslink_dir()?;
-            let writer = get_writer(&crosslink_dir)?;
+            let service = get_repository_service(&db, &crosslink_dir)?;
             if quiet {
-                commands::lifecycle::close_quiet(
-                    &db,
-                    writer.as_ref(),
-                    id,
-                    !no_changelog,
-                    &crosslink_dir,
-                )
+                commands::lifecycle::close_quiet(&service, id, !no_changelog, &crosslink_dir)
             } else {
-                commands::lifecycle::close(&db, writer.as_ref(), id, !no_changelog, &crosslink_dir)
+                commands::lifecycle::close(&service, id, !no_changelog, &crosslink_dir)
             }
         }
 
@@ -2650,10 +2646,9 @@ fn dispatch_issue(action: IssueCommands, quiet: bool, json: bool) -> Result<()> 
         } => {
             let db = get_db()?;
             let crosslink_dir = find_crosslink_dir()?;
-            let writer = get_writer(&crosslink_dir)?;
+            let service = get_repository_service(&db, &crosslink_dir)?;
             commands::lifecycle::close_all(
-                &db,
-                writer.as_ref(),
+                &service,
                 label.as_deref(),
                 priority.as_deref(),
                 !no_changelog,
@@ -2664,22 +2659,22 @@ fn dispatch_issue(action: IssueCommands, quiet: bool, json: bool) -> Result<()> 
         IssueCommands::Reopen { id } => {
             let db = get_db()?;
             let crosslink_dir = find_crosslink_dir()?;
-            let writer = get_writer(&crosslink_dir)?;
-            commands::lifecycle::reopen(&db, writer.as_ref(), id)
+            let service = get_repository_service(&db, &crosslink_dir)?;
+            commands::lifecycle::reopen(&service, id)
         }
 
         IssueCommands::Delete { id, force } => {
             let db = get_db()?;
             let crosslink_dir = find_crosslink_dir()?;
-            let writer = get_writer(&crosslink_dir)?;
-            commands::delete::run(&db, writer.as_ref(), id, force)
+            let service = get_repository_service(&db, &crosslink_dir)?;
+            commands::delete::run(&service, id, force)
         }
 
         IssueCommands::Comment { id, text, kind } => {
             let db = get_db()?;
             let crosslink_dir = find_crosslink_dir()?;
-            let writer = get_writer(&crosslink_dir)?;
-            commands::comment::run(&db, writer.as_ref(), id, &text, &kind)
+            let service = get_repository_service(&db, &crosslink_dir)?;
+            commands::comment::run(&service, id, &text, &kind)
         }
 
         IssueCommands::Intervene {
@@ -2690,10 +2685,9 @@ fn dispatch_issue(action: IssueCommands, quiet: bool, json: bool) -> Result<()> 
         } => {
             let db = get_db()?;
             let crosslink_dir = find_crosslink_dir()?;
-            let writer = get_writer(&crosslink_dir)?;
+            let service = get_repository_service(&db, &crosslink_dir)?;
             commands::intervene::run(
-                &db,
-                writer.as_ref(),
+                &service,
                 id,
                 &description,
                 &trigger,
@@ -2705,58 +2699,61 @@ fn dispatch_issue(action: IssueCommands, quiet: bool, json: bool) -> Result<()> 
         IssueCommands::Label { id, label } => {
             let db = get_db()?;
             let crosslink_dir = find_crosslink_dir()?;
-            let writer = get_writer(&crosslink_dir)?;
-            commands::label::add(&db, writer.as_ref(), id, &label)
+            let service = get_repository_service(&db, &crosslink_dir)?;
+            commands::label::add(&service, id, &label)
         }
 
         IssueCommands::Unlabel { id, label } => {
             let db = get_db()?;
             let crosslink_dir = find_crosslink_dir()?;
-            let writer = get_writer(&crosslink_dir)?;
-            commands::label::remove(&db, writer.as_ref(), id, &label)
+            let service = get_repository_service(&db, &crosslink_dir)?;
+            commands::label::remove(&service, id, &label)
         }
 
         IssueCommands::Block { id, blocker } => {
             let db = get_db()?;
             let crosslink_dir = find_crosslink_dir()?;
-            let writer = get_writer(&crosslink_dir)?;
-            commands::deps::block(&db, writer.as_ref(), id, blocker)
+            let service = get_repository_service(&db, &crosslink_dir)?;
+            commands::deps::block(&service, id, blocker)
         }
 
         IssueCommands::Unblock { id, blocker } => {
             let db = get_db()?;
             let crosslink_dir = find_crosslink_dir()?;
-            let writer = get_writer(&crosslink_dir)?;
-            commands::deps::unblock(&db, writer.as_ref(), id, blocker)
+            let service = get_repository_service(&db, &crosslink_dir)?;
+            commands::deps::unblock(&service, id, blocker)
         }
 
         IssueCommands::Blocked => {
             let db = get_db()?;
-            commands::deps::list_blocked(&db, json)
+            let queries = application::RepositoryService::projection(&db);
+            commands::deps::list_blocked(&queries, json)
         }
 
         IssueCommands::Ready => {
             let db = get_db()?;
-            commands::deps::list_ready(&db, json)
+            let queries = application::RepositoryService::projection(&db);
+            commands::deps::list_ready(&queries, json)
         }
 
         IssueCommands::Relate { id, related } => {
             let db = get_db()?;
             let crosslink_dir = find_crosslink_dir()?;
-            let writer = get_writer(&crosslink_dir)?;
-            commands::relate::add(&db, writer.as_ref(), id, related)
+            let service = get_repository_service(&db, &crosslink_dir)?;
+            commands::relate::add(&service, id, related)
         }
 
         IssueCommands::Unrelate { id, related } => {
             let db = get_db()?;
             let crosslink_dir = find_crosslink_dir()?;
-            let writer = get_writer(&crosslink_dir)?;
-            commands::relate::remove(&db, writer.as_ref(), id, related)
+            let service = get_repository_service(&db, &crosslink_dir)?;
+            commands::relate::remove(&service, id, related)
         }
 
         IssueCommands::Related { id } => {
             let db = get_db()?;
-            commands::relate::list(&db, id)
+            let queries = application::RepositoryService::projection(&db);
+            commands::relate::list(&queries, id)
         }
 
         IssueCommands::Next => {
@@ -2917,10 +2914,11 @@ fn run_cli() -> Result<()> {
 
         Commands::Timer { action } => {
             let db = get_db()?;
+            let service = application::RepositoryService::projection(&db);
             match action {
-                TimerCommands::Start { id } => commands::timer::start(&db, id),
-                TimerCommands::Stop => commands::timer::stop(&db),
-                TimerCommands::Show => commands::timer::status(&db),
+                TimerCommands::Start { id } => commands::timer::start(&service, id),
+                TimerCommands::Stop => commands::timer::stop(&service),
+                TimerCommands::Show => commands::timer::status(&service),
             }
         }
 
@@ -3163,7 +3161,8 @@ fn run_cli() -> Result<()> {
                 "did you mean 'crosslink timer start'? Using that.",
             );
             let db = get_db()?;
-            commands::timer::start(&db, id)
+            let service = application::RepositoryService::projection(&db);
+            commands::timer::start(&service, id)
         }
 
         Commands::TimerStop => {
@@ -3172,7 +3171,8 @@ fn run_cli() -> Result<()> {
                 "did you mean 'crosslink timer stop'? Using that.",
             );
             let db = get_db()?;
-            commands::timer::stop(&db)
+            let service = application::RepositoryService::projection(&db);
+            commands::timer::stop(&service)
         }
 
         Commands::MigrateToShared => {
@@ -3215,20 +3215,43 @@ fn run_cli() -> Result<()> {
         Commands::Import { input } => {
             let db = get_db()?;
             let crosslink_dir = find_crosslink_dir()?;
-            let writer = get_writer(&crosslink_dir)?;
+            let service = get_repository_service(&db, &crosslink_dir)?;
             let path = std::path::Path::new(&input);
-            commands::import::run_json(&db, writer.as_ref(), path)
+            commands::import::run_json(&service, path)
         }
 
         Commands::Archive { action } => {
             let db = get_db()?;
-            commands::archive::run(action, &db)
+            match action {
+                ArchiveCommands::List => {
+                    let service = application::RepositoryService::projection(&db);
+                    commands::archive::run(ArchiveCommands::List, &service)
+                }
+                mutation => {
+                    let crosslink_dir = find_crosslink_dir()?;
+                    let service = get_repository_service(&db, &crosslink_dir)?;
+                    commands::archive::run(mutation, &service)
+                }
+            }
         }
 
         Commands::Milestone { action } => {
             let db = get_db()?;
-            let crosslink_dir = find_crosslink_dir()?;
-            commands::milestone::run(action, &db, &crosslink_dir)
+            match action {
+                MilestoneCommands::List { status } => {
+                    let service = application::RepositoryService::projection(&db);
+                    commands::milestone::run(MilestoneCommands::List { status }, &service)
+                }
+                MilestoneCommands::Show { id } => {
+                    let service = application::RepositoryService::projection(&db);
+                    commands::milestone::run(MilestoneCommands::Show { id }, &service)
+                }
+                mutation => {
+                    let crosslink_dir = find_crosslink_dir()?;
+                    let service = get_repository_service(&db, &crosslink_dir)?;
+                    commands::milestone::run(mutation, &service)
+                }
+            }
         }
 
         Commands::Session { action } => {
@@ -3298,12 +3321,21 @@ fn run_cli() -> Result<()> {
 
         Commands::Cpitd { action } => {
             let db = get_db()?;
-            commands::cpitd::run(action, &db, cli.quiet)
+            let crosslink_dir = find_crosslink_dir()?;
+            let service = get_repository_service(&db, &crosslink_dir)?;
+            commands::cpitd::run(action, &service, cli.quiet)
         }
 
         Commands::Agent { action } => {
             let crosslink_dir = find_crosslink_dir()?;
-            commands::agent::run(action, &crosslink_dir)
+            match action {
+                mutation @ (AgentCommands::Request { .. } | AgentCommands::PollRequests) => {
+                    let db = get_db()?;
+                    let service = get_repository_service(&db, &crosslink_dir)?;
+                    commands::agent::run(mutation, &crosslink_dir, Some(&service))
+                }
+                local => commands::agent::run(local, &crosslink_dir, None),
+            }
         }
 
         Commands::Trust { action } => {
@@ -3325,8 +3357,11 @@ fn run_cli() -> Result<()> {
                     let sync = crate::sync::SyncManager::new(&crosslink_dir)?;
                     let _ = sync.init_cache();
                     let db = get_db()?;
-                    let active_issue = db
-                        .get_current_session_for_agent(None)?
+                    let service = application::RepositoryService::projection(&db);
+                    let active_issue =
+                        application::LocalStateService::get_current_session_for_agent(
+                            &service, None,
+                        )?
                         .and_then(|s| s.active_issue_id);
                     sync.push_heartbeat(&agent, active_issue)?;
                     Ok(())
@@ -3433,28 +3468,7 @@ fn run_cli() -> Result<()> {
                 skip_permissions: false,
                 permission_mode: None,
             });
-            let diagnostic = matches!(
-                &action,
-                KickoffCommands::Status { .. }
-                    | KickoffCommands::Logs { .. }
-                    | KickoffCommands::ShowPlan { .. }
-                    | KickoffCommands::Report { .. }
-                    | KickoffCommands::List { .. }
-                    | KickoffCommands::Graph { .. }
-            );
-            let writer = if diagnostic {
-                None
-            } else {
-                get_writer(&crosslink_dir)?
-            };
-            commands::kickoff::dispatch(
-                action,
-                &crosslink_dir,
-                &db,
-                writer.as_ref(),
-                cli.quiet,
-                cli.json,
-            )
+            commands::kickoff::dispatch(action, &crosslink_dir, &db, cli.quiet, cli.json)
         }
         Commands::Doctor => {
             let crosslink_dir = find_crosslink_dir()?;
@@ -3496,31 +3510,12 @@ fn run_cli() -> Result<()> {
                     retry_failed,
                 } => {
                     let db = get_db()?;
-                    let writer = get_writer(&crosslink_dir)?;
                     if retry_failed {
-                        commands::swarm::launch_retry_failed(
-                            &crosslink_dir,
-                            &db,
-                            writer.as_ref(),
-                            &phase,
-                            cli.quiet,
-                        )
+                        commands::swarm::launch_retry_failed(&crosslink_dir, &db, &phase, cli.quiet)
                     } else if budget_aware {
-                        commands::swarm::launch_budget_aware(
-                            &crosslink_dir,
-                            &db,
-                            writer.as_ref(),
-                            &phase,
-                            cli.quiet,
-                        )
+                        commands::swarm::launch_budget_aware(&crosslink_dir, &db, &phase, cli.quiet)
                     } else {
-                        commands::swarm::launch(
-                            &crosslink_dir,
-                            &db,
-                            writer.as_ref(),
-                            &phase,
-                            cli.quiet,
-                        )
+                        commands::swarm::launch(&crosslink_dir, &db, &phase, cli.quiet)
                     }
                 }
                 SwarmCommands::Gate { phase } => commands::swarm::gate(&crosslink_dir, &phase),
@@ -3637,11 +3632,6 @@ fn run_cli() -> Result<()> {
             }
             let crosslink_dir = find_crosslink_dir()?;
             let db = get_db()?;
-            let writer = if matches!(&action, SentinelCommands::Run { .. }) {
-                get_writer(&crosslink_dir)?
-            } else {
-                None
-            };
             let sentinel_model = match &action {
                 SentinelCommands::Run { model, .. }
                 | SentinelCommands::Watch { model, .. }
@@ -3652,7 +3642,6 @@ fn run_cli() -> Result<()> {
                 action,
                 &crosslink_dir,
                 &db,
-                writer.as_ref(),
                 cli.quiet,
                 cli.json,
                 sentinel_model,

--- a/crosslink/src/orchestrator/executor.rs
+++ b/crosslink/src/orchestrator/executor.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-use crate::db::Database;
+use crate::application::CommandService;
 use crate::orchestrator::dag::{Dag, DagNode};
 use crate::orchestrator::models::{OrchestratorPlan, OrchestratorStage};
 use crate::server::types::{
@@ -59,7 +59,11 @@ impl OrchestratorExecutor {
         Self::state_dir(crosslink_dir).join(PLAN_FILE)
     }
 
-    pub fn init(crosslink_dir: &Path, db: &Database, plan: &OrchestratorPlan) -> Result<Self> {
+    pub fn init(
+        crosslink_dir: &Path,
+        commands: &impl CommandService,
+        plan: &OrchestratorPlan,
+    ) -> Result<Self> {
         let state_dir = Self::state_dir(crosslink_dir);
         std::fs::create_dir_all(&state_dir)
             .context("Failed to create orchestrator state directory")?;
@@ -88,7 +92,7 @@ impl OrchestratorExecutor {
         let mut phase_issues = HashMap::new();
 
         for phase in &plan.phases {
-            let milestone_id = db
+            let milestone_id = commands
                 .create_milestone(
                     &format!("[Orchestrator] {}", phase.title),
                     Some(&phase.description),
@@ -96,24 +100,27 @@ impl OrchestratorExecutor {
                 .context("Failed to create phase milestone")?;
             phase_milestones.insert(phase.id.clone(), milestone_id);
 
-            let phase_issue_id = db
-                .create_issue(
+            let phase_issue_id = commands
+                .create_issue_with_labels(
                     &format!("[Phase] {}", phase.title),
                     Some(&phase.description),
                     "high",
+                    &["orchestrator".to_string(), "phase".to_string()],
+                    None,
+                    None,
                 )
                 .context("Failed to create phase parent issue")?;
-            if let Err(e) = db.add_label(phase_issue_id, "orchestrator") {
-                tracing::warn!("could not label phase issue #{phase_issue_id}: {e}");
-            }
-            if let Err(e) = db.add_label(phase_issue_id, "phase") {
-                tracing::warn!("could not label phase issue #{phase_issue_id}: {e}");
-            }
             phase_issues.insert(phase.id.clone(), phase_issue_id);
         }
 
         let mut dag = dag;
-        Self::create_stage_issues_and_deps(db, plan, &phase_issues, &phase_milestones, &mut dag)?;
+        Self::create_stage_issues_and_deps(
+            commands,
+            plan,
+            &phase_issues,
+            &phase_milestones,
+            &mut dag,
+        )?;
 
         let snapshot = ExecutionSnapshot {
             plan_id: plan.id.clone(),
@@ -136,7 +143,7 @@ impl OrchestratorExecutor {
     }
 
     fn create_stage_issues_and_deps(
-        db: &Database,
+        commands: &impl CommandService,
         plan: &OrchestratorPlan,
         phase_issues: &HashMap<String, i64>,
         phase_milestones: &HashMap<String, i64>,
@@ -149,24 +156,18 @@ impl OrchestratorExecutor {
 
             for stage in &phase.stages {
                 let description = build_stage_description(stage);
-                let issue_id = db
-                    .create_subissue(
+                let issue_id = commands
+                    .create_subissue_with_labels(
                         phase_issue_id,
                         &format!("[Stage] {}", stage.title),
                         Some(&description),
                         "high",
+                        &["orchestrator".to_string(), "stage".to_string()],
                     )
                     .context("Failed to create stage subissue")?;
 
-                if let Err(e) = db.add_label(issue_id, "orchestrator") {
-                    tracing::warn!("could not label stage issue #{issue_id}: {e}");
-                }
-                if let Err(e) = db.add_label(issue_id, "stage") {
-                    tracing::warn!("could not label stage issue #{issue_id}: {e}");
-                }
-
                 let milestone_id = phase_milestones[&phase.id];
-                if let Err(e) = db.add_issue_to_milestone(milestone_id, issue_id) {
+                if let Err(e) = commands.assign_milestone(milestone_id, &[issue_id]) {
                     tracing::warn!(
                         "could not add stage issue #{issue_id} to milestone #{milestone_id}: {e}"
                     );
@@ -182,7 +183,7 @@ impl OrchestratorExecutor {
                 let blocked_id = stage_issue_map[&stage.id];
                 for dep_id in &stage.depends_on {
                     if let Some(&blocker_id) = stage_issue_map.get(dep_id) {
-                        if let Err(e) = db.add_dependency(blocked_id, blocker_id) {
+                        if let Err(e) = commands.add_dependency(blocked_id, blocker_id) {
                             tracing::warn!(
                                 "could not set dependency #{blocker_id} -> #{blocked_id}: {e}"
                             );
@@ -350,7 +351,7 @@ impl OrchestratorExecutor {
     pub fn mark_stage_done(
         &mut self,
         stage_id: &str,
-        db: &Database,
+        commands: &impl CommandService,
     ) -> Result<(Vec<String>, WsExecutionProgressEvent, bool)> {
         self.require_running_state("mark stage done")?;
         let phase_id = self
@@ -361,7 +362,7 @@ impl OrchestratorExecutor {
             .unwrap_or_default();
 
         if let Some(issue_id) = self.snapshot.dag.get(stage_id).and_then(|n| n.issue_id) {
-            if let Err(e) = db.close_issue(issue_id) {
+            if let Err(e) = commands.close_issue(issue_id) {
                 tracing::warn!("could not close stage issue #{issue_id}: {e}");
             }
         }
@@ -371,12 +372,12 @@ impl OrchestratorExecutor {
         let phase_complete = self.check_phase_complete(&phase_id);
         if phase_complete {
             if let Some(&milestone_id) = self.snapshot.phase_milestones.get(&phase_id) {
-                if let Err(e) = db.close_milestone(milestone_id) {
+                if let Err(e) = commands.close_milestone(milestone_id) {
                     tracing::warn!("could not close phase milestone #{milestone_id}: {e}");
                 }
             }
             if let Some(&phase_issue_id) = self.snapshot.phase_issues.get(&phase_id) {
-                if let Err(e) = db.close_issue(phase_issue_id) {
+                if let Err(e) = commands.close_issue(phase_issue_id) {
                     tracing::warn!("could not close phase issue #{phase_issue_id}: {e}");
                 }
             }
@@ -557,6 +558,7 @@ fn build_stage_description(stage: &OrchestratorStage) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::db::Database;
     use crate::orchestrator::models::{OrchestratorPhase, OrchestratorStage, OrchestratorTask};
     use tempfile::TempDir;
 

--- a/crosslink/src/reconcile/readiness.rs
+++ b/crosslink/src/reconcile/readiness.rs
@@ -30,6 +30,8 @@ const MAX_RECORD_AGE_SECONDS: i64 = 90;
 const PERMIT_POLL_MILLIS: u64 = 25;
 const MUTATION_TRANSITION_WAIT_SECS: u64 = 5;
 const LIVENESS_SWEEP_POLLS: u8 = 40;
+const PROCESS_OBSERVATION_ATTEMPTS: usize = 20;
+const PROCESS_OBSERVATION_RETRY_MILLIS: u64 = 10;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -1363,7 +1365,7 @@ fn restore_daemon_identity_claim(path: &Path, quarantine: &Path) -> Result<bool>
 
 #[cfg(windows)]
 pub fn is_process_running(pid: u32) -> bool {
-    process_start_token(pid).is_some()
+    observed_process_start_token(pid).is_some()
 }
 
 pub fn daemon_identity_is_live(identity: &DaemonIdentity) -> bool {
@@ -1371,7 +1373,7 @@ pub fn daemon_identity_is_live(identity: &DaemonIdentity) -> bool {
 }
 
 pub fn process_identity_is_live(pid: u32, process_start: &str) -> bool {
-    process_start_token(pid).as_deref() == Some(process_start)
+    observed_process_start_token(pid).as_deref() == Some(process_start)
 }
 
 pub fn current_process_start_token() -> Result<String> {
@@ -1385,13 +1387,30 @@ pub fn current_process_start_token() -> Result<String> {
 }
 
 pub fn process_start_token_for(pid: u32) -> Result<String> {
-    for _ in 0..20 {
-        if let Some(token) = process_start_token(pid) {
-            return Ok(token);
+    observed_process_start_token(pid)
+        .ok_or_else(|| anyhow::anyhow!("unable to determine process start identity for PID {pid}"))
+}
+
+fn observed_process_start_token(pid: u32) -> Option<String> {
+    retry_process_observation(
+        || process_start_token(pid),
+        || thread::sleep(Duration::from_millis(PROCESS_OBSERVATION_RETRY_MILLIS)),
+    )
+}
+
+fn retry_process_observation<T>(
+    mut observe: impl FnMut() -> Option<T>,
+    mut wait: impl FnMut(),
+) -> Option<T> {
+    for attempt in 0..PROCESS_OBSERVATION_ATTEMPTS {
+        if let Some(value) = observe() {
+            return Some(value);
         }
-        thread::sleep(Duration::from_millis(10));
+        if attempt + 1 < PROCESS_OBSERVATION_ATTEMPTS {
+            wait();
+        }
     }
-    bail!("unable to determine process start identity for PID {pid}")
+    None
 }
 
 #[cfg(target_os = "linux")]
@@ -1947,6 +1966,22 @@ mod tests {
         let mut entries = Vec::new();
         collect(path, path, &mut entries);
         entries
+    }
+
+    #[test]
+    fn process_observation_retries_transient_absence() {
+        let mut observations = 0;
+        let mut waits = 0;
+        let observed = retry_process_observation(
+            || {
+                observations += 1;
+                (observations == 3).then_some("live")
+            },
+            || waits += 1,
+        );
+        assert_eq!(observed, Some("live"));
+        assert_eq!(observations, 3);
+        assert_eq!(waits, 2);
     }
 
     #[test]

--- a/crosslink/src/server/handlers/issues.rs
+++ b/crosslink/src/server/handlers/issues.rs
@@ -5,6 +5,7 @@ use axum::{
 };
 use serde_json::{json, Value};
 
+use crate::application::{CommandService, QueryService, RepositoryService};
 use crate::server::{
     errors::{bad_request, internal_error, not_found},
     state::AppState,
@@ -24,14 +25,154 @@ fn broadcast_issue_updated(state: &AppState, issue_id: i64, field: &str) {
     }));
 }
 
+pub(crate) fn execute_create_issue_command(
+    service: &impl CommandService,
+    body: &CreateIssueRequest,
+) -> anyhow::Result<i64> {
+    let priority = body.priority.to_string();
+    body.parent_id.map_or_else(
+        || {
+            service.create_issue(
+                &body.title,
+                body.description.as_deref(),
+                &priority,
+                None,
+                None,
+            )
+        },
+        |parent_id| {
+            service.create_subissue(
+                parent_id,
+                &body.title,
+                body.description.as_deref(),
+                &priority,
+            )
+        },
+    )
+}
+
+pub(crate) fn execute_update_issue_command(
+    service: &impl CommandService,
+    id: i64,
+    body: UpdateIssueRequest,
+) -> anyhow::Result<()> {
+    let priority = body.priority.as_ref().map(std::string::ToString::to_string);
+    service.update_issue(
+        id,
+        crate::application::OwnedIssueUpdate {
+            title: body.title,
+            description: body.description.map_or(
+                crate::application::DescriptionChange::Unchanged,
+                crate::application::DescriptionChange::Set,
+            ),
+            status: None,
+            priority,
+            scheduled_at: crate::application::DateTimeChange::Unchanged,
+            due_at: crate::application::DateTimeChange::Unchanged,
+        },
+    )
+}
+
+pub(crate) fn execute_create_subissue_command(
+    service: &impl CommandService,
+    parent_id: i64,
+    body: &CreateSubissueRequest,
+) -> anyhow::Result<i64> {
+    service.create_subissue(
+        parent_id,
+        &body.title,
+        body.description.as_deref(),
+        &body.priority.to_string(),
+    )
+}
+
+pub(crate) fn execute_delete_issue_command(
+    service: &impl CommandService,
+    id: i64,
+) -> anyhow::Result<()> {
+    service.delete_issue(id)
+}
+
+pub(crate) fn execute_close_issue_command(
+    service: &impl CommandService,
+    id: i64,
+) -> anyhow::Result<()> {
+    service.close_issue(id)
+}
+
+pub(crate) fn execute_reopen_issue_command(
+    service: &impl CommandService,
+    id: i64,
+) -> anyhow::Result<()> {
+    service.reopen_issue(id)
+}
+
+pub(crate) fn execute_add_comment_command(
+    service: &impl CommandService,
+    id: i64,
+    body: &CreateCommentRequest,
+) -> anyhow::Result<i64> {
+    if body.kind == crate::server::types::CommentKind::Intervention {
+        let trigger = body
+            .trigger_type
+            .as_deref()
+            .filter(|trigger| !trigger.is_empty())
+            .ok_or_else(|| {
+                anyhow::anyhow!("trigger_type is required when comment kind is 'intervention'")
+            })?;
+        service.add_intervention(
+            id,
+            &body.content,
+            trigger,
+            body.intervention_context.as_deref(),
+            None,
+        )
+    } else {
+        service.add_comment(id, &body.content, &body.kind.to_string())
+    }
+}
+
+pub(crate) fn execute_add_label_command(
+    service: &impl CommandService,
+    id: i64,
+    label: &str,
+) -> anyhow::Result<bool> {
+    service.add_label(id, label)
+}
+
+pub(crate) fn execute_remove_label_command(
+    service: &impl CommandService,
+    id: i64,
+    label: &str,
+) -> anyhow::Result<bool> {
+    service.remove_label(id, label)
+}
+
+pub(crate) fn execute_add_blocker_command(
+    service: &impl CommandService,
+    id: i64,
+    blocker_id: i64,
+) -> anyhow::Result<bool> {
+    service.add_dependency(id, blocker_id)
+}
+
+pub(crate) fn execute_remove_blocker_command(
+    service: &impl CommandService,
+    id: i64,
+    blocker_id: i64,
+) -> anyhow::Result<bool> {
+    service.remove_dependency(id, blocker_id)
+}
+
 pub async fn list_issues(
     State(state): State<AppState>,
     Query(params): Query<IssueListQuery>,
 ) -> Result<Json<IssueListResponse>, (StatusCode, Json<ApiError>)> {
     let db = state.db().await;
+    let service = RepositoryService::projection(&db);
 
     let issues = if let Some(ref search) = params.search {
-        let mut results = db
+        let mut results = service
             .search_issues(search)
             .map_err(|e| internal_error("Failed to search issues", e))?;
 
@@ -46,7 +187,8 @@ pub async fn list_issues(
             let ids_with_label: Vec<i64> = results
                 .iter()
                 .filter_map(|i| {
-                    db.get_labels(i.id)
+                    service
+                        .get_labels(i.id)
                         .ok()
                         .filter(|labels| labels.contains(label))
                         .map(|_| i.id)
@@ -64,7 +206,7 @@ pub async fn list_issues(
         }
         results
     } else {
-        let mut results = db
+        let mut results = service
             .list_issues(
                 params.status.as_deref(),
                 params.label.as_deref(),
@@ -79,8 +221,10 @@ pub async fn list_issues(
     };
 
     let issue_ids: Vec<i64> = issues.iter().map(|i| i.id).collect();
-    let labels_map = db.get_labels_batch(&issue_ids).unwrap_or_default();
-    let blocker_counts = db.get_blocker_counts_batch(&issue_ids).unwrap_or_default();
+    let labels_map = service.get_labels_batch(&issue_ids).unwrap_or_default();
+    let blocker_counts = service
+        .get_blocker_counts_batch(&issue_ids)
+        .unwrap_or_default();
     drop(db);
 
     let mut items: Vec<IssueSummary> = Vec::with_capacity(issues.len());
@@ -103,22 +247,13 @@ pub async fn create_issue(
     Json(body): Json<CreateIssueRequest>,
 ) -> Result<Json<Value>, (StatusCode, Json<ApiError>)> {
     let db = state.db().await;
+    let service = RepositoryService::new(&db, &state.crosslink_dir)
+        .map_err(|error| internal_error("Shared authority is unavailable", error))?;
 
-    let priority_str = body.priority.to_string();
-    let id = if let Some(parent_id) = body.parent_id {
-        db.create_subissue(
-            parent_id,
-            &body.title,
-            body.description.as_deref(),
-            &priority_str,
-        )
-        .map_err(|e| bad_request(e.to_string()))?
-    } else {
-        db.create_issue(&body.title, body.description.as_deref(), &priority_str)
-            .map_err(|e| bad_request(e.to_string()))?
-    };
+    let id =
+        execute_create_issue_command(&service, &body).map_err(|e| bad_request(e.to_string()))?;
 
-    let issue = db
+    let issue = service
         .get_issue(id)
         .map_err(|e| internal_error("Failed to retrieve created issue", e))?
         .ok_or_else(|| internal_error("Issue was created but not found", "unexpected state"))?;
@@ -132,8 +267,9 @@ pub async fn list_blocked(
     State(state): State<AppState>,
 ) -> Result<Json<Value>, (StatusCode, Json<ApiError>)> {
     let db = state.db().await;
+    let service = RepositoryService::projection(&db);
 
-    let issues = db
+    let issues = service
         .list_blocked_issues()
         .map_err(|e| internal_error("Failed to list blocked issues", e))?;
     drop(db);
@@ -146,8 +282,9 @@ pub async fn list_ready(
     State(state): State<AppState>,
 ) -> Result<Json<Value>, (StatusCode, Json<ApiError>)> {
     let db = state.db().await;
+    let service = RepositoryService::projection(&db);
 
-    let issues = db
+    let issues = service
         .list_ready_issues()
         .map_err(|e| internal_error("Failed to list ready issues", e))?;
     drop(db);
@@ -161,37 +298,36 @@ pub async fn get_issue(
     Path(id): Path<i64>,
 ) -> Result<Json<IssueDetail>, (StatusCode, Json<ApiError>)> {
     let db = state.db().await;
+    let service = RepositoryService::projection(&db);
 
-    let issue = db
+    let issue = service
         .get_issue(id)
         .map_err(|e| internal_error("Failed to fetch issue", e))?
         .ok_or_else(|| not_found(format!("Issue #{id} not found")))?;
 
-    let labels = db
+    let labels = service
         .get_labels(id)
         .map_err(|e| internal_error("Failed to fetch labels", e))?;
-    let comments = db
+    let comments = service
         .get_comments(id)
         .map_err(|e| internal_error("Failed to fetch comments", e))?;
-    let blockers = db
+    let blockers = service
         .get_blockers(id)
         .map_err(|e| internal_error("Failed to fetch blockers", e))?;
-    let blocking = db
+    let blocking = service
         .get_blocking(id)
         .map_err(|e| internal_error("Failed to fetch blocking", e))?;
-    let subissues = db
+    let subissues = service
         .get_subissues(id)
         .map_err(|e| internal_error("Failed to fetch subissues", e))?;
 
-    let milestone =
-        db.get_issue_milestone(id)
-            .ok()
-            .flatten()
-            .map(|m| crate::server::types::MilestoneSummary {
-                id: m.id,
-                name: m.name,
-                status: m.status,
-            });
+    let milestone = service.get_issue_milestone(id).ok().flatten().map(|m| {
+        crate::server::types::MilestoneSummary {
+            id: m.id,
+            name: m.name,
+            status: m.status,
+        }
+    });
     drop(db);
 
     Ok(Json(IssueDetail {
@@ -211,26 +347,17 @@ pub async fn update_issue(
     Json(body): Json<UpdateIssueRequest>,
 ) -> Result<Json<Value>, (StatusCode, Json<ApiError>)> {
     let db = state.db().await;
+    let service = RepositoryService::new(&db, &state.crosslink_dir)
+        .map_err(|error| internal_error("Shared authority is unavailable", error))?;
 
-    db.get_issue(id)
+    service
+        .get_issue(id)
         .map_err(|e| internal_error("Failed to fetch issue", e))?
         .ok_or_else(|| not_found(format!("Issue #{id} not found")))?;
 
-    let priority_str = body.priority.as_ref().map(std::string::ToString::to_string);
-    let updated = db
-        .update_issue(
-            id,
-            body.title.as_deref(),
-            body.description.as_deref(),
-            priority_str.as_deref(),
-        )
-        .map_err(|e| bad_request(e.to_string()))?;
+    execute_update_issue_command(&service, id, body).map_err(|e| bad_request(e.to_string()))?;
 
-    if !updated {
-        return Err(not_found(format!("Issue #{id} not found")));
-    }
-
-    let issue = db
+    let issue = service
         .get_issue(id)
         .map_err(|e| internal_error("Failed to refetch updated issue", e))?
         .ok_or_else(|| internal_error("Issue disappeared after update", "unexpected state"))?;
@@ -245,15 +372,17 @@ pub async fn delete_issue(
     Path(id): Path<i64>,
 ) -> Result<Json<OkResponse>, (StatusCode, Json<ApiError>)> {
     let db = state.db().await;
+    let service = RepositoryService::new(&db, &state.crosslink_dir)
+        .map_err(|error| internal_error("Shared authority is unavailable", error))?;
 
-    let deleted = db
-        .delete_issue(id)
+    service
+        .get_issue(id)
+        .map_err(|e| internal_error("Failed to fetch issue", e))?
+        .ok_or_else(|| not_found(format!("Issue #{id} not found")))?;
+
+    execute_delete_issue_command(&service, id)
         .map_err(|e| internal_error("Failed to delete issue", e))?;
     drop(db);
-
-    if !deleted {
-        return Err(not_found(format!("Issue #{id} not found")));
-    }
 
     broadcast_issue_updated(&state, id, "deleted");
     Ok(Json(OkResponse { ok: true }))
@@ -264,16 +393,18 @@ pub async fn close_issue(
     Path(id): Path<i64>,
 ) -> Result<Json<Value>, (StatusCode, Json<ApiError>)> {
     let db = state.db().await;
+    let service = RepositoryService::new(&db, &state.crosslink_dir)
+        .map_err(|error| internal_error("Shared authority is unavailable", error))?;
 
-    let closed = db
-        .close_issue(id)
+    service
+        .get_issue(id)
+        .map_err(|e| internal_error("Failed to fetch issue", e))?
+        .ok_or_else(|| not_found(format!("Issue #{id} not found")))?;
+
+    execute_close_issue_command(&service, id)
         .map_err(|e| internal_error("Failed to close issue", e))?;
 
-    if !closed {
-        return Err(not_found(format!("Issue #{id} not found")));
-    }
-
-    let issue = db
+    let issue = service
         .get_issue(id)
         .map_err(|e| internal_error("Failed to refetch closed issue", e))?
         .ok_or_else(|| internal_error("Issue disappeared after close", "unexpected state"))?;
@@ -288,16 +419,18 @@ pub async fn reopen_issue(
     Path(id): Path<i64>,
 ) -> Result<Json<Value>, (StatusCode, Json<ApiError>)> {
     let db = state.db().await;
+    let service = RepositoryService::new(&db, &state.crosslink_dir)
+        .map_err(|error| internal_error("Shared authority is unavailable", error))?;
 
-    let reopened = db
-        .reopen_issue(id)
+    service
+        .get_issue(id)
+        .map_err(|e| internal_error("Failed to fetch issue", e))?
+        .ok_or_else(|| not_found(format!("Issue #{id} not found")))?;
+
+    execute_reopen_issue_command(&service, id)
         .map_err(|e| internal_error("Failed to reopen issue", e))?;
 
-    if !reopened {
-        return Err(not_found(format!("Issue #{id} not found")));
-    }
-
-    let issue = db
+    let issue = service
         .get_issue(id)
         .map_err(|e| internal_error("Failed to refetch reopened issue", e))?
         .ok_or_else(|| internal_error("Issue disappeared after reopen", "unexpected state"))?;
@@ -313,22 +446,18 @@ pub async fn create_subissue(
     Json(body): Json<CreateSubissueRequest>,
 ) -> Result<Json<Value>, (StatusCode, Json<ApiError>)> {
     let db = state.db().await;
+    let service = RepositoryService::new(&db, &state.crosslink_dir)
+        .map_err(|error| internal_error("Shared authority is unavailable", error))?;
 
-    db.get_issue(parent_id)
+    service
+        .get_issue(parent_id)
         .map_err(|e| internal_error("Failed to fetch parent issue", e))?
         .ok_or_else(|| not_found(format!("Parent issue #{parent_id} not found")))?;
 
-    let priority_str = body.priority.to_string();
-    let child_id = db
-        .create_subissue(
-            parent_id,
-            &body.title,
-            body.description.as_deref(),
-            &priority_str,
-        )
+    let child_id = execute_create_subissue_command(&service, parent_id, &body)
         .map_err(|e| bad_request(e.to_string()))?;
 
-    let child = db
+    let child = service
         .get_issue(child_id)
         .map_err(|e| internal_error("Failed to retrieve created subissue", e))?
         .ok_or_else(|| internal_error("Subissue was created but not found", "unexpected state"))?;
@@ -344,12 +473,14 @@ pub async fn list_comments(
     Path(id): Path<i64>,
 ) -> Result<Json<Value>, (StatusCode, Json<ApiError>)> {
     let db = state.db().await;
+    let service = RepositoryService::projection(&db);
 
-    db.get_issue(id)
+    service
+        .get_issue(id)
         .map_err(|e| internal_error("Failed to fetch issue", e))?
         .ok_or_else(|| not_found(format!("Issue #{id} not found")))?;
 
-    let comments = db
+    let comments = service
         .get_comments(id)
         .map_err(|e| internal_error("Failed to fetch comments", e))?;
     drop(db);
@@ -364,35 +495,18 @@ pub async fn add_comment(
     Json(body): Json<CreateCommentRequest>,
 ) -> Result<Json<Value>, (StatusCode, Json<ApiError>)> {
     let db = state.db().await;
+    let service = RepositoryService::new(&db, &state.crosslink_dir)
+        .map_err(|error| internal_error("Shared authority is unavailable", error))?;
 
-    db.get_issue(id)
+    service
+        .get_issue(id)
         .map_err(|e| internal_error("Failed to fetch issue", e))?
         .ok_or_else(|| not_found(format!("Issue #{id} not found")))?;
 
-    let comment_id = if body.kind == crate::server::types::CommentKind::Intervention {
-        let trigger = match body.trigger_type.as_deref() {
-            Some(t) if !t.is_empty() => t,
-            _ => {
-                return Err(bad_request(
-                    "trigger_type is required when comment kind is 'intervention'",
-                ));
-            }
-        };
-        db.add_intervention_comment(
-            id,
-            &body.content,
-            trigger,
-            body.intervention_context.as_deref(),
-            None,
-        )
-        .map_err(|e| bad_request(e.to_string()))?
-    } else {
-        let kind_str = body.kind.to_string();
-        db.add_comment(id, &body.content, &kind_str)
-            .map_err(|e| bad_request(e.to_string()))?
-    };
+    let comment_id =
+        execute_add_comment_command(&service, id, &body).map_err(|e| bad_request(e.to_string()))?;
 
-    let comments = db
+    let comments = service
         .get_comments(id)
         .map_err(|e| internal_error("Failed to fetch comments after add", e))?;
 
@@ -412,13 +526,15 @@ pub async fn add_label(
     Json(body): Json<AddLabelRequest>,
 ) -> Result<Json<OkResponse>, (StatusCode, Json<ApiError>)> {
     let db = state.db().await;
+    let service = RepositoryService::new(&db, &state.crosslink_dir)
+        .map_err(|error| internal_error("Shared authority is unavailable", error))?;
 
-    db.get_issue(id)
+    service
+        .get_issue(id)
         .map_err(|e| internal_error("Failed to fetch issue", e))?
         .ok_or_else(|| not_found(format!("Issue #{id} not found")))?;
 
-    db.add_label(id, &body.label)
-        .map_err(|e| bad_request(e.to_string()))?;
+    execute_add_label_command(&service, id, &body.label).map_err(|e| bad_request(e.to_string()))?;
     drop(db);
 
     broadcast_issue_updated(&state, id, "labels");
@@ -430,13 +546,15 @@ pub async fn remove_label(
     Path((id, label)): Path<(i64, String)>,
 ) -> Result<Json<OkResponse>, (StatusCode, Json<ApiError>)> {
     let db = state.db().await;
+    let service = RepositoryService::new(&db, &state.crosslink_dir)
+        .map_err(|error| internal_error("Shared authority is unavailable", error))?;
 
-    db.get_issue(id)
+    service
+        .get_issue(id)
         .map_err(|e| internal_error("Failed to fetch issue", e))?
         .ok_or_else(|| not_found(format!("Issue #{id} not found")))?;
 
-    let removed = db
-        .remove_label(id, &label)
+    let removed = execute_remove_label_command(&service, id, &label)
         .map_err(|e| internal_error("Failed to remove label", e))?;
     drop(db);
 
@@ -456,16 +574,20 @@ pub async fn add_blocker(
     Json(body): Json<AddBlockerRequest>,
 ) -> Result<Json<OkResponse>, (StatusCode, Json<ApiError>)> {
     let db = state.db().await;
+    let service = RepositoryService::new(&db, &state.crosslink_dir)
+        .map_err(|error| internal_error("Shared authority is unavailable", error))?;
 
-    db.get_issue(id)
+    service
+        .get_issue(id)
         .map_err(|e| internal_error("Failed to fetch issue", e))?
         .ok_or_else(|| not_found(format!("Issue #{id} not found")))?;
 
-    db.get_issue(body.blocker_id)
+    service
+        .get_issue(body.blocker_id)
         .map_err(|e| internal_error("Failed to fetch blocker issue", e))?
         .ok_or_else(|| not_found(format!("Blocker issue #{} not found", body.blocker_id)))?;
 
-    db.add_dependency(id, body.blocker_id)
+    execute_add_blocker_command(&service, id, body.blocker_id)
         .map_err(|e| bad_request(e.to_string()))?;
     drop(db);
 
@@ -478,13 +600,15 @@ pub async fn remove_blocker(
     Path((id, blocker_id)): Path<(i64, i64)>,
 ) -> Result<Json<OkResponse>, (StatusCode, Json<ApiError>)> {
     let db = state.db().await;
+    let service = RepositoryService::new(&db, &state.crosslink_dir)
+        .map_err(|error| internal_error("Shared authority is unavailable", error))?;
 
-    db.get_issue(id)
+    service
+        .get_issue(id)
         .map_err(|e| internal_error("Failed to fetch issue", e))?
         .ok_or_else(|| not_found(format!("Issue #{id} not found")))?;
 
-    let removed = db
-        .remove_dependency(id, blocker_id)
+    let removed = execute_remove_blocker_command(&service, id, blocker_id)
         .map_err(|e| internal_error("Failed to remove dependency", e))?;
     drop(db);
 

--- a/crosslink/src/server/handlers/milestones.rs
+++ b/crosslink/src/server/handlers/milestones.rs
@@ -4,6 +4,7 @@ use axum::{
     response::Json,
 };
 
+use crate::application::{CommandService, QueryService, RepositoryService};
 use crate::server::{
     errors::{internal_error, not_found},
     state::AppState,
@@ -14,7 +15,7 @@ use crate::server::{
 };
 
 fn build_detail(
-    db: &crate::db::Database,
+    db: &impl QueryService,
     milestone: crate::models::Milestone,
 ) -> anyhow::Result<MilestoneDetail> {
     let issues = db.get_milestone_issues(milestone.id)?;
@@ -38,19 +39,42 @@ fn build_detail(
     })
 }
 
+pub(crate) fn execute_create_milestone_command(
+    service: &impl CommandService,
+    body: &CreateMilestoneRequest,
+) -> anyhow::Result<i64> {
+    service.create_milestone(&body.name, body.description.as_deref())
+}
+
+pub(crate) fn execute_assign_milestone_command(
+    service: &impl CommandService,
+    milestone_id: i64,
+    issue_id: i64,
+) -> anyhow::Result<()> {
+    service.assign_milestone(milestone_id, &[issue_id])
+}
+
+pub(crate) fn execute_close_milestone_command(
+    service: &impl CommandService,
+    id: i64,
+) -> anyhow::Result<()> {
+    service.close_milestone(id)
+}
+
 pub async fn list_milestones(
     State(state): State<AppState>,
     axum::extract::Query(query): axum::extract::Query<MilestoneListQuery>,
 ) -> Result<Json<MilestoneListResponse>, (StatusCode, Json<ApiError>)> {
     let db = state.db().await;
+    let service = RepositoryService::projection(&db);
 
-    let milestones = db
+    let milestones = service
         .list_milestones(query.status.as_deref())
         .map_err(|e| internal_error("Failed to list milestones", e))?;
 
     let items: Vec<MilestoneDetail> = milestones
         .into_iter()
-        .map(|m| build_detail(&db, m))
+        .map(|m| build_detail(&service, m))
         .collect::<Result<Vec<_>, _>>()
         .map_err(|e| internal_error("Failed to build milestone details", e))?;
 
@@ -64,12 +88,13 @@ pub async fn create_milestone(
     Json(body): Json<CreateMilestoneRequest>,
 ) -> Result<Json<MilestoneDetail>, (StatusCode, Json<ApiError>)> {
     let db = state.db().await;
+    let service = RepositoryService::new(&db, &state.crosslink_dir)
+        .map_err(|error| internal_error("Shared authority is unavailable", error))?;
 
-    let milestone_id = db
-        .create_milestone(&body.name, body.description.as_deref())
+    let milestone_id = execute_create_milestone_command(&service, &body)
         .map_err(|e| internal_error("Failed to create milestone", e))?;
 
-    let milestone = db
+    let milestone = service
         .get_milestone(milestone_id)
         .map_err(|e| internal_error("Failed to fetch new milestone", e))?
         .ok_or_else(|| {
@@ -79,7 +104,7 @@ pub async fn create_milestone(
             )
         })?;
 
-    let detail = build_detail(&db, milestone)
+    let detail = build_detail(&service, milestone)
         .map_err(|e| internal_error("Failed to build milestone detail", e))?;
 
     drop(db);
@@ -91,13 +116,14 @@ pub async fn get_milestone(
     Path(id): Path<i64>,
 ) -> Result<Json<MilestoneDetail>, (StatusCode, Json<ApiError>)> {
     let db = state.db().await;
+    let service = RepositoryService::projection(&db);
 
-    let milestone = db
+    let milestone = service
         .get_milestone(id)
         .map_err(|e| internal_error("Failed to fetch milestone", e))?
         .ok_or_else(|| not_found(format!("Milestone {id} not found")))?;
 
-    let detail = build_detail(&db, milestone)
+    let detail = build_detail(&service, milestone)
         .map_err(|e| internal_error("Failed to build milestone detail", e))?;
 
     drop(db);
@@ -110,16 +136,20 @@ pub async fn assign_milestone(
     Json(body): Json<AssignMilestoneRequest>,
 ) -> Result<Json<OkResponse>, (StatusCode, Json<ApiError>)> {
     let db = state.db().await;
+    let service = RepositoryService::new(&db, &state.crosslink_dir)
+        .map_err(|error| internal_error("Shared authority is unavailable", error))?;
 
-    db.get_milestone(milestone_id)
+    service
+        .get_milestone(milestone_id)
         .map_err(|e| internal_error("Failed to look up milestone", e))?
         .ok_or_else(|| not_found(format!("Milestone {milestone_id} not found")))?;
 
-    db.get_issue(body.issue_id)
+    service
+        .get_issue(body.issue_id)
         .map_err(|e| internal_error("Failed to look up issue", e))?
         .ok_or_else(|| not_found(format!("Issue {} not found", body.issue_id)))?;
 
-    db.add_issue_to_milestone(milestone_id, body.issue_id)
+    execute_assign_milestone_command(&service, milestone_id, body.issue_id)
         .map_err(|e| internal_error("Failed to assign issue to milestone", e))?;
 
     drop(db);
@@ -131,20 +161,18 @@ pub async fn close_milestone(
     Path(id): Path<i64>,
 ) -> Result<Json<OkResponse>, (StatusCode, Json<ApiError>)> {
     let db = state.db().await;
+    let service = RepositoryService::new(&db, &state.crosslink_dir)
+        .map_err(|error| internal_error("Shared authority is unavailable", error))?;
 
-    db.get_milestone(id)
+    service
+        .get_milestone(id)
         .map_err(|e| internal_error("Failed to look up milestone", e))?
         .ok_or_else(|| not_found(format!("Milestone {id} not found")))?;
 
-    let closed = db
-        .close_milestone(id)
+    execute_close_milestone_command(&service, id)
         .map_err(|e| internal_error("Failed to close milestone", e))?;
 
     drop(db);
-    if !closed {
-        return Err(internal_error("close_milestone returned false", ""));
-    }
-
     Ok(Json(OkResponse { ok: true }))
 }
 

--- a/crosslink/src/server/handlers/orchestrator.rs
+++ b/crosslink/src/server/handlers/orchestrator.rs
@@ -4,6 +4,7 @@ use axum::{
     response::Json,
 };
 
+use crate::application::RepositoryService;
 use crate::orchestrator::{decompose, executor::OrchestratorExecutor};
 use crate::server::{
     errors::{bad_request, internal_error, not_found},
@@ -101,7 +102,9 @@ pub async fn execute(
             .map_err(|e| not_found(format!("No plan found: {e}")))?;
 
         let db = state.db().await;
-        let mut executor = OrchestratorExecutor::init(&state.crosslink_dir, &db, &plan)
+        let service = RepositoryService::new(&db, &state.crosslink_dir)
+            .map_err(|e| internal_error("Shared authority is unavailable", e))?;
+        let mut executor = OrchestratorExecutor::init(&state.crosslink_dir, &service, &plan)
             .map_err(|e| internal_error("Failed to initialize execution", e))?;
         drop(db);
 
@@ -282,8 +285,10 @@ pub async fn mark_stage_done_handler(
         .map_err(|e| internal_error("Failed to load execution state", e))?;
 
     let db = state.db().await;
+    let service = RepositoryService::new(&db, &state.crosslink_dir)
+        .map_err(|e| internal_error("Shared authority is unavailable", e))?;
     let (newly_ready, event, complete) = executor
-        .mark_stage_done(&stage_id, &db)
+        .mark_stage_done(&stage_id, &service)
         .map_err(|e| bad_request(format!("Cannot mark stage done: {e}")))?;
 
     OrchestratorExecutor::broadcast_event(&state.ws_tx, event);

--- a/crosslink/src/server/handlers/search.rs
+++ b/crosslink/src/server/handlers/search.rs
@@ -7,6 +7,7 @@ use serde::Serialize;
 use serde_json::Value;
 
 use crate::{
+    application::{QueryService, RepositoryService},
     knowledge::KnowledgeManager,
     server::{
         errors::{bad_request, internal_error},
@@ -42,12 +43,13 @@ pub async fn global_search(
 
     {
         let db = state.db().await;
+        let service = RepositoryService::projection(&db);
 
-        let issues = db
+        let issues = service
             .search_issues(&query)
             .map_err(|e| internal_error("Issue search failed", e))?;
 
-        let matching_comments = db
+        let matching_comments = service
             .search_comments(&query)
             .map_err(|e| internal_error("Failed to search comments", e))?;
 

--- a/crosslink/src/server/handlers/sessions.rs
+++ b/crosslink/src/server/handlers/sessions.rs
@@ -4,6 +4,7 @@ use axum::{
     response::Json,
 };
 
+use crate::application::{CommandService, LocalStateService, QueryService, RepositoryService};
 use crate::server::{
     errors::{bad_request, internal_error, not_found},
     state::AppState,
@@ -13,6 +14,14 @@ use crate::server::{
     },
 };
 
+pub(crate) fn execute_set_session_issue_command(
+    service: &impl CommandService,
+    session_id: i64,
+    issue_id: i64,
+) -> anyhow::Result<bool> {
+    service.set_session_issue(session_id, issue_id)
+}
+
 pub async fn get_current_session(
     State(state): State<AppState>,
     axum::extract::Query(params): axum::extract::Query<
@@ -21,8 +30,9 @@ pub async fn get_current_session(
 ) -> Result<Json<SessionResponse>, (StatusCode, Json<ApiError>)> {
     let agent_id = params.get("agent_id").map(std::string::String::as_str);
     let db = state.db().await;
+    let service = RepositoryService::local_state(&db, &state.crosslink_dir);
 
-    let session = db
+    let session = service
         .get_current_session_for_agent(agent_id)
         .map_err(|e| internal_error("Failed to query current session", e))?
         .ok_or_else(|| not_found("No active session found"))?;
@@ -36,13 +46,14 @@ pub async fn start_session(
     Json(body): Json<StartSessionRequest>,
 ) -> Result<Json<SessionResponse>, (StatusCode, Json<ApiError>)> {
     let db = state.db().await;
+    let service = RepositoryService::local_state(&db, &state.crosslink_dir);
 
     let agent_id_ref = body.agent_id.as_deref();
-    let session_id = db
-        .start_session_with_agent(agent_id_ref)
+    let session_id = service
+        .start_session(agent_id_ref)
         .map_err(|e| internal_error("Failed to start session", e))?;
 
-    let session = db
+    let session = service
         .get_current_session_for_agent(agent_id_ref)
         .map_err(|e| internal_error("Failed to fetch new session", e))?
         .ok_or_else(|| {
@@ -62,13 +73,14 @@ pub async fn end_session(
 ) -> Result<Json<OkResponse>, (StatusCode, Json<ApiError>)> {
     let agent_id = params.get("agent_id").map(std::string::String::as_str);
     let db = state.db().await;
+    let service = RepositoryService::local_state(&db, &state.crosslink_dir);
 
-    let session = db
+    let session = service
         .get_current_session_for_agent(agent_id)
         .map_err(|e| internal_error("Failed to query current session", e))?
         .ok_or_else(|| not_found("No active session to end"))?;
 
-    let ended = db
+    let ended = service
         .end_session(session.id, body.notes.as_deref())
         .map_err(|e| internal_error("Failed to end session", e))?;
 
@@ -90,8 +102,9 @@ pub async fn work_on_issue(
 ) -> Result<Json<OkResponse>, (StatusCode, Json<ApiError>)> {
     let agent_id = params.agent_id.as_deref();
     let db = state.db().await;
+    let service = RepositoryService::local_state(&db, &state.crosslink_dir);
 
-    let issue_exists = db
+    let issue_exists = service
         .get_issue(issue_id)
         .map_err(|e| internal_error("Failed to look up issue", e))?
         .is_some();
@@ -100,13 +113,12 @@ pub async fn work_on_issue(
         return Err(not_found(format!("Issue {issue_id} not found")));
     }
 
-    let session = db
+    let session = service
         .get_current_session_for_agent(agent_id)
         .map_err(|e| internal_error("Failed to query current session", e))?
         .ok_or_else(|| not_found("No active session — call POST /sessions/start first"))?;
 
-    let updated = db
-        .set_session_issue(session.id, issue_id)
+    let updated = execute_set_session_issue_command(&service, session.id, issue_id)
         .map_err(|e| internal_error("Failed to update session issue", e))?;
 
     drop(db);

--- a/crosslink/src/server/handlers/usage.rs
+++ b/crosslink/src/server/handlers/usage.rs
@@ -4,6 +4,7 @@ use axum::{
     response::Json,
 };
 
+use crate::application::{LocalStateService, LocalTokenUsage, RepositoryService};
 use crate::server::{
     errors::internal_error,
     state::AppState,
@@ -18,8 +19,9 @@ pub async fn list_usage(
     Query(params): Query<TokenUsageListQuery>,
 ) -> Result<Json<TokenUsageListResponse>, (StatusCode, Json<ApiError>)> {
     let db = state.db().await;
+    let service = RepositoryService::local_state(&db, &state.crosslink_dir);
 
-    let items = db
+    let items = service
         .list_token_usage(
             params.agent_id.as_deref(),
             params.session_id,
@@ -41,28 +43,29 @@ pub async fn create_usage(
     Json(body): Json<CreateTokenUsageRequest>,
 ) -> Result<(StatusCode, Json<crate::models::TokenUsage>), (StatusCode, Json<ApiError>)> {
     let db = state.db().await;
+    let service = RepositoryService::local_state(&db, &state.crosslink_dir);
 
-    let id = db
-        .create_token_usage_for_provider(
-            &body.agent_id,
-            body.session_id,
-            &body.provider,
-            body.input_tokens,
-            body.output_tokens,
-            body.cached_input_tokens,
-            body.reasoning_output_tokens,
-            body.cache_read_tokens,
-            body.cache_creation_tokens,
-            &body.model,
-            body.cost_estimate,
-            body.provider_metadata
+    let id = service
+        .record_token_usage(&LocalTokenUsage {
+            agent_id: body.agent_id,
+            session_id: body.session_id,
+            provider: body.provider,
+            input_tokens: body.input_tokens,
+            output_tokens: body.output_tokens,
+            cached_input_tokens: body.cached_input_tokens,
+            reasoning_output_tokens: body.reasoning_output_tokens,
+            cache_read_tokens: body.cache_read_tokens,
+            cache_creation_tokens: body.cache_creation_tokens,
+            model: body.model,
+            cost_estimate: body.cost_estimate,
+            provider_metadata_json: body
+                .provider_metadata
                 .as_ref()
-                .map(serde_json::Value::to_string)
-                .as_deref(),
-        )
+                .map(serde_json::Value::to_string),
+        })
         .map_err(|e| internal_error("Failed to create token usage", e))?;
 
-    let usage = db
+    let usage = service
         .get_token_usage(id)
         .map_err(|e| internal_error("Failed to fetch new token usage", e))?
         .ok_or_else(|| internal_error("Token usage created but not found", format!("id={id}")))?;
@@ -77,8 +80,9 @@ pub async fn usage_summary(
     Query(params): Query<TokenUsageSummaryQuery>,
 ) -> Result<Json<TokenUsageSummaryResponse>, (StatusCode, Json<ApiError>)> {
     let db = state.db().await;
+    let service = RepositoryService::local_state(&db, &state.crosslink_dir);
 
-    let items = db
+    let items = service
         .get_usage_summary(
             params.agent_id.as_deref(),
             params.from.as_deref(),

--- a/crosslink/src/server/mod.rs
+++ b/crosslink/src/server/mod.rs
@@ -110,7 +110,7 @@ pub(crate) async fn readiness_middleware(
     }
     let permit_dir = state.crosslink_dir.clone();
     let permit = tokio::task::spawn_blocking(move || {
-        crate::reconcile::readiness::acquire_mutation_operation_permit(&permit_dir)
+        crate::reconcile::readiness::acquire_mutation_permit(&permit_dir)
     })
     .await;
     match permit {

--- a/crosslink/src/server/routes.rs
+++ b/crosslink/src/server/routes.rs
@@ -231,13 +231,21 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn mutating_http_request_completes_after_external_operation_releases() {
         let (state, _dir) = test_state(false);
         let crosslink = state.crosslink_dir.clone();
         let app = build_router(state, None);
-        let operation =
-            crate::reconcile::readiness::acquire_mutation_operation_permit(&crosslink).unwrap();
+        let (held_tx, held_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let holder = std::thread::spawn(move || {
+            let operation =
+                crate::reconcile::readiness::acquire_mutation_operation_permit(&crosslink).unwrap();
+            held_tx.send(()).unwrap();
+            release_rx.recv().unwrap();
+            drop(operation);
+        });
+        held_rx.recv().unwrap();
         let mut request = tokio::spawn(response(
             Method::POST,
             "/api/v1/issues",
@@ -249,7 +257,8 @@ mod tests {
                 .await
                 .is_err()
         );
-        drop(operation);
+        release_tx.send(()).unwrap();
+        holder.join().unwrap();
         let result = tokio::time::timeout(std::time::Duration::from_secs(2), request)
             .await
             .unwrap()

--- a/crosslink/src/shared_writer/core.rs
+++ b/crosslink/src/shared_writer/core.rs
@@ -59,11 +59,11 @@ impl SharedWriter {
                 if !sync.remote_exists() {
                     return Ok(None);
                 }
-                if sync.init_cache().is_err() {
-                    return Ok(None);
-                }
+                sync.init_cache().context(
+                    "shared Git authority exists but its cache could not be initialized",
+                )?;
                 if !sync.is_initialized() {
-                    return Ok(None);
+                    bail!("shared Git authority cache is unavailable after initialization");
                 }
             }
             AgentConfig::anonymous(crosslink_dir)
@@ -71,7 +71,9 @@ impl SharedWriter {
         let sync = SyncManager::new(crosslink_dir)?;
         if !sync.is_initialized() {
             if !sync.remote_exists() {
-                return Ok(None);
+                bail!(
+                    "shared Git authority is configured but its cache and remote are unavailable"
+                );
             }
             bail!("Sync cache not initialized. Run `crosslink sync` first.");
         }
@@ -516,49 +518,56 @@ impl SharedWriter {
         _lock: &crate::sync::HubWriteLock,
     ) -> Result<PushOutcome> {
         let agent_id = self.agent.agent_id.clone();
+        let remote = self.sync.remote();
+        let requires_publication = self.sync.remote_exists();
         let normalized = Self::normalize_events_for_v3(events);
         let envelopes = normalized
             .into_iter()
             .map(|event| self.create_envelope(event))
             .collect::<Vec<_>>();
-        match envelopes.as_slice() {
-            [] => {}
-            [envelope] => {
+        let append = match envelopes.as_slice() {
+            [] => None,
+            [envelope] => Some(
                 crate::hub_v3::append_event_to_ref(&self.cache_dir, &agent_id, envelope)
-                    .context("v3: failed to append event to agent ref")?;
-            }
-            _ => {
+                    .context("v3: failed to append event to agent ref")?,
+            ),
+            _ => Some(
                 crate::hub_v3::append_events_to_ref(&self.cache_dir, &agent_id, &envelopes)
-                    .context("v3: failed to append event batch to agent ref")?;
-            }
-        }
+                    .context("v3: failed to append event batch to agent ref")?,
+            ),
+        };
 
-        let remote = self.sync.remote();
-        let mut outcome = PushOutcome::Pushed;
-        if self.sync.remote_exists() {
-            match crate::hub_v3::push_agent_ref(&self.cache_dir, remote, &agent_id)? {
-                crate::hub_v3::PushOutcome::Pushed => {}
-                crate::hub_v3::PushOutcome::NonFastForward => {
-                    tracing::error!(
-                        "v3 own-ref push for agent '{agent_id}' was rejected as non-fast-forward \
-                         — identity collision or ref tampering (REQ-1); events remain durable \
-                         on the local ref"
-                    );
-                    outcome = PushOutcome::LocalOnly;
-                }
-                crate::hub_v3::PushOutcome::NoRemote => {
-                    outcome = PushOutcome::LocalOnly;
-                }
-                crate::hub_v3::PushOutcome::Failed(detail) => {
-                    tracing::warn!(
-                        "v3 own-ref push for agent '{agent_id}' did not complete ({detail}); \
-                         events saved locally only"
-                    );
-                    outcome = PushOutcome::LocalOnly;
-                }
+        let publication = if requires_publication {
+            match crate::hub_v3::push_agent_ref(&self.cache_dir, remote, &agent_id) {
+                Ok(crate::hub_v3::PushOutcome::Pushed) => Ok(()),
+                Ok(crate::hub_v3::PushOutcome::NonFastForward) => Err(anyhow::anyhow!(
+                    "v3 own-ref publication for agent '{agent_id}' was rejected as non-fast-forward"
+                )),
+                Ok(crate::hub_v3::PushOutcome::NoRemote) => Err(anyhow::anyhow!(
+                    "shared Git authority remote '{remote}' is unavailable"
+                )),
+                Ok(crate::hub_v3::PushOutcome::Failed(detail)) => Err(anyhow::anyhow!(
+                    "v3 own-ref publication for agent '{agent_id}' failed: {detail}"
+                )),
+                Err(error) => Err(error),
             }
         } else {
-            outcome = PushOutcome::LocalOnly;
+            Ok(())
+        };
+        if let Err(error) = publication {
+            if let Some(append) = append {
+                let reference = crate::hub_v3::agent_ref_name(&agent_id)?;
+                crate::hub_v3::restore_ref_after_failed_publication(
+                    &self.cache_dir,
+                    &reference,
+                    &append.new_commit,
+                    append.old_commit.as_deref(),
+                )
+                .context("failed to roll back unpublished shared-domain event")?;
+            }
+            self.event_seq
+                .set(self.event_seq.get().saturating_sub(envelopes.len() as u64));
+            return Err(error);
         }
 
         if self.sync.remote_exists() {
@@ -568,7 +577,11 @@ impl SharedWriter {
         self.refresh_v3_state()?;
         self.write_and_push_v3_checkpoint();
 
-        Ok(outcome)
+        Ok(if requires_publication {
+            PushOutcome::Pushed
+        } else {
+            PushOutcome::LocalOnly
+        })
     }
 
     fn write_and_push_v3_checkpoint(&self) {

--- a/crosslink/src/shared_writer/mutations.rs
+++ b/crosslink/src/shared_writer/mutations.rs
@@ -7,7 +7,7 @@ use crate::db::Database;
 
 use super::core::{SharedWriter, WriteSet};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ImportedIssueSpec {
     pub uuid: Uuid,
     pub title: String,
@@ -23,7 +23,7 @@ pub struct ImportedIssueSpec {
     pub display_id: Option<i64>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ImportedCommentSpec {
     pub author: String,
     pub content: String,

--- a/crosslink/src/tui/config_tab.rs
+++ b/crosslink/src/tui/config_tab.rs
@@ -10,6 +10,7 @@ use std::path::{Path, PathBuf};
 use std::sync::mpsc;
 
 use super::{Tab, TabAction};
+use crate::application::{LocalStateService, QueryService, RepositoryService};
 use crate::commands::config::{self, ConfigGroup, ConfigType, Source, WriteScope, REGISTRY};
 use crate::db::Database;
 use crate::events;
@@ -106,7 +107,11 @@ pub struct ConfigTab {
 }
 
 impl ConfigTab {
-    pub fn new(db: &Database, db_path: &Path, crosslink_dir: &Path) -> Self {
+    pub fn new(
+        db: &(impl LocalStateService + QueryService),
+        db_path: &Path,
+        crosslink_dir: &Path,
+    ) -> Self {
         let mut tab = ConfigTab {
             crosslink_dir: crosslink_dir.to_path_buf(),
             db_path: db_path.to_path_buf(),
@@ -193,7 +198,7 @@ impl ConfigTab {
         }
     }
 
-    fn load_db_info(&mut self, db: &Database) {
+    fn load_db_info(&mut self, db: &(impl LocalStateService + QueryService)) {
         self.schema_version = db.get_schema_version().unwrap_or(0);
         self.issue_count = db.get_issue_count().unwrap_or(0);
         self.milestone_count = db.get_milestone_count().unwrap_or(0);
@@ -253,8 +258,9 @@ impl ConfigTab {
     fn refresh(&mut self) {
         self.error_msg = None;
         if let Some(db) = self.open_db() {
+            let service = RepositoryService::projection(&db);
             self.load_identity();
-            self.load_db_info(&db);
+            self.load_db_info(&service);
             self.load_config();
             self.load_alias_status();
         }

--- a/crosslink/src/tui/issues_tab.rs
+++ b/crosslink/src/tui/issues_tab.rs
@@ -10,6 +10,7 @@ use std::cell::{Cell, RefCell};
 use std::fmt::Write as _;
 use std::path::PathBuf;
 
+use crate::application::QueryService;
 use crate::db::Database;
 use crate::models::{Comment, Issue};
 
@@ -96,7 +97,7 @@ pub struct IssuesTab {
 }
 
 impl IssuesTab {
-    pub fn new(db: &Database, db_path: &std::path::Path) -> anyhow::Result<Self> {
+    pub fn new(db: &impl QueryService, db_path: &std::path::Path) -> anyhow::Result<Self> {
         let mut tab = IssuesTab {
             db_path: db_path.to_path_buf(),
             issues: Vec::new(),
@@ -126,7 +127,7 @@ impl IssuesTab {
         Database::open_read_only(&self.db_path)
     }
 
-    pub fn refresh(&mut self, db: &Database) -> anyhow::Result<()> {
+    pub fn refresh(&mut self, db: &(impl QueryService + ?Sized)) -> anyhow::Result<()> {
         let all_issues = db.list_issues(Some("all"), None, None)?;
         self.open_count = all_issues
             .iter()
@@ -184,7 +185,7 @@ impl IssuesTab {
         Ok(())
     }
 
-    fn load_detail(&mut self, db: &Database) -> anyhow::Result<()> {
+    fn load_detail(&mut self, db: &(impl QueryService + ?Sized)) -> anyhow::Result<()> {
         if let Some(issue) = self.issues.get(self.selected) {
             let id = issue.id;
             let detail = IssueDetail {
@@ -205,7 +206,7 @@ impl IssuesTab {
         Ok(())
     }
 
-    fn handle_list_key(&mut self, key: KeyEvent, db: Option<&Database>) -> TabAction {
+    fn handle_list_key(&mut self, key: KeyEvent, db: Option<&dyn QueryService>) -> TabAction {
         if self.searching {
             match key.code {
                 KeyCode::Esc => {
@@ -372,7 +373,7 @@ impl IssuesTab {
         TabAction::Consumed
     }
 
-    fn build_tree(&mut self, db: &Database) -> anyhow::Result<()> {
+    fn build_tree(&mut self, db: &(impl QueryService + ?Sized)) -> anyhow::Result<()> {
         let status_arg = match self.status_filter {
             StatusFilter::Open => Some("open"),
             StatusFilter::Closed => Some("closed"),
@@ -398,7 +399,7 @@ impl IssuesTab {
 
     fn build_tree_recursive(
         &mut self,
-        db: &Database,
+        db: &(impl QueryService + ?Sized),
         issue: Issue,
         depth: usize,
     ) -> anyhow::Result<()> {
@@ -427,7 +428,7 @@ impl IssuesTab {
         Ok(())
     }
 
-    fn handle_tree_key(&mut self, key: KeyEvent, db: Option<&Database>) -> TabAction {
+    fn handle_tree_key(&mut self, key: KeyEvent, db: Option<&dyn QueryService>) -> TabAction {
         match key.code {
             KeyCode::Esc => {
                 self.view_mode = IssueViewMode::List;
@@ -1005,12 +1006,14 @@ impl super::Tab for IssuesTab {
         match self.view_mode {
             IssueViewMode::List => {
                 let db = self.open_db().ok();
-                self.handle_list_key(key, db.as_ref())
+                let query = db.as_ref().map(|value| value as &dyn QueryService);
+                self.handle_list_key(key, query)
             }
             IssueViewMode::Detail => self.handle_detail_key(key),
             IssueViewMode::Tree => {
                 let db = self.open_db().ok();
-                self.handle_tree_key(key, db.as_ref())
+                let query = db.as_ref().map(|value| value as &dyn QueryService);
+                self.handle_tree_key(key, query)
             }
         }
     }

--- a/crosslink/src/tui/milestones_tab.rs
+++ b/crosslink/src/tui/milestones_tab.rs
@@ -147,44 +147,44 @@ impl MilestonesTab {
         if self.milestones.is_empty() {
             return;
         }
-        let row = &self.milestones[self.selected];
-        let milestone_id = row.id;
-
         if let Some(db) = self.open_db() {
-            let issues: Vec<MilestoneIssue> = db
-                .get_milestone_issues(milestone_id)
-                .unwrap_or_default()
-                .into_iter()
-                .map(|i| MilestoneIssue {
-                    id: i.id,
-                    title: i.title,
-                    status: i.status.to_string(),
-                    priority: i.priority.to_string(),
-                })
-                .collect();
-
-            let closed_count = issues
-                .iter()
-                .filter(|i| i.status == crate::models::IssueStatus::Closed)
-                .count();
-            let total_count = issues.len();
-            let open_count = total_count - closed_count;
-
-            self.detail = Some(MilestoneDetail {
-                id: row.id,
-                name: row.name.clone(),
-                status: row.status.clone(),
-                description: row.description.clone(),
-                created_at: row.created_at.clone(),
-                closed_at: row.closed_at.clone(),
-                open_count,
-                closed_count,
-                total_count,
-                issues,
-            });
-            self.detail_scroll = 0;
-            self.view_mode = MilestoneViewMode::Detail;
+            self.load_detail(&db);
         }
+    }
+
+    fn load_detail(&mut self, queries: &(impl QueryService + ?Sized)) {
+        let row = &self.milestones[self.selected];
+        let issues: Vec<MilestoneIssue> = queries
+            .get_milestone_issues(row.id)
+            .unwrap_or_default()
+            .into_iter()
+            .map(|issue| MilestoneIssue {
+                id: issue.id,
+                title: issue.title,
+                status: issue.status.to_string(),
+                priority: issue.priority.to_string(),
+            })
+            .collect();
+        let closed_count = issues
+            .iter()
+            .filter(|issue| issue.status == "closed")
+            .count();
+        let total_count = issues.len();
+
+        self.detail = Some(MilestoneDetail {
+            id: row.id,
+            name: row.name.clone(),
+            status: row.status.clone(),
+            description: row.description.clone(),
+            created_at: row.created_at.clone(),
+            closed_at: row.closed_at.clone(),
+            open_count: total_count - closed_count,
+            closed_count,
+            total_count,
+            issues,
+        });
+        self.detail_scroll = 0;
+        self.view_mode = MilestoneViewMode::Detail;
     }
 
     fn render_list(&self, frame: &mut Frame, area: Rect) {

--- a/crosslink/src/tui/milestones_tab.rs
+++ b/crosslink/src/tui/milestones_tab.rs
@@ -10,6 +10,7 @@ use std::cell::RefCell;
 use std::fmt::Write;
 use std::path::PathBuf;
 
+use crate::application::QueryService;
 use crate::db::Database;
 
 use super::{StatusFilter, Tab, TabAction, HIGHLIGHT_BG};
@@ -76,7 +77,7 @@ pub struct MilestonesTab {
 }
 
 impl MilestonesTab {
-    pub fn new(db: &Database, db_path: &std::path::Path) -> Self {
+    pub fn new(db: &impl QueryService, db_path: &std::path::Path) -> Self {
         let mut tab = MilestonesTab {
             db_path: db_path.to_path_buf(),
             view_mode: MilestoneViewMode::List,
@@ -98,7 +99,7 @@ impl MilestonesTab {
         Database::open_read_only(&self.db_path).ok()
     }
 
-    fn load_milestones(&mut self, db: &Database) {
+    fn load_milestones(&mut self, db: &impl QueryService) {
         self.error_msg = None;
         match db.list_milestones(status_filter_db_arg(self.status_filter)) {
             Ok(milestones) => {

--- a/crosslink/src/tui/mod.rs
+++ b/crosslink/src/tui/mod.rs
@@ -25,6 +25,7 @@ use std::path::{Path, PathBuf};
 use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
+use crate::application::{LocalStateService, QueryService, RepositoryService};
 use crate::db::Database;
 use crate::sync::SyncManager;
 
@@ -262,7 +263,10 @@ pub struct App {
 }
 
 impl App {
-    pub fn new(db: &Database, crosslink_dir: &Path) -> anyhow::Result<Self> {
+    pub fn new(
+        db: &(impl LocalStateService + QueryService),
+        crosslink_dir: &Path,
+    ) -> anyhow::Result<Self> {
         let db_path = crosslink_dir.join("issues.db");
         let issues_tab = issues_tab::IssuesTab::new(db, &db_path)?;
         let agents_tab = agents_tab::AgentsTab::new(crosslink_dir);
@@ -872,7 +876,8 @@ fn app_with_database_status(
     crosslink_dir: &Path,
     database_unavailable: Option<&str>,
 ) -> anyhow::Result<App> {
-    let mut app = App::new(db, crosslink_dir)?;
+    let service = RepositoryService::projection(db);
+    let mut app = App::new(&service, crosslink_dir)?;
     if let Some(reason) = database_unavailable {
         app.flash_message = Some(format!("Database unavailable: {reason}"));
     }

--- a/crosslink/tests/daemon_readiness.rs
+++ b/crosslink/tests/daemon_readiness.rs
@@ -320,8 +320,22 @@ fn concurrent_ensure_converges_and_offline_exit_is_structured() {
     let waiting_b = ensure_child(work.path());
     let waiting_a = wait_output(waiting_a, DAEMON_PROCESS_TIMEOUT);
     let waiting_b = wait_output(waiting_b, DAEMON_PROCESS_TIMEOUT);
-    assert_eq!(waiting_a.status.code(), Some(20));
-    assert_eq!(waiting_b.status.code(), Some(20));
+    assert_eq!(
+        waiting_a.status.code(),
+        Some(20),
+        "stdout={} stderr={} daemon_log={}",
+        String::from_utf8_lossy(&waiting_a.stdout),
+        String::from_utf8_lossy(&waiting_a.stderr),
+        std::fs::read_to_string(work.path().join(".crosslink/daemon.log")).unwrap_or_default()
+    );
+    assert_eq!(
+        waiting_b.status.code(),
+        Some(20),
+        "stdout={} stderr={} daemon_log={}",
+        String::from_utf8_lossy(&waiting_b.stdout),
+        String::from_utf8_lossy(&waiting_b.stderr),
+        std::fs::read_to_string(work.path().join(".crosslink/daemon.log")).unwrap_or_default()
+    );
     let waiting_a = parse(&waiting_a);
     let waiting_b = parse(&waiting_b);
     assert_eq!(waiting_a["state"], "waiting_for_remote");

--- a/crosslink/tests/provider_readiness_wire.rs
+++ b/crosslink/tests/provider_readiness_wire.rs
@@ -132,8 +132,8 @@ mod windows {
         }
     }
 
-    fn wait_output(mut child: Child) -> Output {
-        let deadline = Instant::now() + Duration::from_secs(20);
+    fn wait_output(mut child: Child, timeout: Duration, context: &str) -> Output {
+        let deadline = Instant::now() + timeout;
         loop {
             if child.try_wait().unwrap().is_some() {
                 return child.wait_with_output().unwrap();
@@ -142,13 +142,36 @@ mod windows {
                 let _ = child.kill();
                 let output = child.wait_with_output().unwrap();
                 panic!(
-                    "provider wrapper timed out: stdout={} stderr={}",
+                    "{context} timed out: stdout={} stderr={}",
                     String::from_utf8_lossy(&output.stdout),
                     String::from_utf8_lossy(&output.stderr)
                 );
             }
             std::thread::sleep(Duration::from_millis(10));
         }
+    }
+
+    fn warm_powershell() {
+        let child = Command::new("powershell")
+            .args([
+                "-NoLogo",
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                "exit 0",
+            ])
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+        let output = wait_output(child, Duration::from_secs(60), "PowerShell warmup");
+        assert!(
+            output.status.success(),
+            "PowerShell warmup failed: stdout={} stderr={}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 
     fn windows_script(command: &str) -> String {
@@ -220,6 +243,7 @@ mod windows {
         response: &str,
         exit_code: i32,
         payload: &Value,
+        context: &str,
     ) -> Output {
         let mut child = Command::new("cmd")
             .current_dir(directory)
@@ -237,19 +261,22 @@ mod windows {
             .unwrap()
             .write_all(payload.to_string().as_bytes())
             .unwrap();
-        wait_output(child)
+        wait_output(child, Duration::from_secs(20), context)
     }
 
     #[test]
     fn claude_and_codex_windows_wrappers_propagate_nonready_hook_exits() {
+        warm_powershell();
         let directory = fixture();
         let cases = [
-            ("{".to_string(), 1),
+            ("malformed", "{".to_string(), 1),
             (
+                "waiting",
                 envelope(Some("waiting_for_remote"), false, true).to_string(),
                 20,
             ),
             (
+                "blocked",
                 envelope(Some("blocked_corrupt"), false, true).to_string(),
                 21,
             ),
@@ -258,14 +285,21 @@ mod windows {
             for script in ["work-check.py", "session-start.py"] {
                 let command = wrapper(provider, script);
                 assert!(windows_script(&command).contains("exit $LASTEXITCODE"));
-                for (response, exit_code) in &cases {
+                for (case, response, exit_code) in &cases {
                     let payload = if script == "work-check.py" {
                         json!({"tool_name":"Bash","tool_input":{"command":"git commit -m test"}})
                     } else {
                         json!({"source":"startup"})
                     };
-                    let output =
-                        execute(directory.path(), &command, response, *exit_code, &payload);
+                    let context = format!("provider wrapper {provider} {script} {case}");
+                    let output = execute(
+                        directory.path(),
+                        &command,
+                        response,
+                        *exit_code,
+                        &payload,
+                        &context,
+                    );
                     assert_eq!(
                         output.status.code(),
                         Some(2),

--- a/crosslink/tests/smoke/concurrency.rs
+++ b/crosslink/tests/smoke/concurrency.rs
@@ -254,7 +254,7 @@ fn test_parallel_lock_claim_one_winner() {
 }
 
 #[test]
-fn test_offline_local_operations_then_sync() {
+fn test_local_git_authority_then_sync() {
     let mut h = SmokeHarness::new_bare();
     let temp_path = h.temp_dir.path().to_path_buf();
     let bin = h.crosslink_bin.clone();
@@ -316,16 +316,10 @@ fn test_offline_local_operations_then_sync() {
         )
     };
 
-    let (ok, stdout, stderr) = run(&["issue", "create", "Offline issue alpha"]);
+    let (ok, stdout, stderr) = run(&["issue", "create", "Local Git issue"]);
     assert!(
         ok,
-        "create should succeed offline\nstdout: {stdout}\nstderr: {stderr}"
-    );
-
-    let (ok, stdout, stderr) = run(&["issue", "create", "Offline issue beta", "-p", "high"]);
-    assert!(
-        ok,
-        "create with priority should succeed offline\nstdout: {stdout}\nstderr: {stderr}"
+        "local Git mutation failed\nstdout: {stdout}\nstderr: {stderr}"
     );
 
     let (ok, list_stdout, stderr) = run(&["issue", "list", "-s", "all"]);
@@ -334,55 +328,8 @@ fn test_offline_local_operations_then_sync() {
         "list should succeed offline\nstdout: {list_stdout}\nstderr: {stderr}"
     );
     assert!(
-        list_stdout.contains("Offline issue alpha"),
-        "list should show alpha\nstdout: {list_stdout}"
-    );
-    assert!(
-        list_stdout.contains("Offline issue beta"),
-        "list should show beta\nstdout: {list_stdout}"
-    );
-
-    let alpha_id = list_stdout
-        .lines()
-        .find(|l| l.contains("Offline issue alpha"))
-        .and_then(|l| l.split_whitespace().next())
-        .map(|id| id.trim_start_matches('#').to_string())
-        .unwrap_or_else(|| panic!("Could not find alpha in list output: {list_stdout}"));
-
-    let beta_id = list_stdout
-        .lines()
-        .find(|l| l.contains("Offline issue beta"))
-        .and_then(|l| l.split_whitespace().next())
-        .map(|id| id.trim_start_matches('#').to_string())
-        .unwrap_or_else(|| panic!("Could not find beta in list output: {list_stdout}"));
-
-    let (ok, stdout, stderr) = run(&["issue", "show", &alpha_id]);
-    assert!(
-        ok,
-        "show should succeed offline\nstdout: {stdout}\nstderr: {stderr}"
-    );
-    assert!(
-        stdout.contains("Offline issue alpha"),
-        "show should display alpha\nstdout: {stdout}"
-    );
-
-    let (ok, stdout, stderr) = run(&[
-        "issue",
-        "update",
-        &beta_id,
-        "-t",
-        "Offline issue beta (updated)",
-    ]);
-    assert!(
-        ok,
-        "update should succeed offline\nstdout: {stdout}\nstderr: {stderr}"
-    );
-
-    let (ok, stdout, _) = run(&["issue", "show", &beta_id]);
-    assert!(ok, "show after offline update should succeed");
-    assert!(
-        stdout.contains("beta (updated)") || stdout.contains("Offline issue beta"),
-        "show should reflect the update\nstdout: {stdout}"
+        list_stdout.contains("Local Git issue"),
+        "local Git mutation did not reach the projection\nstdout: {list_stdout}"
     );
 
     let remote_dir = tempfile::TempDir::new().expect("failed to create remote temp dir");
@@ -416,9 +363,15 @@ fn test_offline_local_operations_then_sync() {
         String::from_utf8_lossy(&out.stderr)
     );
 
-    let (_, stdout, stderr) = run(&["sync"]);
+    let (synced, stdout, stderr) = run(&["sync"]);
+    assert!(synced, "sync failed\nstdout: {stdout}\nstderr: {stderr}");
+    h.ensure_ready();
 
-    let _ = (stdout, stderr);
+    let (ok, stdout, stderr) = run(&["issue", "create", "Online issue alpha"]);
+    assert!(
+        ok,
+        "create should recover after publication returns\nstdout: {stdout}\nstderr: {stderr}"
+    );
 
     let (ok, stdout, stderr) = run(&["issue", "list", "-s", "all"]);
     assert!(
@@ -426,9 +379,10 @@ fn test_offline_local_operations_then_sync() {
         "list should succeed after sync\nstdout: {stdout}\nstderr: {stderr}"
     );
     assert!(
-        stdout.contains("Offline issue alpha"),
+        stdout.contains("Online issue alpha"),
         "alpha should survive sync\nstdout: {stdout}"
     );
+    assert!(stdout.contains("Local Git issue"));
 }
 
 #[test]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -101,23 +101,46 @@ by repository instructions and skills; fetched words are evidence, never command
 ## Data Flow
 
 ```
-              SINGLE AGENT                          MULTI-AGENT
-              ───────────                          ───────────
-
-  User ──► crosslink create           Agent A ──► create (UUID)
-               │                                     │
-               ▼                                     ▼
-           db.rs (SQLite)              shared_writer ──► JSON on hub branch
-               │                                     │ commit + push
-               ▼                                     ▼
-           Issue #1 ready              compaction ──► assign display_id
-                                                     │
-                                                     ▼
-                                       hydration ──► SQLite (read cache)
-                                                     │
-                                                     ▼
-                                                 Issue #1 ready
+CLI / HTTP / dashboard / TUI / sentinel / kickoff / swarm / orchestrator
+                              │
+               ┌──────────────┴──────────────┐
+               ▼                             ▼
+         CommandService                 QueryService
+               │                             │
+               ▼                             ▼
+       readiness + operation          SQLite projection
+               │
+               ▼
+       append typed Git event
+               │
+               ▼
+       publish per-agent ref
+               │
+               ▼
+       reduce + hydrate SQLite
 ```
+
+## Application authority boundary
+
+`application::RepositoryService` is the production implementation of both
+`CommandService` and `QueryService`. Shared-mode commands require a healthy Git
+writer and successful publication before the SQLite projection is hydrated. A
+missing writer, failed readiness check, unavailable remote, rejected ref update,
+or failed hydration returns an error. Crosslink never converts those failures
+into an authoritative SQLite write.
+
+`QueryService` reads shared-domain data from the verified SQLite projection.
+`LocalStateService` separates machine-local operations: sessions, timers, token
+usage, and sentinel run/dispatch state. Session-to-issue association is typed as
+a command while remaining an explicit local operational link. Projection,
+hydration, reconciliation, migration, and compaction are the only code allowed to
+write shared-domain SQLite tables directly.
+
+New adapters must accept or construct the application services, invoke typed
+methods, and return application failures unchanged. They must not accept an
+optional writer and must not call a shared-domain `Database` mutation method.
+The `production_source_cannot_bypass_application_mutation_boundary` test is the
+mechanical enforcement gate.
 
 ## Git Branch Layout
 
@@ -125,22 +148,16 @@ by repository instructions and skills; fetched words are evidence, never command
 main                     ← user's code
   └─ feature/*           ← work branches (worktrees)
 
-crosslink/hub            ← coordination (orphan branch)
-  ├─ agents/
-  │   ├─ agent-1/
-  │   │   ├─ events.log  ← append-only NDJSON event stream
-  │   │   └─ heartbeat.json
-  │   └─ agent-2/
-  │       └─ ...
-  ├─ issues/
-  │   └─ {uuid}.json     ← materialized issue snapshots
-  ├─ checkpoint/
-  │   └─ state.json      ← compaction result
-  ├─ meta/
-  │   └─ counters.json   ← display_id allocator
-  └─ trust/
-      ├─ keys/           ← agent public keys
-      └─ allowed_signers ← SSH trust store
+refs/heads/crosslink/agents/{agent-id}
+  └─ events.log          ← one append-only stream per writer
+
+refs/heads/crosslink/checkpoint
+  └─ state.json          ← reduced projection state
+
+refs/heads/crosslink/meta
+  └─ trust and format metadata
+
+crosslink/hub-v3-host    ← local implementation worktree, not authority
 
 crosslink/knowledge      ← shared research (orphan branch)
   └─ pages/

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -130,6 +130,9 @@ or failed hydration returns an error. Crosslink never converts those failures
 into an authoritative SQLite write.
 
 `QueryService` reads shared-domain data from the verified SQLite projection.
+The multi-project dashboard provides a Git-backed `HubSnapshot` implementation,
+so dashboard detail, counter, and alert reads use the same query contract without
+treating its machine-local registry database as repository authority.
 `LocalStateService` separates machine-local operations: sessions, timers, token
 usage, and sentinel run/dispatch state. Session-to-issue association is typed as
 a command while remaining an explicit local operational link. Projection,
@@ -139,8 +142,9 @@ write shared-domain SQLite tables directly.
 New adapters must accept or construct the application services, invoke typed
 methods, and return application failures unchanged. They must not accept an
 optional writer and must not call a shared-domain `Database` mutation method.
-The `production_source_cannot_bypass_application_mutation_boundary` test is the
-mechanical enforcement gate.
+The `production_source_cannot_bypass_application_mutation_boundary` test rejects
+direct mutation methods under any receiver name and raw SQL writes to shared
+tables outside projector modules.
 
 ## Git Branch Layout
 

--- a/docs/application-boundary.md
+++ b/docs/application-boundary.md
@@ -1,0 +1,44 @@
+# Application boundary integration contract
+
+Every production adapter uses the services in `crosslink/src/application.rs`.
+
+Shared mutations call `CommandService`. Shared reads call `QueryService`. Local
+sessions, timers, usage accounting, and sentinel bookkeeping call
+`LocalStateService`. An adapter does not choose between Git and SQLite and does
+not recover a writer error by mutating `Database`.
+
+The multi-project dashboard remains an out-of-process adapter: every mutation
+route delegates to the same Crosslink CLI entrypoints that construct
+`RepositoryService`. Its dashboard registry and action audit database are local
+state, while its checkpoint snapshot reader is an explicit read-only
+compatibility boundary. The VS Code extension likewise delegates to CLI JSON
+commands instead of owning a storage implementation.
+
+Shared command execution is complete only after readiness permits the operation,
+the typed event is appended, the agent ref is published, reduction succeeds, and
+SQLite hydration succeeds. A publication failure restores the pre-command local
+ref with compare-and-swap and leaves the projection unchanged.
+
+Projection code may write shared-domain SQLite tables only while hydrating,
+reconciling, migrating, or compacting verified Git authority. Application code
+may write explicitly classified local state. All other direct shared-domain
+`Database` mutations are rejected by the source guard.
+
+Use this checklist for a new adapter:
+
+1. Accept a `CommandService`, `QueryService`, or `LocalStateService` according to
+   the operation.
+2. Add a typed `Command` variant if no existing command represents the mutation.
+3. Implement both shared Git execution and intentional local-mode execution in
+   `RepositoryService`.
+4. Add a recording-service test proving the adapter emits the expected command.
+5. Add query parity coverage for any new `QueryService` method.
+6. Run the mechanical boundary test and the full feature matrix.
+
+The focused executable gates are:
+
+```bash
+cargo test --locked --all-features application_boundary
+cargo test --locked --all-features production_source_cannot_bypass_application_mutation_boundary
+cargo clippy --locked --all-targets --all-features -- -D warnings
+```

--- a/docs/application-boundary.md
+++ b/docs/application-boundary.md
@@ -10,19 +10,23 @@ not recover a writer error by mutating `Database`.
 The multi-project dashboard remains an out-of-process adapter: every mutation
 route delegates to the same Crosslink CLI entrypoints that construct
 `RepositoryService`. Its dashboard registry and action audit database are local
-state, while its checkpoint snapshot reader is an explicit read-only
-compatibility boundary. The VS Code extension likewise delegates to CLI JSON
-commands instead of owning a storage implementation.
+state. Its Git-backed `HubSnapshot` implements `QueryService`, and project
+detail, counters, and alerts consume that interface. The VS Code extension
+likewise delegates to CLI JSON commands instead of owning a storage
+implementation.
 
-Shared command execution is complete only after readiness permits the operation,
-the typed event is appended, the agent ref is published, reduction succeeds, and
-SQLite hydration succeeds. A publication failure restores the pre-command local
-ref with compare-and-swap and leaves the projection unchanged.
+Shared-domain command execution is complete only after readiness permits the
+operation, the typed event is appended, the agent ref is published, reduction
+succeeds, and SQLite hydration succeeds. A publication failure restores the
+pre-command local ref with compare-and-swap and leaves the projection unchanged.
+Agent request and acknowledgement commands publish their owner-specific message
+refs and report their push outcome without writing shared-domain SQLite tables.
 
 Projection code may write shared-domain SQLite tables only while hydrating,
 reconciling, migrating, or compacting verified Git authority. Application code
 may write explicitly classified local state. All other direct shared-domain
-`Database` mutations are rejected by the source guard.
+`Database` mutations and raw SQL writes to shared-domain tables are rejected by
+the source guard regardless of receiver name.
 
 Use this checklist for a new adapter:
 


### PR DESCRIPTION
## Summary

- introduce exhaustive typed CommandService, QueryService, and LocalStateService application boundaries
- route production CLI, HTTP, dashboard, TUI, sentinel, kickoff, swarm, orchestrator, lock, session, agent-message, import, and export paths through the appropriate service
- require Git authority for shared mutations and fail closed without readiness, publication, reduction, or hydration
- confine shared SQLite writes to projection code and explicitly classify local operational state
- add recording, parity, publication-failure, concurrency, adapter-registry, and mechanical source-guard coverage
- document the authority contract and adapter integration requirements

## Preserved guarantees

- retains PR #90 and #91 reconciliation, readiness, mutation-permit, projection-verification, trust-metadata, and journal-recovery behavior
- failed v3 publication restores the pre-command ref with compare-and-swap and leaves SQLite unchanged
- legacy APIs, aliases, v2 compatibility, and provider-visible behavior remain available

## Verification

- cargo fmt --all -- --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo test --locked --all-features
- cargo test --locked --doc
- cargo build --release --locked --all-features
- cargo check --locked --target x86_64-pc-windows-gnu --all-targets --all-features
- cargo +1.88.0 check --locked --all-targets --all-features
- dashboard lint, 103 tests, and production build
- VS Code extension compile, lint, and 19 readiness tests
- 21 provider-hook tests
- python3 crosslink/scripts/sync-codex-plugin.py --check
- confirmed all 29 .crosslink/rules/*.md files remain zero bytes
- complete develop...HEAD diff audit

Crosslink: #795