### PR TITLE
feat(checkpoint): add per-agent causal frontiers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,8 @@ jobs:
             "commands::kickoff::",
             "dashboard::pty::tests",
             "git_compat::",
-            "orchestrator::decompose::"
+            "orchestrator::decompose::",
+            "phase2_causality"
           )
           foreach ($filter in $filters) {
             cargo test --bin crosslink --verbose $filter -- --skip proptest --skip prop_

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,7 @@ jobs:
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Run integration tests
-        if: matrix.os != 'windows-latest'
+        if: matrix.os == 'ubuntu-latest'
         run: cargo test --test cli_integration --verbose
 
       - name: Run bounded repository readiness integration tests
@@ -213,6 +213,84 @@ jobs:
 
       - name: Run cross-platform provider readiness and Windows wrapper tests
         run: cargo test --test provider_readiness_wire --verbose
+
+
+  macos-cli:
+    needs: lint
+    name: macOS CLI (${{ matrix.shard }})
+    runs-on: macos-latest
+    timeout-minutes: 20
+    env:
+      CLI_TEST_FILTERS: >-
+        test_a test_b test_c test_d test_e test_f test_g test_h test_i test_j test_k test_l
+        test_m test_n test_o test_p test_q test_r test_search test_security test_sentinel
+        test_session test_show test_special test_sql test_start test_stop test_stress_deep_nesting
+        test_stress_many_issues test_stress_rapid_operations test_stress_very_long_description
+        test_stress_very_long_title test_subissue test_t test_u test_v test_w test_x test_y test_z
+    defaults:
+      run:
+        working-directory: crosslink
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard: a-l
+            filters: test_a test_b test_c test_d test_e test_f test_g test_h test_i test_j test_k test_l
+          - shard: m-z
+            filters: test_m test_n test_o test_p test_q test_r test_search test_security test_sentinel test_session test_show test_special test_sql test_start test_stop test_subissue test_t test_u test_v test_w test_x test_y test_z
+          - shard: stress
+            filters: test_stress_deep_nesting test_stress_many_issues test_stress_rapid_operations test_stress_very_long_description test_stress_very_long_title
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            crosslink/target/
+          key: ${{ runner.os }}-cargo-test-${{ hashFiles('crosslink/Cargo.lock') }}
+
+      - name: Verify complete shard partition
+        shell: bash
+        run: |
+          listed="$(cargo test --test cli_integration -- --list)"
+          tests="$(printf '%s\n' "$listed" | sed -n 's/: test$//p')"
+          test_count=0
+          invalid=""
+          for test_name in $tests; do
+            test_count=$((test_count + 1))
+            match_count=0
+            matches=""
+            for filter in $CLI_TEST_FILTERS; do
+              case "$test_name" in
+                *"$filter"*)
+                  match_count=$((match_count + 1))
+                  matches="$matches $filter"
+                  ;;
+              esac
+            done
+            if [ "$match_count" -ne 1 ]; then
+              invalid="$invalid $test_name=$matches;"
+            fi
+          done
+          if [ "$test_count" -eq 0 ] || [ -n "$invalid" ]; then
+            echo "CLI test partition is incomplete or overlapping:$invalid" >&2
+            exit 1
+          fi
+
+      - name: Run CLI shard
+        shell: bash
+        run: |
+          for filter in ${{ matrix.filters }}; do
+            cargo test --test cli_integration --verbose "$filter"
+          done
 
 
   windows-cli:
@@ -393,7 +471,7 @@ jobs:
 
 
   proptest:
-    needs: [test, windows-cli, windows-readiness]
+    needs: [test, macos-cli, windows-cli, windows-readiness]
     name: Property Tests
     runs-on: ubuntu-latest
     if: startsWith(github.head_ref, 'release/') || (github.event_name == 'pull_request' && github.base_ref == 'main')
@@ -426,7 +504,7 @@ jobs:
 
 
   fuzz:
-    needs: [test, windows-cli, windows-readiness]
+    needs: [test, macos-cli, windows-cli, windows-readiness]
     name: Fuzz Tests
     runs-on: ubuntu-latest
     if: startsWith(github.head_ref, 'release/') || (github.event_name == 'pull_request' && github.base_ref == 'main')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,8 +225,12 @@ jobs:
         test_a test_b test_c test_d test_e test_f test_g test_h test_i test_j test_k test_l
         test_m test_n test_o test_p test_q test_r test_search test_security test_sentinel
         test_session test_show test_special test_sql test_start test_stop test_stress_deep_nesting
-        test_stress_many_issues test_stress_rapid_operations test_stress_very_long_description
-        test_stress_very_long_title test_subissue
+        test_stress_many_issues_000_019 test_stress_many_issues_020_039
+        test_stress_many_issues_040_059 test_stress_many_issues_060_079
+        test_stress_many_issues_080_099 test_stress_rapid_operations_000_003
+        test_stress_rapid_operations_004_007 test_stress_rapid_operations_008_011
+        test_stress_rapid_operations_012_015 test_stress_rapid_operations_016_019
+        test_stress_very_long_description test_stress_very_long_title test_subissue
         test_t test_u test_v test_w test_x test_y test_z
     defaults:
       run:
@@ -243,10 +247,30 @@ jobs:
             prefixes: test_m test_n test_o test_p test_q test_r
           - shard: s-core
             prefixes: test_search test_security test_sentinel test_session test_show test_special test_sql test_start test_stop
-          - shard: s-stress-create
-            prefixes: test_stress_many_issues test_stress_very_long_description test_stress_very_long_title
-          - shard: s-stress-rapid
-            prefixes: test_stress_rapid_operations
+          - shard: s-stress-many-000-019
+            prefixes: test_stress_many_issues_000_019
+          - shard: s-stress-many-020-039
+            prefixes: test_stress_many_issues_020_039
+          - shard: s-stress-many-040-059
+            prefixes: test_stress_many_issues_040_059
+          - shard: s-stress-many-060-079
+            prefixes: test_stress_many_issues_060_079
+          - shard: s-stress-many-080-099
+            prefixes: test_stress_many_issues_080_099
+          - shard: s-stress-rapid-000-003
+            prefixes: test_stress_rapid_operations_000_003
+          - shard: s-stress-rapid-004-007
+            prefixes: test_stress_rapid_operations_004_007
+          - shard: s-stress-rapid-008-011
+            prefixes: test_stress_rapid_operations_008_011
+          - shard: s-stress-rapid-012-015
+            prefixes: test_stress_rapid_operations_012_015
+          - shard: s-stress-rapid-016-019
+            prefixes: test_stress_rapid_operations_016_019
+          - shard: s-stress-long-description
+            prefixes: test_stress_very_long_description
+          - shard: s-stress-long-title
+            prefixes: test_stress_very_long_title
           - shard: s-stress-tree
             prefixes: test_stress_deep_nesting test_subissue
           - shard: t-z

--- a/crosslink/src/checkpoint.rs
+++ b/crosslink/src/checkpoint.rs
@@ -1,14 +1,55 @@
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 use uuid::Uuid;
 
-use crate::events::OrderingKey;
+use crate::events::{EventEnvelope, OrderingKey};
+
+pub const CHECKPOINT_SCHEMA_VERSION: u32 = 2;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CausalFrontier {
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub agents: BTreeMap<String, AgentFrontier>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentFrontier {
+    pub sequence: u64,
+    pub tip_oid: String,
+    pub prefix_sha256: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FrontierRelation {
+    Equal,
+    Dominates,
+    Dominated,
+    Concurrent,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub(crate) enum WatermarkCompatibility {
+    Legacy(OrderingKey),
+    Unsupported { unsupported_checkpoint_schema: u32 },
+}
+
+const fn legacy_schema_version() -> u32 {
+    1
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CheckpointState {
+    #[serde(default = "legacy_schema_version")]
+    pub checkpoint_schema_version: u32,
+
+    #[serde(default, skip_serializing_if = "CausalFrontier::is_empty")]
+    pub frontier: CausalFrontier,
+
     pub next_display_id: i64,
     pub next_comment_id: i64,
     pub display_id_map: BTreeMap<Uuid, i64>,
@@ -33,8 +74,8 @@ pub struct CheckpointState {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub unsigned_event_warnings: Vec<UnsignedEventWarning>,
 
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub watermark: Option<OrderingKey>,
+    #[serde(default, rename = "watermark", skip_serializing_if = "Option::is_none")]
+    pub(crate) legacy_watermark: Option<WatermarkCompatibility>,
 }
 
 const fn default_next_id() -> i64 {
@@ -44,6 +85,8 @@ const fn default_next_id() -> i64 {
 impl Default for CheckpointState {
     fn default() -> Self {
         Self {
+            checkpoint_schema_version: CHECKPOINT_SCHEMA_VERSION,
+            frontier: CausalFrontier::default(),
             next_display_id: 1,
             next_comment_id: 1,
             display_id_map: BTreeMap::new(),
@@ -56,9 +99,50 @@ impl Default for CheckpointState {
             skew_warnings: Vec::new(),
             compaction_lease: None,
             unsigned_event_warnings: Vec::new(),
-            watermark: None,
+            legacy_watermark: Some(WatermarkCompatibility::Unsupported {
+                unsupported_checkpoint_schema: CHECKPOINT_SCHEMA_VERSION,
+            }),
         }
     }
+}
+
+impl CausalFrontier {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.agents.is_empty()
+    }
+
+    #[must_use]
+    pub fn relation(&self, other: &Self) -> FrontierRelation {
+        let mut greater = false;
+        let mut less = false;
+        let ids: BTreeSet<_> = self.agents.keys().chain(other.agents.keys()).collect();
+        for id in ids {
+            let left = self.agents.get(id).map_or(0, |entry| entry.sequence);
+            let right = other.agents.get(id).map_or(0, |entry| entry.sequence);
+            greater |= left > right;
+            less |= left < right;
+        }
+        match (greater, less) {
+            (false, false) => FrontierRelation::Equal,
+            (true, false) => FrontierRelation::Dominates,
+            (false, true) => FrontierRelation::Dominated,
+            (true, true) => FrontierRelation::Concurrent,
+        }
+    }
+}
+
+pub fn event_prefix_sha256(events: &[EventEnvelope], sequence: u64) -> Result<String> {
+    let mut hasher = Sha256::new();
+    for event in events
+        .iter()
+        .take_while(|event| event.agent_seq <= sequence)
+    {
+        let bytes = serde_json::to_vec(event).context("failed to hash event envelope")?;
+        hasher.update((bytes.len() as u64).to_be_bytes());
+        hasher.update(bytes);
+    }
+    Ok(hex::encode(hasher.finalize()))
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -180,7 +264,60 @@ pub struct UnsignedEventWarning {
 impl CheckpointState {
     #[allow(dead_code)]
     pub fn from_slice(bytes: &[u8]) -> Result<Self> {
-        serde_json::from_slice(bytes).context("Failed to parse checkpoint state from bytes")
+        let state: Self =
+            serde_json::from_slice(bytes).context("Failed to parse checkpoint state from bytes")?;
+        state.validate_schema()?;
+        Ok(state)
+    }
+
+    pub fn validate_schema(&self) -> Result<()> {
+        match self.checkpoint_schema_version {
+            1 => match &self.legacy_watermark {
+                None | Some(WatermarkCompatibility::Legacy(_)) => Ok(()),
+                Some(WatermarkCompatibility::Unsupported { .. }) => {
+                    anyhow::bail!("legacy checkpoint contains a causal schema guard")
+                }
+            },
+            CHECKPOINT_SCHEMA_VERSION => match &self.legacy_watermark {
+                Some(WatermarkCompatibility::Unsupported {
+                    unsupported_checkpoint_schema,
+                }) if *unsupported_checkpoint_schema == CHECKPOINT_SCHEMA_VERSION => Ok(()),
+                _ => anyhow::bail!(
+                    "checkpoint schema {CHECKPOINT_SCHEMA_VERSION} is missing its fail-closed compatibility guard"
+                ),
+            },
+            version if version > CHECKPOINT_SCHEMA_VERSION => anyhow::bail!(
+                "unsupported checkpoint schema version {version}; this binary supports through version {CHECKPOINT_SCHEMA_VERSION}"
+            ),
+            version => anyhow::bail!("unsupported checkpoint schema version {version}"),
+        }
+    }
+
+    #[must_use]
+    pub const fn is_legacy(&self) -> bool {
+        self.checkpoint_schema_version == 1
+    }
+
+    #[must_use]
+    pub const fn legacy_watermark(&self) -> Option<&OrderingKey> {
+        match &self.legacy_watermark {
+            Some(WatermarkCompatibility::Legacy(watermark)) => Some(watermark),
+            None | Some(WatermarkCompatibility::Unsupported { .. }) => None,
+        }
+    }
+
+    pub fn activate_causal(&mut self, frontier: CausalFrontier) {
+        self.checkpoint_schema_version = CHECKPOINT_SCHEMA_VERSION;
+        self.frontier = frontier;
+        self.legacy_watermark = Some(WatermarkCompatibility::Unsupported {
+            unsupported_checkpoint_schema: CHECKPOINT_SCHEMA_VERSION,
+        });
+    }
+
+    pub(crate) fn activate_legacy(&mut self, watermark: Option<OrderingKey>) {
+        self.checkpoint_schema_version = 1;
+        self.frontier = CausalFrontier::default();
+        self.legacy_watermark = watermark.map(WatermarkCompatibility::Legacy);
     }
 }
 
@@ -198,11 +335,12 @@ pub fn read_checkpoint(cache_dir: &Path) -> Result<CheckpointState> {
     }
     let content = std::fs::read_to_string(&path)
         .with_context(|| format!("Failed to read checkpoint: {}", path.display()))?;
-    serde_json::from_str(&content)
+    CheckpointState::from_slice(content.as_bytes())
         .with_context(|| format!("Failed to parse checkpoint: {}", path.display()))
 }
 
 pub fn write_checkpoint(cache_dir: &Path, state: &CheckpointState) -> Result<()> {
+    state.validate_schema()?;
     let dir = checkpoint_dir(cache_dir);
     std::fs::create_dir_all(&dir)
         .with_context(|| format!("Failed to create checkpoint dir: {}", dir.display()))?;
@@ -212,9 +350,13 @@ pub fn write_checkpoint(cache_dir: &Path, state: &CheckpointState) -> Result<()>
 }
 
 pub fn read_watermark(cache_dir: &Path) -> Result<Option<OrderingKey>> {
+    let state_path = checkpoint_dir(cache_dir).join(CHECKPOINT_FILE);
     let state = read_checkpoint(cache_dir)?;
-    if state.watermark.is_some() {
-        return Ok(state.watermark);
+    if state.legacy_watermark().is_some() {
+        return Ok(state.legacy_watermark().cloned());
+    }
+    if state_path.exists() && !state.is_legacy() {
+        return Ok(None);
     }
 
     let path = checkpoint_dir(cache_dir).join(WATERMARK_FILE);
@@ -231,13 +373,66 @@ pub fn read_watermark(cache_dir: &Path) -> Result<Option<OrderingKey>> {
 #[cfg(test)]
 pub(crate) fn write_watermark(cache_dir: &Path, key: &OrderingKey) -> Result<()> {
     let mut state = read_checkpoint(cache_dir)?;
-    state.watermark = Some(key.clone());
+    state.activate_legacy(Some(key.clone()));
     write_checkpoint(cache_dir, &state)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[derive(Deserialize)]
+    struct LegacyCheckpointReader {
+        watermark: Option<OrderingKey>,
+    }
+
+    #[test]
+    fn phase2_causality_current_checkpoint_fails_closed_in_legacy_reader() {
+        let bytes = serde_json::to_vec(&CheckpointState::default()).unwrap();
+        assert!(serde_json::from_slice::<LegacyCheckpointReader>(&bytes).is_err());
+        let legacy =
+            br#"{"watermark":{"timestamp":"2026-01-01T00:00:00Z","agent_id":"a","agent_seq":1}}"#;
+        assert_eq!(
+            serde_json::from_slice::<LegacyCheckpointReader>(legacy)
+                .unwrap()
+                .watermark
+                .unwrap()
+                .agent_seq,
+            1
+        );
+    }
+
+    #[test]
+    fn phase2_causality_legacy_and_future_schema_detection_is_explicit() {
+        let legacy = br#"{"next_display_id":1,"next_comment_id":1,"display_id_map":{},"locks":{},"issues":{},"watermark":{"timestamp":"2026-01-01T00:00:00Z","agent_id":"a","agent_seq":1}}"#;
+        let state = CheckpointState::from_slice(legacy).unwrap();
+        assert!(state.is_legacy());
+        let future = br#"{"checkpoint_schema_version":3,"next_display_id":1,"next_comment_id":1,"display_id_map":{},"locks":{},"issues":{},"watermark":{"unsupported_checkpoint_schema":3}}"#;
+        let error = CheckpointState::from_slice(future).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("unsupported checkpoint schema version 3"));
+    }
+
+    #[test]
+    fn phase2_causality_frontier_relation_is_componentwise() {
+        let entry = |sequence| AgentFrontier {
+            sequence,
+            tip_oid: format!("tip-{sequence}"),
+            prefix_sha256: format!("hash-{sequence}"),
+        };
+        let mut left = CausalFrontier::default();
+        left.agents.insert("a".to_string(), entry(2));
+        left.agents.insert("b".to_string(), entry(1));
+        let mut right = CausalFrontier::default();
+        right.agents.insert("a".to_string(), entry(1));
+        right.agents.insert("b".to_string(), entry(2));
+        assert_eq!(left.relation(&right), FrontierRelation::Concurrent);
+        right.agents.insert("a".to_string(), entry(2));
+        assert_eq!(right.relation(&left), FrontierRelation::Dominates);
+        assert_eq!(left.relation(&right), FrontierRelation::Dominated);
+        assert_eq!(right.relation(&right), FrontierRelation::Equal);
+    }
 
     #[test]
     fn test_default_checkpoint_state() {
@@ -398,8 +593,9 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let cache_dir = dir.path();
 
-        let state = CheckpointState::default();
-        assert!(state.watermark.is_none());
+        let mut state = CheckpointState::default();
+        state.activate_legacy(None);
+        assert!(state.legacy_watermark().is_none());
         write_checkpoint(cache_dir, &state).unwrap();
 
         let checkpoint_dir = cache_dir.join("checkpoint");

--- a/crosslink/src/commands/kickoff/helpers.rs
+++ b/crosslink/src/commands/kickoff/helpers.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Output, Stdio};
+use std::time::{Duration, Instant};
 
 use super::types::*;
 
@@ -449,6 +450,31 @@ pub(crate) fn command_available(cmd: &str) -> bool {
     let lookup = Command::new("which").arg(cmd).output();
 
     lookup.is_ok_and(|o| o.status.success())
+}
+
+pub(super) fn command_output_with_timeout(
+    command: &mut Command,
+    timeout: Duration,
+) -> Option<Output> {
+    let mut child = command
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .ok()?;
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => return child.wait_with_output().ok(),
+            Ok(None) if Instant::now() < deadline => {
+                std::thread::sleep(Duration::from_millis(20));
+            }
+            Ok(None) | Err(_) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return None;
+            }
+        }
+    }
 }
 
 pub(super) fn detect_platform() -> Platform {

--- a/crosslink/src/commands/kickoff/monitor.rs
+++ b/crosslink/src/commands/kickoff/monitor.rs
@@ -2,11 +2,13 @@ use anyhow::{bail, Context, Result};
 use std::fmt::Write;
 use std::path::Path;
 use std::process::Command;
+use std::time::Duration;
 
 use crate::agents::{parse_jsonl_event, runtime_provider, runtime_snapshot};
 
 const RUNTIME_LOG: &str = ".crosslink/runtime/agent-events.jsonl";
 const USAGE_MARKER: &str = ".crosslink/runtime/recorded-usage.json";
+const RUNTIME_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(2);
 
 pub(super) fn record_runtime_usage(crosslink_dir: &Path, worktree_dir: &Path, agent_id: &str) {
     use sha2::{Digest, Sha256};
@@ -308,17 +310,16 @@ pub(super) fn discover_agents(crosslink_dir: &Path) -> Result<Vec<AgentInfo>> {
     }
 
     if command_available("docker") {
-        if let Ok(output) = Command::new("docker")
-            .args([
-                "ps",
-                "-a",
-                "--filter",
-                "label=crosslink-agent=true",
-                "--format",
-                "{{.Names}}\t{{.Status}}\t{{.Label \"crosslink-task\"}}",
-            ])
-            .output()
-        {
+        let mut command = Command::new("docker");
+        command.args([
+            "ps",
+            "-a",
+            "--filter",
+            "label=crosslink-agent=true",
+            "--format",
+            "{{.Names}}\t{{.Status}}\t{{.Label \"crosslink-task\"}}",
+        ]);
+        if let Some(output) = command_output_with_timeout(&mut command, RUNTIME_DISCOVERY_TIMEOUT) {
             if output.status.success() {
                 let stdout = String::from_utf8_lossy(&output.stdout);
                 for line in stdout.lines() {

--- a/crosslink/src/commands/kickoff/tests.rs
+++ b/crosslink/src/commands/kickoff/tests.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
-use std::time::Duration;
+use std::process::Command;
+use std::time::{Duration, Instant};
 
 use super::helpers::*;
 use super::launch::*;
@@ -2285,6 +2286,25 @@ fn test_command_available_nonexistent() {
 #[test]
 fn test_command_available_real() {
     assert!(command_available("which"));
+}
+
+#[test]
+fn external_command_timeout_is_bounded() {
+    #[cfg(windows)]
+    let mut command = {
+        let mut command = Command::new("ping.exe");
+        command.args(["-n", "6", "127.0.0.1"]);
+        command
+    };
+    #[cfg(not(windows))]
+    let mut command = {
+        let mut command = Command::new("sleep");
+        command.arg("5");
+        command
+    };
+    let started = Instant::now();
+    assert!(command_output_with_timeout(&mut command, Duration::from_millis(100)).is_none());
+    assert!(started.elapsed() < Duration::from_secs(3));
 }
 
 #[test]

--- a/crosslink/src/compaction.rs
+++ b/crosslink/src/compaction.rs
@@ -1,17 +1,18 @@
 use anyhow::{Context, Result};
 use chrono::Utc;
-use std::collections::{BTreeSet, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use uuid::Uuid;
 
 use crate::checkpoint::{
-    read_watermark, write_checkpoint, CheckpointState, CompactComment, CompactIssue,
-    CompactMilestone, CompactTimeEntry, LockEntry, SkewWarning, UnsignedEventWarning,
+    event_prefix_sha256, read_watermark, write_checkpoint, AgentFrontier, CausalFrontier,
+    CheckpointState, CompactComment, CompactIssue, CompactMilestone, CompactTimeEntry, LockEntry,
+    SkewWarning, UnsignedEventWarning,
 };
 use crate::events::{Event, EventEnvelope, OrderingKey};
-use crate::hub_source::{HubSource, WorktreeSource};
+use crate::hub_source::{AgentHistory, HubSource, WorktreeSource};
 use crate::issue_file::{IssueFile, LockFileV2};
 
 const LEASE_DURATION_SECS: i64 = 30;
@@ -133,35 +134,54 @@ pub struct ReductionOutcome {
 
 pub fn reduce(source: &dyn HubSource) -> Result<ReductionOutcome> {
     let mut state = source.read_checkpoint()?;
+    state.validate_schema()?;
+    let external_legacy_watermark = source.read_legacy_watermark()?;
+    let legacy_watermark = state
+        .legacy_watermark()
+        .cloned()
+        .or(external_legacy_watermark);
+    let legacy = state.is_legacy() || legacy_watermark.is_some();
 
-    let watermark = match state.watermark.clone() {
-        Some(wm) => Some(wm),
-        None => source.read_legacy_watermark()?,
-    };
+    if legacy && !source.histories_are_complete() {
+        return reduce_legacy_snapshot(source, state, legacy_watermark.as_ref());
+    }
+
+    let histories = validated_histories(source)?;
+    let replaying_from_empty;
+    if legacy {
+        if let Some(baseline) = source.read_authority_baseline()? {
+            validate_frontier(source, &baseline.frontier, &histories)?;
+            state = baseline.state;
+            state.activate_causal(baseline.frontier);
+            replaying_from_empty = false;
+        } else {
+            state.activate_causal(CausalFrontier::default());
+            replaying_from_empty = true;
+        }
+    } else {
+        validate_frontier(source, &state.frontier, &histories)?;
+        let rebuilt = rebuild_state_to_frontier(source, &histories, &state.frontier)?;
+        anyhow::ensure!(
+            checkpoint_semantics_equal(&state, &rebuilt)?,
+            "checkpoint semantic state does not equal authoritative reconstruction at its causal frontier"
+        );
+        replaying_from_empty = state.frontier.is_empty();
+    }
 
     let mut all_events = Vec::new();
-    for agent_id in source.agent_ids()? {
-        let events = source.read_events(&agent_id, watermark.as_ref())?;
-        all_events.extend(events);
-    }
-
-    if state.watermark.is_none() {
-        if let Some(ref wm) = watermark {
-            state.watermark = Some(wm.clone());
-        }
-    }
-
-    if all_events.is_empty() && watermark.is_some() {
-        return Ok(ReductionOutcome {
-            state,
-            changed_issues: HashSet::new(),
-            changed_locks: HashSet::new(),
-            events_processed: 0,
-        });
-    }
-
-    if watermark.is_none() {
-        state = CheckpointState::default();
+    for (agent_id, history) in &histories {
+        let applied = state
+            .frontier
+            .agents
+            .get(agent_id)
+            .map_or(0, |entry| entry.sequence);
+        all_events.extend(
+            history
+                .events
+                .iter()
+                .filter(|event| event.agent_seq > applied)
+                .cloned(),
+        );
     }
 
     all_events.sort_by_cached_key(OrderingKey::from_envelope);
@@ -170,7 +190,7 @@ pub fn reduce(source: &dyn HubSource) -> Result<ReductionOutcome> {
     let mut changed_issues: HashSet<Uuid> = HashSet::new();
     let mut changed_locks: HashSet<i64> = HashSet::new();
 
-    if watermark.is_none() {
+    if replaying_from_empty {
         state.skew_warnings.clear();
         state.unsigned_event_warnings.clear();
     }
@@ -190,10 +210,268 @@ pub fn reduce(source: &dyn HubSource) -> Result<ReductionOutcome> {
         );
     }
 
-    if let Some(last) = all_events.last() {
-        state.watermark = Some(OrderingKey::from_envelope(last));
-    }
+    let frontier = frontier_for_histories(&histories, Some(&state.frontier))?;
+    state.activate_causal(frontier);
 
+    Ok(ReductionOutcome {
+        state,
+        changed_issues,
+        changed_locks,
+        events_processed,
+    })
+}
+
+pub fn rebuild_from_authority(source: &dyn HubSource) -> Result<ReductionOutcome> {
+    let histories = validated_histories(source)?;
+    let mut state = if let Some(baseline) = source.read_authority_baseline()? {
+        validate_frontier(source, &baseline.frontier, &histories)?;
+        let mut state = baseline.state;
+        state.activate_causal(baseline.frontier);
+        state
+    } else {
+        CheckpointState::default()
+    };
+    let mut all_events: Vec<_> = histories
+        .iter()
+        .flat_map(|(agent_id, history)| {
+            let applied = state
+                .frontier
+                .agents
+                .get(agent_id)
+                .map_or(0, |entry| entry.sequence);
+            history
+                .events
+                .iter()
+                .filter(move |event| event.agent_seq > applied)
+                .cloned()
+        })
+        .collect();
+    all_events.sort_by_cached_key(OrderingKey::from_envelope);
+    let events_processed = all_events.len();
+    let mut changed_issues = HashSet::new();
+    let mut changed_locks = HashSet::new();
+    let allowed_signers_path = source
+        .allowed_signers_file()?
+        .unwrap_or_else(|| PathBuf::from("/dev/null/no-allowed-signers"));
+    for envelope in &all_events {
+        detect_clock_skew(&mut state, envelope);
+        check_unsigned(&mut state, envelope, &allowed_signers_path);
+        apply(
+            &mut state,
+            envelope,
+            &mut changed_issues,
+            &mut changed_locks,
+        );
+    }
+    state.activate_causal(frontier_for_histories(&histories, None)?);
+    Ok(ReductionOutcome {
+        state,
+        changed_issues,
+        changed_locks,
+        events_processed,
+    })
+}
+
+fn rebuild_state_to_frontier(
+    source: &dyn HubSource,
+    histories: &BTreeMap<String, AgentHistory>,
+    target: &CausalFrontier,
+) -> Result<CheckpointState> {
+    validate_frontier(source, target, histories)?;
+    let mut state = if let Some(baseline) = source.read_authority_baseline()? {
+        validate_frontier(source, &baseline.frontier, histories)?;
+        anyhow::ensure!(
+            matches!(
+                target.relation(&baseline.frontier),
+                crate::checkpoint::FrontierRelation::Equal
+                    | crate::checkpoint::FrontierRelation::Dominates
+            ),
+            "checkpoint causal frontier does not cover its pinned authority baseline"
+        );
+        let mut state = baseline.state;
+        state.activate_causal(baseline.frontier);
+        state
+    } else {
+        CheckpointState::default()
+    };
+    let mut events = Vec::new();
+    for (agent_id, history) in histories {
+        let applied = state
+            .frontier
+            .agents
+            .get(agent_id)
+            .map_or(0, |entry| entry.sequence);
+        let covered = target
+            .agents
+            .get(agent_id)
+            .map_or(0, |entry| entry.sequence);
+        anyhow::ensure!(
+            covered >= applied,
+            "checkpoint causal frontier for agent '{agent_id}' precedes its pinned authority baseline"
+        );
+        events.extend(
+            history
+                .events
+                .iter()
+                .filter(|event| event.agent_seq > applied && event.agent_seq <= covered)
+                .cloned(),
+        );
+    }
+    events.sort_by_cached_key(OrderingKey::from_envelope);
+    let allowed_signers_path = source
+        .allowed_signers_file()?
+        .unwrap_or_else(|| PathBuf::from("/dev/null/no-allowed-signers"));
+    let mut changed_issues = HashSet::new();
+    let mut changed_locks = HashSet::new();
+    for envelope in &events {
+        detect_clock_skew(&mut state, envelope);
+        check_unsigned(&mut state, envelope, &allowed_signers_path);
+        apply(
+            &mut state,
+            envelope,
+            &mut changed_issues,
+            &mut changed_locks,
+        );
+    }
+    state.activate_causal(target.clone());
+    Ok(state)
+}
+
+fn checkpoint_semantics_equal(left: &CheckpointState, right: &CheckpointState) -> Result<bool> {
+    let normalize = |state: &CheckpointState| {
+        let mut state = state.clone();
+        state.compaction_lease = None;
+        state.skew_warnings.clear();
+        state.unsigned_event_warnings.clear();
+        serde_json::to_value(state).context("serializing checkpoint for semantic verification")
+    };
+    Ok(normalize(left)? == normalize(right)?)
+}
+
+pub fn frontier_from_authority(source: &dyn HubSource) -> Result<CausalFrontier> {
+    frontier_for_histories(&validated_histories(source)?, None)
+}
+
+fn validated_histories(source: &dyn HubSource) -> Result<BTreeMap<String, AgentHistory>> {
+    let mut ids = source.agent_ids()?;
+    ids.sort();
+    ids.dedup();
+    let mut histories = BTreeMap::new();
+    for agent_id in ids {
+        let mut history = source
+            .read_agent_history(&agent_id)
+            .with_context(|| format!("failed to read complete history for agent '{agent_id}'"))?;
+        history.validate()?;
+        histories.insert(agent_id, history);
+    }
+    Ok(histories)
+}
+
+fn validate_frontier(
+    source: &dyn HubSource,
+    frontier: &CausalFrontier,
+    histories: &BTreeMap<String, AgentHistory>,
+) -> Result<()> {
+    for (agent_id, entry) in &frontier.agents {
+        let history = histories.get(agent_id).with_context(|| {
+            format!("frontier claims agent '{agent_id}' but its pinned ref is missing")
+        })?;
+        anyhow::ensure!(
+            entry.sequence > 0,
+            "frontier for agent '{agent_id}' contains a non-canonical zero sequence"
+        );
+        anyhow::ensure!(
+            entry.sequence <= history.events.len() as u64,
+            "frontier for agent '{agent_id}' claims sequence {} but pinned history ends at {}",
+            entry.sequence,
+            history.events.len()
+        );
+        anyhow::ensure!(
+            source.tip_contains(agent_id, &entry.tip_oid)?,
+            "frontier tip {} for agent '{agent_id}' is not a prefix of pinned tip {}",
+            entry.tip_oid,
+            history.tip_oid
+        );
+        let actual = event_prefix_sha256(&history.events, entry.sequence)?;
+        anyhow::ensure!(
+            actual == entry.prefix_sha256,
+            "frontier prefix hash for agent '{agent_id}' sequence {} is forged or rewritten",
+            entry.sequence
+        );
+        if let Some(digest) = entry.tip_oid.strip_prefix("sha256:") {
+            anyhow::ensure!(
+                digest == entry.prefix_sha256,
+                "frontier snapshot identity for agent '{agent_id}' does not match its prefix hash"
+            );
+        }
+    }
+    Ok(())
+}
+
+fn frontier_for_histories(
+    histories: &BTreeMap<String, AgentHistory>,
+    previous: Option<&CausalFrontier>,
+) -> Result<CausalFrontier> {
+    let mut agents = BTreeMap::new();
+    for (agent_id, history) in histories {
+        let sequence = history.events.len() as u64;
+        if sequence == 0 {
+            continue;
+        }
+        let prefix_sha256 = event_prefix_sha256(&history.events, sequence)?;
+        let tip_oid = previous
+            .and_then(|frontier| frontier.agents.get(agent_id))
+            .filter(|entry| entry.sequence == sequence && entry.prefix_sha256 == prefix_sha256)
+            .map_or_else(|| history.tip_oid.clone(), |entry| entry.tip_oid.clone());
+        agents.insert(
+            agent_id.clone(),
+            AgentFrontier {
+                sequence,
+                tip_oid,
+                prefix_sha256,
+            },
+        );
+    }
+    Ok(CausalFrontier { agents })
+}
+
+fn reduce_legacy_snapshot(
+    source: &dyn HubSource,
+    mut state: CheckpointState,
+    watermark: Option<&OrderingKey>,
+) -> Result<ReductionOutcome> {
+    let mut all_events = Vec::new();
+    for agent_id in source.agent_ids()? {
+        all_events.extend(source.read_events(&agent_id, watermark)?);
+    }
+    if all_events.is_empty() {
+        return Ok(ReductionOutcome {
+            state,
+            changed_issues: HashSet::new(),
+            changed_locks: HashSet::new(),
+            events_processed: 0,
+        });
+    }
+    all_events.sort_by_cached_key(OrderingKey::from_envelope);
+    let events_processed = all_events.len();
+    let mut changed_issues = HashSet::new();
+    let mut changed_locks = HashSet::new();
+    let allowed_signers_path = source
+        .allowed_signers_file()?
+        .unwrap_or_else(|| PathBuf::from("/dev/null/no-allowed-signers"));
+    for envelope in &all_events {
+        detect_clock_skew(&mut state, envelope);
+        check_unsigned(&mut state, envelope, &allowed_signers_path);
+        apply(
+            &mut state,
+            envelope,
+            &mut changed_issues,
+            &mut changed_locks,
+        );
+    }
+    if let Some(last) = all_events.last() {
+        state.activate_legacy(Some(OrderingKey::from_envelope(last)));
+    }
     Ok(ReductionOutcome {
         state,
         changed_issues,
@@ -215,7 +493,7 @@ pub fn compact(
     let source = WorktreeSource::new(cache_dir);
     let outcome = reduce(&source)?;
 
-    if outcome.events_processed == 0 && outcome.state.watermark.is_some() {
+    if outcome.events_processed == 0 && !outcome.state.frontier.is_empty() {
         let git_violations = crate::clock_skew::detect_git_skew_violations(cache_dir)
             .unwrap_or_else(|e| {
                 tracing::warn!("git skew detection failed, defaulting to no violations: {e}");
@@ -480,6 +758,13 @@ fn apply_issue_event(
             signed_by,
             signature,
         } => {
+            if state
+                .issues
+                .get(issue_uuid)
+                .is_some_and(|issue| issue.comments.contains_key(comment_uuid))
+            {
+                return;
+            }
             let claimed = adopt_comment_id(state, *display_id);
             apply_issue_field(state, envelope, changed_issues, *issue_uuid, |issue| {
                 issue
@@ -915,6 +1200,7 @@ mod tests {
     use crate::checkpoint::{read_checkpoint, CompactionLease};
     use crate::events::{append_event, Event, EventEnvelope};
     use chrono::Duration;
+    use proptest::prelude::*;
 
     fn try_acquire_lease(state: &mut CheckpointState, agent_id: &str) -> bool {
         let now = Utc::now();
@@ -992,6 +1278,156 @@ mod tests {
     ) -> Result<Option<CompactionResult>> {
         let lock = test_hub_lock(cache_dir);
         compact(cache_dir, agent_id, force, &lock)
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(32))]
+
+        #[test]
+        fn phase2_causality_per_agent_selection_is_independent_of_clock_order(
+            first_offset in -100_000_i64..100_000,
+            second_offset in -100_000_i64..100_000,
+        ) {
+            let dir = tempfile::tempdir().unwrap();
+            let cache_dir = dir.path();
+            setup_cache(cache_dir);
+            let mut first = make_envelope(
+                "agent-a",
+                1,
+                Event::LockClaimed { issue_display_id: 1, branch: None },
+            );
+            first.timestamp = chrono::DateTime::<Utc>::UNIX_EPOCH
+                + Duration::seconds(first_offset);
+            append_event(&cache_dir.join("agents/agent-a/events.log"), &first).unwrap();
+            compact_t(cache_dir, "agent-a", true).unwrap();
+
+            let mut second = make_envelope(
+                "agent-b",
+                1,
+                Event::LockClaimed { issue_display_id: 2, branch: None },
+            );
+            second.timestamp = chrono::DateTime::<Utc>::UNIX_EPOCH
+                + Duration::seconds(second_offset);
+            append_event(&cache_dir.join("agents/agent-b/events.log"), &second).unwrap();
+            let result = compact_t(cache_dir, "agent-b", true).unwrap().unwrap();
+            prop_assert_eq!(result.events_processed, 1);
+            let state = read_checkpoint(cache_dir).unwrap();
+            prop_assert!(state.locks.contains_key(&1));
+            prop_assert!(state.locks.contains_key(&2));
+        }
+
+        #[test]
+        fn phase2_causality_reduction_accepts_arbitrary_delivery_permutations(keys in any::<[u8; 6]>()) {
+            let dir = tempfile::tempdir().unwrap();
+            setup_cache(dir.path());
+            let mut events = Vec::new();
+            for index in 0..6_usize {
+                let agent = if index < 3 { "agent-a" } else { "agent-b" };
+                let sequence = (index % 3 + 1) as u64;
+                let mut event = make_envelope(
+                    agent,
+                    sequence,
+                    Event::LockClaimed {
+                        issue_display_id: index as i64 + 1,
+                        branch: None,
+                    },
+                );
+                event.timestamp = chrono::DateTime::<Utc>::UNIX_EPOCH
+                    + Duration::seconds((6 - index) as i64);
+                events.push(event);
+            }
+            let mut order: Vec<_> = (0..events.len()).collect();
+            order.sort_by_key(|index| (keys[*index], *index));
+            for index in order {
+                let event = &events[index];
+                append_event(
+                    &dir.path().join("agents").join(&event.agent_id).join("events.log"),
+                    event,
+                )
+                .unwrap();
+            }
+            let outcome = reduce(&WorktreeSource::new(dir.path())).unwrap();
+            prop_assert_eq!(outcome.events_processed, 6);
+            prop_assert_eq!(outcome.state.locks.len(), 6);
+            prop_assert_eq!(outcome.state.frontier.agents["agent-a"].sequence, 3);
+            prop_assert_eq!(outcome.state.frontier.agents["agent-b"].sequence, 3);
+        }
+    }
+
+    #[test]
+    fn phase2_causality_reduction_rejects_missing_middle_sequence() {
+        let dir = tempfile::tempdir().unwrap();
+        setup_cache(dir.path());
+        let log = dir.path().join("agents/agent-a/events.log");
+        for sequence in [1, 3] {
+            append_event(
+                &log,
+                &make_envelope(
+                    "agent-a",
+                    sequence,
+                    Event::LockClaimed {
+                        issue_display_id: i64::try_from(sequence).unwrap(),
+                        branch: None,
+                    },
+                ),
+            )
+            .unwrap();
+        }
+        let error = reduce(&WorktreeSource::new(dir.path())).unwrap_err();
+        assert!(error.to_string().contains("expected sequence 2"));
+    }
+
+    #[test]
+    fn phase2_causality_reduction_rejects_forged_prefix_hash() {
+        let dir = tempfile::tempdir().unwrap();
+        setup_cache(dir.path());
+        append_event(
+            &dir.path().join("agents/agent-a/events.log"),
+            &make_envelope(
+                "agent-a",
+                1,
+                Event::LockClaimed {
+                    issue_display_id: 1,
+                    branch: None,
+                },
+            ),
+        )
+        .unwrap();
+        compact_t(dir.path(), "agent-a", true).unwrap();
+        let mut state = read_checkpoint(dir.path()).unwrap();
+        state
+            .frontier
+            .agents
+            .get_mut("agent-a")
+            .unwrap()
+            .prefix_sha256 = "00".repeat(32);
+        write_checkpoint(dir.path(), &state).unwrap();
+        let error = reduce(&WorktreeSource::new(dir.path())).unwrap_err();
+        assert!(error.to_string().contains("forged or rewritten"));
+    }
+
+    #[test]
+    fn phase2_causality_reduction_rejects_forged_checkpoint_semantics() {
+        let dir = tempfile::tempdir().unwrap();
+        setup_cache(dir.path());
+        append_event(
+            &dir.path().join("agents/agent-a/events.log"),
+            &make_envelope(
+                "agent-a",
+                1,
+                Event::LockClaimed {
+                    issue_display_id: 1,
+                    branch: None,
+                },
+            ),
+        )
+        .unwrap();
+        compact_t(dir.path(), "agent-a", true).unwrap();
+        let mut state = read_checkpoint(dir.path()).unwrap();
+        state.locks.get_mut(&1).unwrap().agent_id = "forged-agent".to_string();
+        write_checkpoint(dir.path(), &state).unwrap();
+        let error = reduce(&WorktreeSource::new(dir.path())).unwrap_err();
+        assert!(error.to_string().contains("semantic state"));
     }
 
     #[test]
@@ -1666,10 +2102,10 @@ mod tests {
         compact_t(cache_dir, "agent-1", true).unwrap();
 
         let pruned = prune_events(cache_dir, "agent-1").unwrap();
-        assert_eq!(pruned, 2);
+        assert_eq!(pruned, 0);
 
         let remaining = crate::events::read_events(&log).unwrap();
-        assert!(remaining.is_empty());
+        assert_eq!(remaining.len(), 2);
     }
 
     #[test]
@@ -3568,7 +4004,7 @@ mod tests {
         compact_t(cache_dir, "agent-1", true).unwrap();
 
         let state = read_checkpoint(cache_dir).unwrap();
-        let embedded_watermark = state.watermark.clone().unwrap();
+        let embedded_watermark = OrderingKey::from_envelope(&e1);
 
         let checkpoint_dir = cache_dir.join("checkpoint");
         let legacy_wm_path = checkpoint_dir.join("watermark.json");
@@ -3576,7 +4012,7 @@ mod tests {
         std::fs::write(&legacy_wm_path, &wm_json).unwrap();
 
         let mut state_no_wm = state;
-        state_no_wm.watermark = None;
+        state_no_wm.activate_legacy(None);
         write_checkpoint(cache_dir, &state_no_wm).unwrap();
 
         let e2 = make_envelope(
@@ -3602,7 +4038,7 @@ mod tests {
         );
 
         assert!(
-            final_state.watermark.is_some(),
+            final_state.legacy_watermark().is_some(),
             "Checkpoint should have embedded watermark after migration"
         );
     }
@@ -3787,6 +4223,37 @@ mod tests {
             signed_by: None,
             signature: None,
         }
+    }
+
+    #[test]
+    fn phase2_causality_legacy_replay_does_not_reallocate_existing_comment_id() {
+        let issue_uuid = Uuid::new_v4();
+        let comment_uuid = Uuid::new_v4();
+        let issue = make_envelope("agent-1", 1, issue_created(issue_uuid, "Issue"));
+        let comment = make_envelope(
+            "agent-1",
+            2,
+            comment_added(issue_uuid, comment_uuid, "Comment"),
+        );
+        let mut state = CheckpointState::default();
+        let mut changed_issues = HashSet::new();
+        let mut changed_locks = HashSet::new();
+        apply(&mut state, &issue, &mut changed_issues, &mut changed_locks);
+        apply(
+            &mut state,
+            &comment,
+            &mut changed_issues,
+            &mut changed_locks,
+        );
+        let next_comment_id = state.next_comment_id;
+        apply(
+            &mut state,
+            &comment,
+            &mut changed_issues,
+            &mut changed_locks,
+        );
+        assert_eq!(state.next_comment_id, next_comment_id);
+        assert_eq!(state.issues[&issue_uuid].comments.len(), 1);
     }
 
     #[test]

--- a/crosslink/src/daemon.rs
+++ b/crosslink/src/daemon.rs
@@ -388,8 +388,9 @@ fn acquire_run_lease(crosslink_dir: &Path, identity: &DaemonIdentity) -> Result<
         match publish_lease(&path, &contents) {
             Ok(true) => return Ok(FileLease { path, contents }),
             Ok(false) => {
-                let existing = fs::read(&path)
-                    .with_context(|| format!("reading daemon run lease {}", path.display()))?;
+                let Some(existing) = read_lease_if_present(&path, "daemon run lease")? else {
+                    continue;
+                };
                 if let Ok(holder) = serde_json::from_slice::<DaemonIdentity>(&existing) {
                     if holder.repository_id != identity.repository_id {
                         remove_owned_lease(&path, &existing)?;
@@ -445,9 +446,20 @@ fn publish_lease(path: &Path, contents: &[u8]) -> std::io::Result<bool> {
     Ok(published)
 }
 
+fn read_lease_if_present(path: &Path, description: &str) -> Result<Option<Vec<u8>>> {
+    match fs::read(path) {
+        Ok(contents) => Ok(Some(contents)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => {
+            Err(error).with_context(|| format!("reading {description} {}", path.display()))
+        }
+    }
+}
+
 fn remove_stale_start_lease(path: &Path, repository_id: &str) -> Result<bool> {
-    let contents = fs::read(path)
-        .with_context(|| format!("reading daemon startup lease {}", path.display()))?;
+    let Some(contents) = read_lease_if_present(path, "daemon startup lease")? else {
+        return Ok(true);
+    };
     if let Ok(owner) = serde_json::from_slice::<ProcessLeaseOwner>(&contents) {
         if owner.repository_id != repository_id {
             remove_owned_lease(path, &contents)?;
@@ -475,14 +487,25 @@ fn remove_stale_start_lease(path: &Path, repository_id: &str) -> Result<bool> {
 
 fn remove_owned_lease(path: &Path, contents: &[u8]) -> Result<()> {
     if fs::read(path).ok().as_deref() == Some(contents) {
-        fs::remove_file(path)
-            .with_context(|| format!("removing stale lease {}", path.display()))?;
+        match fs::remove_file(path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(error)
+                    .with_context(|| format!("removing stale lease {}", path.display()));
+            }
+        }
     }
     Ok(())
 }
 
 fn lease_is_fresh(path: &Path, duration: Duration) -> Result<bool> {
-    let modified = fs::metadata(path)?.modified()?;
+    let metadata = match fs::metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error.into()),
+    };
+    let modified = metadata.modified()?;
     Ok(modified.elapsed().unwrap_or_default() < duration)
 }
 
@@ -1244,6 +1267,17 @@ mod tests {
             .filter(|_| lease_liveness_probe_due(&mut sweep))
             .count();
         assert_eq!(probes, 10);
+    }
+
+    #[test]
+    fn vanished_lease_is_retryable() {
+        let root = initialized();
+        let path = root.path().join(".crosslink/daemon.start.lock");
+        assert!(read_lease_if_present(&path, "daemon startup lease")
+            .unwrap()
+            .is_none());
+        assert!(!lease_is_fresh(&path, Duration::from_secs(1)).unwrap());
+        assert!(remove_stale_start_lease(&path, "repository").unwrap());
     }
 
     #[test]

--- a/crosslink/src/dashboard/reader.rs
+++ b/crosslink/src/dashboard/reader.rs
@@ -199,16 +199,11 @@ fn read_snapshot_v3(
 }
 
 fn read_checkpoint_state(repo_dir: &Path) -> Result<crate::checkpoint::CheckpointState> {
-    let Some(tip) = crate::hub_v3::git_rev_parse_optional(repo_dir, crate::hub_v3::CHECKPOINT_REF)?
-    else {
-        return Ok(crate::checkpoint::CheckpointState::default());
-    };
-    let spec = format!("{tip}:state.json");
-    let Some(bytes) = crate::hub_v3::git_cat_file_blob_optional(repo_dir, &spec)? else {
-        return Ok(crate::checkpoint::CheckpointState::default());
-    };
-    crate::checkpoint::CheckpointState::from_slice(&bytes)
-        .context("failed to parse v3 checkpoint state.json for dashboard snapshot")
+    let source = crate::hub_source::RefHubSource::new(repo_dir)
+        .context("failed to pin v3 refs for dashboard snapshot")?;
+    Ok(crate::compaction::reduce(&source)
+        .context("failed to verify and reduce v3 checkpoint for dashboard snapshot")?
+        .state)
 }
 
 fn compact_issue_to_file(issue: &crate::checkpoint::CompactIssue) -> crate::issue_file::IssueFile {

--- a/crosslink/src/hub_source.rs
+++ b/crosslink/src/hub_source.rs
@@ -1,8 +1,12 @@
 use anyhow::{Context, Result};
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use crate::checkpoint::{read_checkpoint, read_watermark, CheckpointState};
+use crate::checkpoint::{
+    event_prefix_sha256, read_checkpoint, read_watermark, AgentFrontier, CausalFrontier,
+    CheckpointState,
+};
 use crate::events::{read_events_from_bytes, EventEnvelope, OrderingKey};
 
 pub trait HubSource {
@@ -19,6 +23,77 @@ pub trait HubSource {
     fn read_legacy_watermark(&self) -> Result<Option<OrderingKey>>;
 
     fn allowed_signers_file(&self) -> Result<Option<PathBuf>>;
+
+    fn read_agent_history(&self, agent_id: &str) -> Result<AgentHistory> {
+        let mut events = self.read_events(agent_id, None)?;
+        events.sort_by_key(|event| event.agent_seq);
+        let digest = event_prefix_sha256(&events, u64::MAX)?;
+        Ok(AgentHistory {
+            agent_id: agent_id.to_string(),
+            tip_oid: format!("sha256:{digest}"),
+            events,
+        })
+    }
+
+    fn tip_contains(&self, agent_id: &str, claimed_tip: &str) -> Result<bool> {
+        let history = self.read_agent_history(agent_id)?;
+        if claimed_tip == history.tip_oid {
+            return Ok(true);
+        }
+        Ok(claimed_tip.starts_with("sha256:"))
+    }
+
+    fn histories_are_complete(&self) -> bool {
+        false
+    }
+
+    fn read_authority_baseline(&self) -> Result<Option<AuthorityBaseline>> {
+        Ok(None)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct AgentHistory {
+    pub agent_id: String,
+    pub tip_oid: String,
+    pub events: Vec<EventEnvelope>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AuthorityBaseline {
+    pub state: CheckpointState,
+    pub frontier: CausalFrontier,
+}
+
+#[derive(serde::Deserialize)]
+struct AuthorityBaselineMeta {
+    #[serde(default)]
+    genesis_checkpoint_commit: Option<String>,
+    #[serde(default)]
+    seed_agent_tips: Option<BTreeMap<String, String>>,
+}
+
+impl AgentHistory {
+    pub fn validate(&mut self) -> Result<()> {
+        self.events.sort_by_key(|event| event.agent_seq);
+        for (index, event) in self.events.iter().enumerate() {
+            let expected = index as u64 + 1;
+            anyhow::ensure!(
+                event.agent_id == self.agent_id,
+                "agent '{}' history contains an event owned by '{}' at sequence {}",
+                self.agent_id,
+                event.agent_id,
+                event.agent_seq
+            );
+            anyhow::ensure!(
+                event.agent_seq == expected,
+                "agent '{}' history is not a contiguous prefix: expected sequence {expected}, found {}",
+                self.agent_id,
+                event.agent_seq
+            );
+        }
+        Ok(())
+    }
 }
 
 pub struct WorktreeSource {
@@ -270,6 +345,18 @@ impl HubSource for ObjectStoreSource {
     fn allowed_signers_file(&self) -> Result<Option<PathBuf>> {
         Ok(self.allowed_signers_path.clone())
     }
+
+    fn read_agent_history(&self, agent_id: &str) -> Result<AgentHistory> {
+        Ok(AgentHistory {
+            agent_id: agent_id.to_string(),
+            tip_oid: self.commit_sha.clone(),
+            events: self.read_events(agent_id, None)?,
+        })
+    }
+
+    fn tip_contains(&self, _agent_id: &str, claimed_tip: &str) -> Result<bool> {
+        Ok(claimed_tip == self.commit_sha)
+    }
 }
 
 #[derive(Debug)]
@@ -339,6 +426,12 @@ impl RefHubSource {
             _allowed_signers_dir: allowed_signers_dir,
             allowed_signers_path,
         })
+    }
+
+    pub fn at_checkpoint(repo_dir: &Path, checkpoint_sha: Option<String>) -> Result<Self> {
+        let mut source = Self::new(repo_dir)?;
+        source.checkpoint_sha = checkpoint_sha;
+        Ok(source)
     }
 
     #[must_use]
@@ -413,6 +506,149 @@ impl HubSource for RefHubSource {
 
     fn allowed_signers_file(&self) -> Result<Option<PathBuf>> {
         Ok(self.allowed_signers_path.clone())
+    }
+
+    fn read_agent_history(&self, agent_id: &str) -> Result<AgentHistory> {
+        let Some((_, tip)) = self.agent_tips.iter().find(|(id, _)| id == agent_id) else {
+            anyhow::bail!("agent ref for '{agent_id}' is missing from the pinned authority");
+        };
+        let commits = git_first_parent_history(&self.repo_path, tip)?;
+        let mut by_sequence: BTreeMap<u64, (Vec<u8>, EventEnvelope)> = BTreeMap::new();
+        for commit in commits {
+            let Some(bytes) = git_cat_file_blob(&self.repo_path, &commit, "events.log")? else {
+                continue;
+            };
+            let events = read_events_from_bytes(&bytes).with_context(|| {
+                format!("failed to parse agent '{agent_id}' history at pinned commit {commit}")
+            })?;
+            let mut seen = std::collections::BTreeSet::new();
+            for event in events {
+                anyhow::ensure!(
+                    seen.insert(event.agent_seq),
+                    "agent '{agent_id}' history repeats sequence {} in pinned commit {commit}",
+                    event.agent_seq
+                );
+                let encoded = serde_json::to_vec(&event)
+                    .context("failed to encode event while validating agent history")?;
+                if let Some((existing, _)) = by_sequence.get(&event.agent_seq) {
+                    anyhow::ensure!(
+                        *existing == encoded,
+                        "agent '{agent_id}' history rewrites sequence {} between pinned commits",
+                        event.agent_seq
+                    );
+                } else {
+                    by_sequence.insert(event.agent_seq, (encoded, event));
+                }
+            }
+        }
+        Ok(AgentHistory {
+            agent_id: agent_id.to_string(),
+            tip_oid: tip.clone(),
+            events: by_sequence.into_values().map(|(_, event)| event).collect(),
+        })
+    }
+
+    fn tip_contains(&self, agent_id: &str, claimed_tip: &str) -> Result<bool> {
+        let Some((_, current_tip)) = self.agent_tips.iter().find(|(id, _)| id == agent_id) else {
+            return Ok(false);
+        };
+        git_is_ancestor(&self.repo_path, claimed_tip, current_tip)
+    }
+
+    fn histories_are_complete(&self) -> bool {
+        true
+    }
+
+    fn read_authority_baseline(&self) -> Result<Option<AuthorityBaseline>> {
+        let Some(meta_sha) = &self.meta_sha else {
+            return Ok(None);
+        };
+        let bytes = git_cat_file_blob(&self.repo_path, meta_sha, "hub.json")?
+            .with_context(|| format!("pinned meta commit {meta_sha} has no hub.json"))?;
+        let meta: AuthorityBaselineMeta = serde_json::from_slice(&bytes).with_context(|| {
+            format!("failed to parse hub.json at pinned meta commit {meta_sha}")
+        })?;
+        let (checkpoint, tips) = match (meta.genesis_checkpoint_commit, meta.seed_agent_tips) {
+            (None, None) => return Ok(None),
+            (Some(checkpoint), Some(tips)) => (checkpoint, tips),
+            _ => anyhow::bail!(
+                "pinned hub metadata must record both genesis_checkpoint_commit and seed_agent_tips"
+            ),
+        };
+        let seed = Self::at_tips(
+            &self.repo_path,
+            Some(checkpoint),
+            Some(meta_sha.clone()),
+            tips.into_iter().collect(),
+        )?;
+        let mut state = seed.read_checkpoint()?;
+        let mut agents = BTreeMap::new();
+        for agent_id in seed.agent_ids()? {
+            let mut history = seed.read_agent_history(&agent_id)?;
+            history.validate()?;
+            anyhow::ensure!(
+                self.tip_contains(&agent_id, &history.tip_oid)?,
+                "pinned authority baseline tip {} for agent '{agent_id}' is not a prefix of the current authority",
+                history.tip_oid
+            );
+            let sequence = history.events.len() as u64;
+            if sequence == 0 {
+                continue;
+            }
+            agents.insert(
+                agent_id,
+                AgentFrontier {
+                    sequence,
+                    tip_oid: history.tip_oid,
+                    prefix_sha256: event_prefix_sha256(&history.events, sequence)?,
+                },
+            );
+        }
+        let frontier = CausalFrontier { agents };
+        state.activate_causal(frontier.clone());
+        Ok(Some(AuthorityBaseline { state, frontier }))
+    }
+}
+
+fn git_first_parent_history(repo_path: &Path, tip: &str) -> Result<Vec<String>> {
+    let output = Command::new("git")
+        .current_dir(repo_path)
+        .args(["rev-list", "--first-parent", "--reverse", tip])
+        .output()
+        .with_context(|| format!("failed to enumerate pinned agent history at {tip}"))?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "failed to enumerate pinned agent history at {tip}: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(str::to_string)
+        .collect())
+}
+
+fn git_is_ancestor(repo_path: &Path, ancestor: &str, descendant: &str) -> Result<bool> {
+    anyhow::ensure!(
+        commit_object_exists(repo_path, ancestor)?,
+        "frontier claims missing pinned commit {ancestor}"
+    );
+    let output = Command::new("git")
+        .current_dir(repo_path)
+        .args(["merge-base", "--is-ancestor", ancestor, descendant])
+        .output()
+        .with_context(|| {
+            format!("failed to validate frontier tip {ancestor} against {descendant}")
+        })?;
+    match output.status.code() {
+        Some(0) => Ok(true),
+        Some(1) => Ok(false),
+        _ => anyhow::bail!(
+            "failed to validate frontier tip {ancestor} against {descendant}: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ),
     }
 }
 
@@ -731,8 +967,16 @@ pub(crate) mod test_support {
             a.changed_locks, b.changed_locks,
             "{label}: changed_locks mismatch"
         );
-        let state_a = serde_json::to_value(&a.state).unwrap();
-        let state_b = serde_json::to_value(&b.state).unwrap();
+        let mut normalized_a = a.state.clone();
+        let mut normalized_b = b.state.clone();
+        for entry in normalized_a.frontier.agents.values_mut() {
+            entry.tip_oid.clear();
+        }
+        for entry in normalized_b.frontier.agents.values_mut() {
+            entry.tip_oid.clear();
+        }
+        let state_a = serde_json::to_value(&normalized_a).unwrap();
+        let state_b = serde_json::to_value(&normalized_b).unwrap();
         assert_eq!(state_a, state_b, "{label}: checkpoint state mismatch");
     }
 }
@@ -774,6 +1018,94 @@ mod tests {
                 due_at: None,
             },
         )
+    }
+
+    fn commit_reduced_checkpoint(repo: &Path) -> CheckpointState {
+        let state = crate::compaction::reduce(&RefHubSource::new(repo).unwrap())
+            .unwrap()
+            .state;
+        let bytes = serde_json::to_vec_pretty(&state).unwrap();
+        crate::hub_v3::commit_blob_to_ref(
+            repo,
+            crate::hub_v3::CHECKPOINT_REF,
+            "state.json",
+            &bytes,
+            "causal checkpoint",
+        )
+        .unwrap();
+        state
+    }
+
+    #[test]
+    fn phase2_causality_ref_hub_rejects_rewritten_sequence_in_descendant_history() {
+        let repo = tempfile::tempdir().unwrap();
+        ref_repo_init(repo.path());
+        let original = make_issue_created("agent-a", 1, Uuid::new_v4());
+        crate::hub_v3::commit_log_bytes(
+            repo.path(),
+            "agent-a",
+            &log_bytes(std::slice::from_ref(&original)),
+            "original",
+        )
+        .unwrap();
+        commit_reduced_checkpoint(repo.path());
+        let rewritten = make_issue_created("agent-a", 1, Uuid::new_v4());
+        crate::hub_v3::commit_log_bytes(
+            repo.path(),
+            "agent-a",
+            &log_bytes(&[rewritten]),
+            "rewrite",
+        )
+        .unwrap();
+        let error =
+            crate::compaction::reduce(&RefHubSource::new(repo.path()).unwrap()).unwrap_err();
+        let message = format!("{error:#}");
+        assert!(message.contains("rewrites sequence 1"), "{message}");
+    }
+
+    #[test]
+    fn phase2_causality_ref_hub_rejects_missing_and_non_prefix_frontier_tips() {
+        let repo = tempfile::tempdir().unwrap();
+        ref_repo_init(repo.path());
+        let event = make_issue_created("agent-a", 1, Uuid::new_v4());
+        crate::hub_v3::commit_log_bytes(repo.path(), "agent-a", &log_bytes(&[event]), "event")
+            .unwrap();
+        let mut state = commit_reduced_checkpoint(repo.path());
+        state.frontier.agents.get_mut("agent-a").unwrap().tip_oid = "f".repeat(40);
+        let bytes = serde_json::to_vec_pretty(&state).unwrap();
+        crate::hub_v3::commit_blob_to_ref(
+            repo.path(),
+            crate::hub_v3::CHECKPOINT_REF,
+            "state.json",
+            &bytes,
+            "missing frontier tip",
+        )
+        .unwrap();
+        let error =
+            crate::compaction::reduce(&RefHubSource::new(repo.path()).unwrap()).unwrap_err();
+        assert!(error.to_string().contains("missing pinned commit"));
+
+        let unrelated = crate::hub_v3::commit_blob_to_ref(
+            repo.path(),
+            crate::hub_v3::META_REF,
+            "hub.json",
+            b"{}",
+            "unrelated tip",
+        )
+        .unwrap();
+        state.frontier.agents.get_mut("agent-a").unwrap().tip_oid = unrelated;
+        let bytes = serde_json::to_vec_pretty(&state).unwrap();
+        crate::hub_v3::commit_blob_to_ref(
+            repo.path(),
+            crate::hub_v3::CHECKPOINT_REF,
+            "state.json",
+            &bytes,
+            "non-prefix frontier tip",
+        )
+        .unwrap();
+        let error =
+            crate::compaction::reduce(&RefHubSource::new(repo.path()).unwrap()).unwrap_err();
+        assert!(error.to_string().contains("is not a prefix"));
     }
 
     #[test]
@@ -899,10 +1231,8 @@ mod tests {
         write_agent_events(hub_dir, "agent-1", &[e1.clone()]);
 
         let wm = OrderingKey::from_envelope(&e1);
-        let mut state = CheckpointState {
-            watermark: Some(wm),
-            ..Default::default()
-        };
+        let mut state = CheckpointState::default();
+        state.activate_legacy(Some(wm));
 
         state.issues.insert(
             uuid1,
@@ -1186,10 +1516,8 @@ mod tests {
             .unwrap();
 
         let wm = OrderingKey::from_envelope(&e_pre);
-        let mut state = CheckpointState {
-            watermark: Some(wm),
-            ..Default::default()
-        };
+        let mut state = CheckpointState::default();
+        state.activate_legacy(Some(wm));
         state.issues.insert(
             uuid_pre,
             crate::checkpoint::CompactIssue {
@@ -1230,8 +1558,8 @@ mod tests {
         let outcome = crate::compaction::reduce(&source).unwrap();
 
         assert_eq!(
-            outcome.events_processed, 2,
-            "only post-watermark events apply"
+            outcome.events_processed, 3,
+            "legacy ref history is fully replayed"
         );
 
         assert!(
@@ -1247,6 +1575,96 @@ mod tests {
             "post-wm issue 2 applied"
         );
         assert_eq!(outcome.state.issues.len(), 3);
+    }
+
+    #[test]
+    fn phase2_causality_legacy_upgrade_replays_from_pinned_genesis_without_losing_eventless_records(
+    ) {
+        let repo_tmp = tempfile::tempdir().unwrap();
+        let repo = repo_tmp.path();
+        ref_repo_init(repo);
+
+        let seeded_uuid = Uuid::new_v4();
+        let orphan_uuid = Uuid::new_v4();
+        let late_uuid = Uuid::new_v4();
+        let e1 = make_issue_created("agent-1", 1, seeded_uuid);
+        crate::hub_v3::commit_log_bytes(
+            repo,
+            "agent-1",
+            &log_bytes(std::slice::from_ref(&e1)),
+            "seed history",
+        )
+        .unwrap();
+        let seed_tip =
+            git_rev_parse_optional(repo, &format!("{}agent-1", crate::hub_v3::AGENT_REF_PREFIX))
+                .unwrap()
+                .unwrap();
+        let mut baseline =
+            crate::compaction::rebuild_from_authority(&RefHubSource::new(repo).unwrap())
+                .unwrap()
+                .state;
+        let mut orphan = baseline.issues[&seeded_uuid].clone();
+        orphan.uuid = orphan_uuid;
+        orphan.display_id = Some(50);
+        orphan.title = "Imported without an event".to_string();
+        baseline.issues.insert(orphan_uuid, orphan);
+        baseline.display_id_map.insert(orphan_uuid, 50);
+        baseline.next_display_id = 51;
+        let genesis = crate::hub_v3::commit_blob_to_ref(
+            repo,
+            crate::hub_v3::CHECKPOINT_REF,
+            "state.json",
+            &serde_json::to_vec_pretty(&baseline).unwrap(),
+            "pinned migration genesis",
+        )
+        .unwrap();
+        let meta = crate::hub_v3::HubMeta {
+            hub_version: 3,
+            migrated_from_commit: "legacy-source".to_string(),
+            migrated_at: Utc::now(),
+            finalized_at: None,
+            genesis_checkpoint_commit: Some(genesis),
+            seed_agent_tips: Some(std::collections::BTreeMap::from([(
+                "agent-1".to_string(),
+                seed_tip,
+            )])),
+        };
+        crate::hub_v3::commit_blob_to_ref(
+            repo,
+            crate::hub_v3::META_REF,
+            "hub.json",
+            &serde_json::to_vec_pretty(&meta).unwrap(),
+            "migration metadata",
+        )
+        .unwrap();
+
+        let e2 = make_issue_created("agent-1", 2, late_uuid);
+        crate::hub_v3::commit_log_bytes(repo, "agent-1", &log_bytes(&[e1, e2]), "late history")
+            .unwrap();
+        let mut legacy = baseline;
+        legacy.activate_legacy(Some(OrderingKey {
+            timestamp: Utc::now() + Duration::days(1),
+            agent_id: "agent-1".to_string(),
+            agent_seq: 1,
+        }));
+        crate::hub_v3::commit_blob_to_ref(
+            repo,
+            crate::hub_v3::CHECKPOINT_REF,
+            "state.json",
+            &serde_json::to_vec_pretty(&legacy).unwrap(),
+            "legacy checkpoint",
+        )
+        .unwrap();
+
+        let source = RefHubSource::new(repo).unwrap();
+        let migrated = crate::compaction::reduce(&source).unwrap();
+        assert_eq!(migrated.events_processed, 1);
+        assert!(migrated.state.issues.contains_key(&seeded_uuid));
+        assert!(migrated.state.issues.contains_key(&orphan_uuid));
+        assert!(migrated.state.issues.contains_key(&late_uuid));
+        let rebuilt = crate::compaction::rebuild_from_authority(&source).unwrap();
+        assert!(rebuilt.state.issues.contains_key(&orphan_uuid));
+        assert!(rebuilt.state.issues.contains_key(&late_uuid));
     }
 
     #[test]
@@ -1386,12 +1804,7 @@ mod tests {
         let ref_source = RefHubSource::new(repo).unwrap();
         let ref_outcome = crate::compaction::reduce(&ref_source).unwrap();
 
-        let wt = serde_json::to_value(&worktree_outcome.state).unwrap();
-        let rf = serde_json::to_value(&ref_outcome.state).unwrap();
-        assert_eq!(
-            wt, rf,
-            "WorktreeSource and RefHubSource must reduce to identical state"
-        );
+        assert_outcomes_equal(&worktree_outcome, &ref_outcome, "worktree-ref");
         assert_eq!(
             worktree_outcome.events_processed, ref_outcome.events_processed,
             "both sources must process the same number of events"

--- a/crosslink/src/hub_v3.rs
+++ b/crosslink/src/hub_v3.rs
@@ -963,10 +963,17 @@ fn render_browse_readme(state: &crate::checkpoint::CheckpointState) -> Vec<u8> {
         .filter(|u| !state.deleted_issues.contains(u))
         .count();
     let milestones = state.milestones.len();
-    let watermark = state
-        .watermark
-        .as_ref()
-        .map_or_else(|| "(none)".to_string(), |w| w.timestamp.to_rfc3339());
+    let frontier = if state.frontier.agents.is_empty() {
+        "(empty)".to_string()
+    } else {
+        state
+            .frontier
+            .agents
+            .iter()
+            .map(|(agent, entry)| format!("{agent}:{}", entry.sequence))
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
 
     let body = format!(
         "# crosslink hub (v3 checkpoint)\n\
@@ -991,7 +998,7 @@ of its own branch.\n\
 \n\
 - Live issues: {live_issues}\n\
 - Milestones: {milestones}\n\
-- Compaction watermark: {watermark}\n"
+- Causal frontier: {frontier}\n"
     );
     body.into_bytes()
 }
@@ -1064,7 +1071,12 @@ pub fn compact_v3(
         .context("failed to construct RefHubSource for v3 compaction")?;
     let outcome = crate::compaction::reduce(&source).context("v3 reduction failed")?;
     let events_processed = outcome.events_processed;
-    let watermark = outcome.state.watermark.clone();
+    let covered_sequence = outcome
+        .state
+        .frontier
+        .agents
+        .get(agent_id)
+        .map(|entry| entry.sequence);
 
     let mut state = outcome.state;
     state.compaction_lease = None;
@@ -1158,8 +1170,8 @@ pub fn compact_v3(
 
     let prune_ok = checkpoint_commit.is_some() && (remote.is_none() || checkpoint_pushed);
     let events_pruned = if prune_ok {
-        match &watermark {
-            Some(wm) => prune_own_ref(repo_dir, agent_id, wm)?,
+        match covered_sequence {
+            Some(sequence) => prune_own_ref(repo_dir, agent_id, sequence)?,
             None => 0,
         }
     } else {
@@ -1200,11 +1212,7 @@ fn remote_checkpoint_sha(repo_dir: &Path, _remote: &str) -> Option<String> {
     git_rev_parse_optional(repo_dir, tracking).ok().flatten()
 }
 
-fn prune_own_ref(
-    repo_dir: &Path,
-    agent_id: &str,
-    watermark: &crate::events::OrderingKey,
-) -> Result<usize> {
+fn prune_own_ref(repo_dir: &Path, agent_id: &str, covered_sequence: u64) -> Result<usize> {
     let ref_name = format!("{AGENT_REF_PREFIX}{agent_id}");
     let Some(tip) = git_rev_parse_optional(repo_dir, &ref_name)? else {
         return Ok(0);
@@ -1218,7 +1226,7 @@ fn prune_own_ref(
     let before = all.len();
     let remaining: Vec<_> = all
         .into_iter()
-        .filter(|e| crate::events::OrderingKey::from_envelope(e) > *watermark)
+        .filter(|event| event.agent_seq > covered_sequence)
         .collect();
     let pruned = before - remaining.len();
     if pruned == 0 {
@@ -1263,15 +1271,6 @@ pub fn warn_if_migrated_v2_operation(repo_dir: &Path, mode: HubMode) {
     }
 }
 
-#[must_use]
-pub fn genesis_sentinel_watermark() -> crate::events::OrderingKey {
-    crate::events::OrderingKey {
-        timestamp: chrono::DateTime::<chrono::Utc>::UNIX_EPOCH,
-        agent_id: "hub-v3-genesis".to_string(),
-        agent_seq: 0,
-    }
-}
-
 pub fn bootstrap_v3_hub(
     repo_dir: &Path,
     agent_id: &str,
@@ -1309,10 +1308,7 @@ pub fn bootstrap_v3_hub(
     )
     .context("failed to write genesis meta marker")?;
 
-    let genesis = crate::checkpoint::CheckpointState {
-        watermark: Some(genesis_sentinel_watermark()),
-        ..crate::checkpoint::CheckpointState::default()
-    };
+    let genesis = crate::checkpoint::CheckpointState::default();
     let state_bytes =
         serde_json::to_vec_pretty(&genesis).context("failed to serialize genesis checkpoint")?;
     commit_blob_to_ref(
@@ -3271,7 +3267,7 @@ mod tests {
     }
 
     #[test]
-    fn compact_v3_concurrent_cas_loss_is_benign() {
+    fn phase2_causality_compact_v3_concurrent_cas_loss_is_benign() {
         let dir = tempfile::tempdir().unwrap();
         git_init(dir.path());
         let agent_id = "cv3-cas";
@@ -3306,7 +3302,7 @@ mod tests {
     }
 
     #[test]
-    fn compact_v3_two_compactors_produce_consistent_checkpoint() {
+    fn phase2_causality_compact_v3_two_compactors_produce_consistent_checkpoint() {
         use std::sync::Arc;
         let dir = tempfile::tempdir().unwrap();
         git_init(dir.path());
@@ -3497,7 +3493,7 @@ mod tests {
             compact_v3(one.path(), agent, &lock, None).unwrap();
         }
         let one_tip = run_git_output(one.path(), &["rev-parse", CHECKPOINT_REF]);
-        let one_tree = read_browse_tree(one.path(), &one_tip);
+        let mut one_tree = read_browse_tree(one.path(), &one_tip);
 
         let inc = tempfile::tempdir().unwrap();
         git_init(inc.path());
@@ -3509,7 +3505,10 @@ mod tests {
             drop(lock);
         }
         let inc_tip = run_git_output(inc.path(), &["rev-parse", CHECKPOINT_REF]);
-        let inc_tree = read_browse_tree(inc.path(), &inc_tip);
+        let mut inc_tree = read_browse_tree(inc.path(), &inc_tip);
+
+        one_tree.remove("state.json");
+        inc_tree.remove("state.json");
 
         assert_eq!(
             one_tree, inc_tree,

--- a/crosslink/src/lock_check.rs
+++ b/crosslink/src/lock_check.rs
@@ -293,18 +293,23 @@ mod tests {
             } else {
                 chrono::Utc::now() - chrono::Duration::minutes(200)
             };
-            let mut state = crate::checkpoint::CheckpointState {
-                watermark: Some(crate::hub_v3::genesis_sentinel_watermark()),
-                ..Default::default()
-            };
-            state.locks.insert(
-                issue_id,
-                crate::checkpoint::LockEntry {
-                    agent_id: holder.to_string(),
+            let envelope = crate::events::EventEnvelope {
+                agent_id: holder.to_string(),
+                agent_seq: 1,
+                timestamp: claimed_at,
+                event: crate::events::Event::LockClaimed {
+                    issue_display_id: issue_id,
                     branch: None,
-                    claimed_at,
                 },
-            );
+                signed_by: None,
+                signature: None,
+            };
+            crate::hub_v3::append_event_to_ref(cache_dir, holder, &envelope).unwrap();
+            let state = crate::compaction::reduce(
+                &crate::hub_source::RefHubSource::new(cache_dir).unwrap(),
+            )
+            .unwrap()
+            .state;
             let bytes = serde_json::to_vec_pretty(&state).unwrap();
             crate::hub_v3::commit_blob_to_ref(
                 cache_dir,

--- a/crosslink/src/reconcile.rs
+++ b/crosslink/src/reconcile.rs
@@ -98,6 +98,7 @@ pub enum MigrationAction {
     ImportV2,
     RenameHiddenV3Refs,
     ResolveMixedSharedStore,
+    UpgradeCheckpointCausality { from: u32, to: u32 },
     EstablishReconciliationGeneration,
     ResumeReconciliation,
 }
@@ -199,6 +200,23 @@ fn plan_repository_reconciliation(
     if !matches!(format.shared_store, SharedStoreFormat::VisibleV3 { .. }) {
         return plan;
     }
+    match detect_checkpoint_schema(repository_root) {
+        Ok(version) if version < crate::checkpoint::CHECKPOINT_SCHEMA_VERSION => {
+            plan.actions
+                .push(MigrationAction::UpgradeCheckpointCausality {
+                    from: version,
+                    to: crate::checkpoint::CHECKPOINT_SCHEMA_VERSION,
+                });
+        }
+        Ok(version) if version == crate::checkpoint::CHECKPOINT_SCHEMA_VERSION => {}
+        Ok(version) => plan.blockers.push(format!(
+            "checkpoint schema {version} is newer than supported schema {}",
+            crate::checkpoint::CHECKPOINT_SCHEMA_VERSION
+        )),
+        Err(error) => plan
+            .blockers
+            .push(format!("checkpoint schema is unreadable: {error:#}")),
+    }
     if crosslink_dir.join("reconciliation-journal.json").exists() {
         plan.actions.push(MigrationAction::ResumeReconciliation);
     } else {
@@ -222,6 +240,32 @@ fn plan_repository_reconciliation(
         ReadinessState::BlockedCorrupt
     };
     plan
+}
+
+pub(crate) fn detect_checkpoint_schema(repository_root: &Path) -> Result<u32> {
+    let tip = match crate::hub_v3::git_rev_parse_optional(
+        repository_root,
+        crate::hub_v3::CHECKPOINT_REF,
+    )? {
+        Some(tip) => Some(tip),
+        None => crate::hub_v3::git_rev_parse_optional(repository_root, HIDDEN_CHECKPOINT_REF)?,
+    };
+    let Some(tip) = tip else {
+        anyhow::bail!("checkpoint ref is missing");
+    };
+    let spec = format!("{tip}:state.json");
+    let bytes = crate::hub_v3::git_cat_file_blob_optional(repository_root, &spec)?
+        .context("checkpoint state.json is missing")?;
+    let value: Value = serde_json::from_slice(&bytes).context("checkpoint state is not JSON")?;
+    let version = value
+        .get("checkpoint_schema_version")
+        .and_then(Value::as_u64)
+        .unwrap_or(1);
+    let version = u32::try_from(version).context("checkpoint schema version exceeds u32")?;
+    if version <= crate::checkpoint::CHECKPOINT_SCHEMA_VERSION {
+        crate::checkpoint::CheckpointState::from_slice(&bytes)?;
+    }
+    Ok(version)
 }
 
 #[must_use]
@@ -546,6 +590,7 @@ mod tests {
     #[derive(Deserialize)]
     struct FixtureManifest {
         sqlite: Vec<SqliteFixture>,
+        checkpoint: Vec<CheckpointFixture>,
         git: Vec<GitFixture>,
     }
 
@@ -560,6 +605,13 @@ mod tests {
     struct GitFixture {
         file: String,
         expected_kind: String,
+    }
+
+    #[derive(Deserialize)]
+    struct CheckpointFixture {
+        file: String,
+        version: u32,
+        valid: bool,
     }
 
     fn refs(names: &[&str]) -> BTreeSet<String> {
@@ -733,6 +785,31 @@ mod tests {
                 "mixed",
             ])
         );
+    }
+
+    #[test]
+    fn immutable_checkpoint_fixtures_cover_legacy_current_and_fail_closed_schemas() {
+        let manifest = fixture_manifest();
+        let root = fixture_root();
+        let mut versions = BTreeSet::new();
+        let mut validity = BTreeSet::new();
+        for fixture in manifest.checkpoint {
+            let bytes = std::fs::read(root.join(&fixture.file)).unwrap();
+            let value: Value = serde_json::from_slice(&bytes).unwrap();
+            let version = value
+                .get("checkpoint_schema_version")
+                .and_then(Value::as_u64)
+                .unwrap_or(1) as u32;
+            assert_eq!(version, fixture.version);
+            assert_eq!(
+                crate::checkpoint::CheckpointState::from_slice(&bytes).is_ok(),
+                fixture.valid
+            );
+            versions.insert(version);
+            validity.insert(fixture.valid);
+        }
+        assert_eq!(versions, BTreeSet::from([1, 2, 3]));
+        assert_eq!(validity, BTreeSet::from([false, true]));
     }
 
     #[test]

--- a/crosslink/src/reconcile/migration.rs
+++ b/crosslink/src/reconcile/migration.rs
@@ -14,7 +14,6 @@ use crate::checkpoint::{
     CheckpointState, CompactComment, CompactIssue, CompactMilestone, CompactTimeEntry,
 };
 use crate::compaction;
-use crate::events::OrderingKey;
 use crate::hub_source::{HubSource, RefHubSource};
 use crate::hub_v3::{self, HubMeta, CHECKPOINT_REF, META_REF};
 use crate::issue_file::{
@@ -515,8 +514,49 @@ impl HistoricalImporter for MigrationImporter<'_> {
         );
         let current_targets = direct_v3_targets(source)?;
         let Some(database_evidence) = source.refs().get("local/issues.db") else {
-            let semantic = self.read_target_semantic(repository, &current_targets)?;
-            return Ok(PreparedImport::new(current_targets, semantic));
+            let raw = read_checkpoint_target(repository, &current_targets)?;
+            if !raw.is_legacy() {
+                let semantic = self.read_target_semantic(repository, &current_targets)?;
+                return Ok(PreparedImport::new(current_targets, semantic));
+            }
+            let state = reduce_v3_state(repository, &current_targets)?;
+            anyhow::ensure!(
+                state.checkpoint_schema_version == crate::checkpoint::CHECKPOINT_SCHEMA_VERSION,
+                "legacy checkpoint replay did not produce the current causal schema"
+            );
+            let signers = read_v3_allowed_signers(repository, &current_targets)?;
+            let mut targets = current_targets;
+            let old_checkpoint = targets
+                .get(CHECKPOINT_REF)
+                .context("v3 source checkpoint is missing")?
+                .clone();
+            let staging_ref = format!(
+                "refs/crosslink/reconciliation/build/{}/checkpoint-causality",
+                source.fingerprint()
+            );
+            git_update_ref(repository, &staging_ref, &old_checkpoint)?;
+            let state_bytes = serde_json::to_vec_pretty(&state)
+                .context("serializing migrated causal checkpoint")?;
+            let checkpoint_oid = hub_v3::commit_blob_to_ref(
+                repository,
+                &staging_ref,
+                "state.json",
+                &state_bytes,
+                "crosslink reconciliation checkpoint causality upgrade",
+            )?;
+            targets.insert(CHECKPOINT_REF.to_string(), checkpoint_oid.clone());
+            if let Some(meta_oid) = add_causal_baseline_metadata(
+                repository,
+                &targets,
+                &checkpoint_oid,
+                source.fingerprint(),
+            )? {
+                targets.insert(META_REF.to_string(), meta_oid);
+            }
+            return Ok(PreparedImport::new(
+                targets,
+                canonical_semantic(&state, signers)?,
+            ));
         };
         let materialized =
             tempfile::tempdir().context("creating pinned local database merge workspace")?;
@@ -573,6 +613,76 @@ impl HistoricalImporter for MigrationImporter<'_> {
             .context("reading allowed_signers from prepared reconciliation target")?;
         canonical_semantic(&outcome.state, allowed_signers)
     }
+}
+
+fn add_causal_baseline_metadata(
+    repository: &Path,
+    targets: &BTreeMap<String, String>,
+    checkpoint_oid: &str,
+    generation_id: &str,
+) -> Result<Option<String>> {
+    let meta_oid = targets
+        .get(META_REF)
+        .context("v3 target metadata is missing")?;
+    let bytes = git_cat_file_blob_optional(repository, &format!("{meta_oid}:hub.json"))?
+        .context("v3 target hub.json is missing")?;
+    let mut value: serde_json::Value =
+        serde_json::from_slice(&bytes).context("parsing v3 target hub.json")?;
+    let object = value
+        .as_object_mut()
+        .context("v3 target hub.json is not an object")?;
+    let has_checkpoint = object
+        .get("genesis_checkpoint_commit")
+        .is_some_and(|value| !value.is_null());
+    let has_tips = object
+        .get("seed_agent_tips")
+        .is_some_and(|value| !value.is_null());
+    match (has_checkpoint, has_tips) {
+        (true, true) => return Ok(None),
+        (false, false) => {}
+        _ => anyhow::bail!(
+            "v3 target hub.json must record both genesis_checkpoint_commit and seed_agent_tips"
+        ),
+    }
+    let tips = targets
+        .iter()
+        .filter_map(|(reference, oid)| {
+            reference
+                .strip_prefix(hub_v3::AGENT_REF_PREFIX)
+                .map(|agent| (agent.to_string(), oid.clone()))
+        })
+        .collect::<BTreeMap<_, _>>();
+    object.insert(
+        "genesis_checkpoint_commit".to_string(),
+        serde_json::Value::String(checkpoint_oid.to_string()),
+    );
+    object.insert(
+        "seed_agent_tips".to_string(),
+        serde_json::to_value(tips).context("serializing causal baseline agent tips")?,
+    );
+    let updated = serde_json::to_vec_pretty(&value).context("serializing causal hub metadata")?;
+    let staging_ref = format!("refs/crosslink/reconciliation/build/{generation_id}/meta-causality");
+    git_update_ref(repository, &staging_ref, meta_oid)?;
+    hub_v3::commit_blob_to_ref(
+        repository,
+        &staging_ref,
+        "hub.json",
+        &updated,
+        "crosslink reconciliation causal baseline metadata",
+    )
+    .map(Some)
+}
+
+fn read_checkpoint_target(
+    repository: &Path,
+    targets: &BTreeMap<String, String>,
+) -> Result<CheckpointState> {
+    let tip = targets
+        .get(CHECKPOINT_REF)
+        .context("v3 target checkpoint is missing")?;
+    let bytes = git_cat_file_blob_optional(repository, &format!("{tip}:state.json"))?
+        .context("v3 target checkpoint state.json is missing")?;
+    CheckpointState::from_slice(&bytes).context("reading pinned v3 checkpoint state")
 }
 
 fn read_allowed_signers(source_dir: &Path) -> Result<Option<Vec<u8>>> {
@@ -708,6 +818,8 @@ fn merge_checkpoint_states(
             .as_object_mut()
             .ok_or_else(|| anyhow::anyhow!("checkpoint state is not an object"))?;
         object.remove("watermark");
+        object.remove("checkpoint_schema_version");
+        object.remove("frontier");
         object.remove("compaction_lease");
         object.remove("next_display_id");
         object.remove("next_comment_id");
@@ -728,14 +840,7 @@ fn merge_checkpoint_states(
     }
     let mut state: CheckpointState = serde_json::from_value(merged)
         .context("deserializing losslessly merged checkpoint state")?;
-    state.watermark = [
-        base.watermark.clone(),
-        local.watermark.clone(),
-        remote.watermark.clone(),
-    ]
-    .into_iter()
-    .flatten()
-    .max();
+    state.activate_causal(crate::checkpoint::CausalFrontier::default());
     state.compaction_lease = None;
     repair_issue_display_ids(&mut state);
     let max_comment = state
@@ -835,6 +940,8 @@ fn canonical_semantic(
     state: &CheckpointState,
     allowed_signers: Option<Vec<u8>>,
 ) -> Result<CanonicalSemantic> {
+    let mut state = state.clone();
+    state.activate_causal(crate::checkpoint::CausalFrontier::default());
     CanonicalSemantic::from_value(serde_json::json!({
         "state": state,
         "trust": allowed_signers.map(hex::encode),
@@ -1901,7 +2008,7 @@ fn normalized_projection_state(mut state: CheckpointState) -> Result<CheckpointS
     state.skew_warnings.clear();
     state.compaction_lease = None;
     state.unsigned_event_warnings.clear();
-    state.watermark = None;
+    state.activate_causal(crate::checkpoint::CausalFrontier::default());
     for issue in state.issues.values_mut() {
         for comment in issue.comments.values_mut() {
             comment.signed_by = None;
@@ -1997,9 +2104,6 @@ fn build_genesis_from_files(cache_dir: &Path) -> Result<CheckpointState> {
     let next_comment_id = counters.next_comment_id.max(max_comment_id + 1);
     let next_milestone_id = counters.next_milestone_id.max(max_milestone_id + 1);
 
-    let watermark =
-        max_event_ordering_key(cache_dir)?.unwrap_or_else(hub_v3::genesis_sentinel_watermark);
-
     let mut state = CheckpointState {
         next_display_id,
         next_comment_id,
@@ -2013,7 +2117,7 @@ fn build_genesis_from_files(cache_dir: &Path) -> Result<CheckpointState> {
         skew_warnings: Vec::new(),
         compaction_lease: None,
         unsigned_event_warnings: Vec::new(),
-        watermark: Some(watermark),
+        ..CheckpointState::default()
     };
     repair_issue_display_ids(&mut state);
     Ok(state)
@@ -2218,7 +2322,7 @@ fn build_genesis_from_open_database(
         skew_warnings: Vec::new(),
         compaction_lease: None,
         unsigned_event_warnings: Vec::new(),
-        watermark: Some(hub_v3::genesis_sentinel_watermark()),
+        ..CheckpointState::default()
     })
 }
 
@@ -2304,35 +2408,6 @@ fn derive_uuid(kind: &str, issue_uuid: Uuid, id: i64) -> Uuid {
     let mut bytes = [0u8; 16];
     bytes.copy_from_slice(&digest[0..16]);
     Uuid::from_bytes(bytes)
-}
-
-fn max_event_ordering_key(cache_dir: &Path) -> Result<Option<OrderingKey>> {
-    let agents_dir = cache_dir.join("agents");
-    let mut max_key: Option<OrderingKey> = None;
-    if !agents_dir.exists() {
-        return Ok(None);
-    }
-    for entry in std::fs::read_dir(&agents_dir)
-        .with_context(|| format!("failed to read agents dir {}", agents_dir.display()))?
-    {
-        let entry = entry?;
-        if !entry.file_type()?.is_dir() {
-            continue;
-        }
-        let log_path = entry.path().join("events.log");
-        if !log_path.exists() {
-            continue;
-        }
-        let events = crate::events::read_events(&log_path)?;
-        for ev in &events {
-            let key = OrderingKey::from_envelope(ev);
-            match &max_key {
-                Some(m) if *m >= key => {}
-                _ => max_key = Some(key),
-            }
-        }
-    }
-    Ok(max_key)
 }
 
 fn merge_agent_event_logs(agent_id: &str, left: &[u8], right: &[u8]) -> Result<Vec<u8>> {
@@ -2450,7 +2525,18 @@ fn seed_v3_targets(
         targets.insert(format!("{}{agent_id}", hub_v3::AGENT_REF_PREFIX), oid);
     }
 
-    let state_bytes = serde_json::to_vec_pretty(genesis)
+    let pinned_agents = targets
+        .iter()
+        .filter_map(|(reference, oid)| {
+            reference
+                .strip_prefix(hub_v3::AGENT_REF_PREFIX)
+                .map(|agent| (agent.to_string(), oid.clone()))
+        })
+        .collect();
+    let source = RefHubSource::at_tips(repository, None, None, pinned_agents)?;
+    let mut checkpoint = genesis.clone();
+    checkpoint.activate_causal(crate::compaction::frontier_from_authority(&source)?);
+    let state_bytes = serde_json::to_vec_pretty(&checkpoint)
         .context("serializing reconciliation checkpoint state")?;
     let checkpoint_ref = format!("{build_root}/checkpoint");
     let checkpoint_oid = hub_v3::commit_blob_to_ref(
@@ -3955,9 +4041,10 @@ pub(crate) mod tests {
 
         let genesis = build_genesis_from_files(&cache_dir).unwrap();
 
-        let base = crate::compaction::reduce(&RefHubSource::new(&cache_dir).unwrap())
+        let mut base = crate::compaction::reduce(&RefHubSource::new(&cache_dir).unwrap())
             .unwrap()
             .state;
+        base.activate_causal(crate::checkpoint::CausalFrontier::default());
         assert_eq!(
             serde_json::to_value(&genesis).unwrap(),
             serde_json::to_value(&base).unwrap(),
@@ -3968,7 +4055,7 @@ pub(crate) mod tests {
         let new_uuid = Uuid::new_v4();
         let env = EventEnvelope {
             agent_id: "alpha".to_string(),
-            agent_seq: 9999,
+            agent_seq: 11,
             timestamp: Utc::now() + chrono::Duration::seconds(60),
             event: Event::IssueCreated {
                 uuid: new_uuid,
@@ -4003,6 +4090,180 @@ pub(crate) mod tests {
         );
 
         assert_eq!(after.issues.len(), genesis.issues.len() + 1);
+    }
+
+    #[test]
+    fn phase2_causality_daemon_activation_migrates_legacy_checkpoint_and_recovers_late_event() {
+        let (_work, _remote, crosslink_dir, cache_dir) = setup_v2_hub();
+        hub_v3(&crosslink_dir, false, false, false, false).unwrap();
+
+        let source = RefHubSource::new(&cache_dir).unwrap();
+        let mut legacy = compaction::reduce(&source).unwrap().state;
+        let orphan_uuid = Uuid::new_v4();
+        let mut orphan = legacy.issues.values().next().unwrap().clone();
+        orphan.uuid = orphan_uuid;
+        orphan.display_id = Some(legacy.next_display_id);
+        orphan.title = "Pre-metadata imported issue".to_string();
+        orphan.parent_uuid = None;
+        orphan.blockers.clear();
+        orphan.related.clear();
+        orphan.milestone_uuid = None;
+        orphan.comments.clear();
+        orphan.time_entries.clear();
+        legacy
+            .display_id_map
+            .insert(orphan_uuid, legacy.next_display_id);
+        legacy.next_display_id += 1;
+        legacy.issues.insert(orphan_uuid, orphan);
+        let meta_tip = rev(&cache_dir, META_REF).unwrap();
+        let meta_bytes = git_cat_file_blob_optional(&cache_dir, &format!("{meta_tip}:hub.json"))
+            .unwrap()
+            .unwrap();
+        let mut meta_value: serde_json::Value = serde_json::from_slice(&meta_bytes).unwrap();
+        let meta_object = meta_value.as_object_mut().unwrap();
+        meta_object.remove("genesis_checkpoint_commit");
+        meta_object.remove("seed_agent_tips");
+        hub_v3::commit_blob_to_ref(
+            &cache_dir,
+            META_REF,
+            "hub.json",
+            &serde_json::to_vec_pretty(&meta_value).unwrap(),
+            "pre-metadata v3 hub",
+        )
+        .unwrap();
+        run(
+            &cache_dir,
+            &[
+                "push",
+                "--force",
+                "origin",
+                &format!("{META_REF}:{META_REF}"),
+            ],
+        );
+        legacy.activate_legacy(Some(crate::events::OrderingKey {
+            timestamp: Utc::now() + chrono::Duration::days(1),
+            agent_id: "alpha".to_string(),
+            agent_seq: 10,
+        }));
+        let legacy_bytes = serde_json::to_vec_pretty(&legacy).unwrap();
+        let legacy_tip = hub_v3::commit_blob_to_ref(
+            &cache_dir,
+            CHECKPOINT_REF,
+            "state.json",
+            &legacy_bytes,
+            "legacy global watermark checkpoint",
+        )
+        .unwrap();
+        run(
+            &cache_dir,
+            &[
+                "push",
+                "--force",
+                "origin",
+                &format!("{CHECKPOINT_REF}:{CHECKPOINT_REF}"),
+            ],
+        );
+
+        let issue_uuid = Uuid::new_v4();
+        let envelope = crate::events::EventEnvelope {
+            agent_id: "alpha".to_string(),
+            agent_seq: 11,
+            timestamp: chrono::DateTime::<Utc>::UNIX_EPOCH + chrono::Duration::seconds(1),
+            event: crate::events::Event::IssueCreated {
+                uuid: issue_uuid,
+                title: "Late offline issue".to_string(),
+                description: None,
+                priority: "high".to_string(),
+                labels: vec!["offline".to_string()],
+                parent_uuid: None,
+                created_by: "alpha".to_string(),
+                display_id: None,
+                scheduled_at: None,
+                due_at: None,
+            },
+            signed_by: None,
+            signature: None,
+        };
+        hub_v3::append_event_to_ref(&cache_dir, "alpha", &envelope).unwrap();
+        let alpha_ref = agent_ref_name("alpha").unwrap();
+        run(
+            &cache_dir,
+            &[
+                "push",
+                "--force",
+                "origin",
+                &format!("{alpha_ref}:{alpha_ref}"),
+            ],
+        );
+
+        let report = crate::reconcile::check_repository(&crosslink_dir);
+        assert!(report.plan.actions.contains(
+            &crate::reconcile::MigrationAction::UpgradeCheckpointCausality {
+                from: 1,
+                to: crate::checkpoint::CHECKPOINT_SCHEMA_VERSION,
+            }
+        ));
+        let sync = SyncManager::new(&crosslink_dir).unwrap();
+        let lock = sync.acquire_lock().unwrap();
+        let importer = MigrationImporter {
+            crosslink_dir: &crosslink_dir,
+            cache_dir: &cache_dir,
+            hub_lock: &lock,
+            agent_id: "alpha".to_string(),
+        };
+        let failed = RepositoryReconciler::new(
+            &cache_dir,
+            crosslink_dir.join("reconciliation-journal.json"),
+            "origin",
+            &importer,
+        )
+        .with_failpoint(crate::reconcile::publication::Failpoint {
+            transition: crate::reconcile::publication::Transition::Verify,
+            position: crate::reconcile::publication::TransitionPosition::After,
+            occurrence: 1,
+        })
+        .reconcile(report.format);
+        assert!(failed.is_err());
+        let pinned_legacy = RefHubSource::new(&cache_dir)
+            .and_then(|source| source.read_checkpoint())
+            .unwrap();
+        assert!(pinned_legacy.is_legacy());
+        drop(importer);
+        drop(lock);
+        let activation = activate_repository(&crosslink_dir).unwrap();
+        assert!(
+            matches!(
+                &activation,
+                RepositoryActivation::ReadyMigrated { .. }
+                    | RepositoryActivation::ReadyAdopted { .. }
+            ),
+            "unexpected activation: {activation:?}"
+        );
+
+        let state = RefHubSource::new(&cache_dir)
+            .and_then(|source| compaction::reduce(&source).map(|outcome| outcome.state))
+            .unwrap();
+        assert_eq!(
+            state.checkpoint_schema_version,
+            crate::checkpoint::CHECKPOINT_SCHEMA_VERSION
+        );
+        assert_eq!(state.frontier.agents["alpha"].sequence, 11);
+        assert!(state.issues.contains_key(&issue_uuid));
+        assert!(state.issues.contains_key(&orphan_uuid));
+        let meta = hub_v3::read_hub_meta(&cache_dir).unwrap().unwrap();
+        assert!(meta.genesis_checkpoint_commit.is_some());
+        assert!(meta.seed_agent_tips.is_some());
+
+        let descriptor = rev(&cache_dir, crate::reconcile::publication::GENERATION_REF).unwrap();
+        let bytes =
+            git_cat_file_blob_optional(&cache_dir, &format!("{descriptor}:generation.json"))
+                .unwrap()
+                .unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(
+            value["source"]["refs"][CHECKPOINT_REF]["authority_oid"],
+            legacy_tip
+        );
     }
 
     #[test]
@@ -4187,10 +4448,11 @@ pub(crate) mod tests {
         let cp = crate::checkpoint::read_checkpoint(&cache_dir);
         let _ = cp;
         let genesis = build_genesis_from_files(&cache_dir).unwrap();
-        assert!(
-            genesis.watermark.is_some(),
-            "no-events genesis must have a watermark"
+        assert_eq!(
+            genesis.checkpoint_schema_version,
+            crate::checkpoint::CHECKPOINT_SCHEMA_VERSION
         );
+        assert!(genesis.frontier.is_empty());
         let reduced = crate::compaction::reduce(&RefHubSource::new(&cache_dir).unwrap())
             .unwrap()
             .state;

--- a/crosslink/src/reconcile/publication.rs
+++ b/crosslink/src/reconcile/publication.rs
@@ -322,7 +322,7 @@ impl<'a, I: HistoricalImporter> RepositoryReconciler<'a, I> {
     }
 
     #[cfg(test)]
-    fn with_failpoint(mut self, failpoint: Failpoint) -> Self {
+    pub(crate) fn with_failpoint(mut self, failpoint: Failpoint) -> Self {
         self.failure = FailureController::new(Some(failpoint));
         self
     }
@@ -1321,6 +1321,19 @@ impl<'a, I: HistoricalImporter> RepositoryReconciler<'a, I> {
         else {
             return Ok(None);
         };
+        if matches!(
+            observed_format.shared_store,
+            SharedStoreFormat::VisibleV3 { .. } | SharedStoreFormat::HiddenV3 { .. }
+        ) {
+            let checkpoint_schema = super::detect_checkpoint_schema(self.repository)?;
+            if checkpoint_schema < crate::checkpoint::CHECKPOINT_SCHEMA_VERSION {
+                return Ok(None);
+            }
+            anyhow::ensure!(
+                checkpoint_schema == crate::checkpoint::CHECKPOINT_SCHEMA_VERSION,
+                "checkpoint schema {checkpoint_schema} is unsupported"
+            );
+        }
         for _ in 0..8 {
             fetch_oid(self.repository, self.remote, &descriptor_oid)?;
             let descriptor = read_descriptor(self.repository, &descriptor_oid)?;
@@ -1412,6 +1425,37 @@ impl<'a, I: HistoricalImporter> RepositoryReconciler<'a, I> {
             ));
         }
         let mut advanced = false;
+        let winner_checkpoint = &winner.targets[crate::hub_v3::CHECKPOINT_REF].oid;
+        let proposed_checkpoint = &proposed.targets[crate::hub_v3::CHECKPOINT_REF].oid;
+        if winner_checkpoint != proposed_checkpoint
+            && is_ancestor(self.repository, winner_checkpoint, proposed_checkpoint)?
+        {
+            let winner_schema = checkpoint_schema_at_commit(self.repository, winner_checkpoint)?;
+            let proposed_schema =
+                checkpoint_schema_at_commit(self.repository, proposed_checkpoint)?;
+            if winner_schema < crate::checkpoint::CHECKPOINT_SCHEMA_VERSION
+                && proposed_schema == crate::checkpoint::CHECKPOINT_SCHEMA_VERSION
+            {
+                advanced = true;
+            }
+        }
+        let source_checkpoint = proposed
+            .source
+            .refs
+            .get(crate::hub_v3::CHECKPOINT_REF)
+            .or_else(|| proposed.source.refs.get(crate::hub_v3::OLD_CHECKPOINT_REF));
+        if let Some(source_checkpoint) = source_checkpoint {
+            let source_schema =
+                checkpoint_schema_at_commit(self.repository, &source_checkpoint.oid)?;
+            let proposed_schema =
+                checkpoint_schema_at_commit(self.repository, proposed_checkpoint)?;
+            if source_schema < crate::checkpoint::CHECKPOINT_SCHEMA_VERSION
+                && proposed_schema == crate::checkpoint::CHECKPOINT_SCHEMA_VERSION
+                && is_ancestor(self.repository, &source_checkpoint.oid, proposed_checkpoint)?
+            {
+                advanced = true;
+            }
+        }
         for (name, winner_evidence) in &winner.source.refs {
             if !is_retired_source_ref(name) {
                 continue;
@@ -1932,11 +1976,15 @@ impl<'a, I: HistoricalImporter> RepositoryReconciler<'a, I> {
         if has_unrecorded_legacy_source(source, observed_format) {
             return Ok(false);
         }
-        if !matches!(observed_format.local_database, LocalDatabaseFormat::Missing) {
-            let observed = self.pin_source(observed_format.clone()).with_context(|| {
+        let observed = if matches!(observed_format.local_database, LocalDatabaseFormat::Missing) {
+            None
+        } else {
+            Some(self.pin_source(observed_format.clone()).with_context(|| {
                 format!("pinning observed repository format {observed_format:?}")
-            })?;
-            if observed.refs.contains_key("local/issues.db")
+            })?)
+        };
+        if let Some(current) = &observed {
+            if current.refs.contains_key("local/issues.db")
                 && !source.refs.contains_key("local/issues.db")
             {
                 return Ok(false);
@@ -1957,21 +2005,32 @@ impl<'a, I: HistoricalImporter> RepositoryReconciler<'a, I> {
                 return Ok(true);
             }
         }
-        let current = self.pin_source(source.format.clone())?;
+        let current = match observed {
+            Some(current) => current,
+            None => self.pin_source(observed_format.clone())?,
+        };
         let local_projection_consumed = source.refs.contains_key("local/issues.db")
             && !current.refs.contains_key("local/issues.db");
-        if current.format.shared_store != source.format.shared_store
+        let visible_v3_evolved = matches!(
+            (&source.format.shared_store, &current.format.shared_store),
+            (
+                SharedStoreFormat::VisibleV3 { .. },
+                SharedStoreFormat::VisibleV3 { .. }
+            )
+        );
+        if (!visible_v3_evolved && current.format.shared_store != source.format.shared_store)
             || (!local_projection_consumed
                 && (current.format.local_database != source.format.local_database
                     || current.local_fingerprint != source.local_fingerprint))
-            || current
-                .refs
-                .keys()
-                .filter(|name| name.as_str() != "local/issues.db")
-                .ne(source
+            || (!visible_v3_evolved
+                && current
                     .refs
                     .keys()
-                    .filter(|name| name.as_str() != "local/issues.db"))
+                    .filter(|name| name.as_str() != "local/issues.db")
+                    .ne(source
+                        .refs
+                        .keys()
+                        .filter(|name| name.as_str() != "local/issues.db")))
             || (!local_projection_consumed
                 && current.refs.contains_key("local/issues.db")
                     != source.refs.contains_key("local/issues.db"))
@@ -2003,6 +2062,27 @@ impl<'a, I: HistoricalImporter> RepositoryReconciler<'a, I> {
         }
         Ok(true)
     }
+}
+
+fn checkpoint_schema_at_commit(repository: &Path, commit: &str) -> Result<u32> {
+    let spec = format!("{commit}:state.json");
+    let output = Command::new("git")
+        .current_dir(repository)
+        .args(["cat-file", "blob", &spec])
+        .output()
+        .with_context(|| format!("reading checkpoint state at {commit}"))?;
+    anyhow::ensure!(
+        output.status.success(),
+        "checkpoint state at {commit} is unavailable: {}",
+        String::from_utf8_lossy(&output.stderr).trim()
+    );
+    let value: Value = serde_json::from_slice(&output.stdout)
+        .with_context(|| format!("checkpoint state at {commit} is invalid JSON"))?;
+    let version = value
+        .get("checkpoint_schema_version")
+        .and_then(Value::as_u64)
+        .unwrap_or(1);
+    u32::try_from(version).context("checkpoint schema version exceeds u32")
 }
 
 fn has_unrecorded_legacy_source(

--- a/crosslink/src/server/handlers/agents.rs
+++ b/crosslink/src/server/handlers/agents.rs
@@ -1070,10 +1070,7 @@ mod tests {
         } else {
             chrono::Utc::now() - chrono::Duration::minutes(120)
         };
-        let mut cp = crate::checkpoint::CheckpointState {
-            watermark: Some(crate::hub_v3::genesis_sentinel_watermark()),
-            ..Default::default()
-        };
+        let mut cp = crate::checkpoint::CheckpointState::default();
         cp.locks.insert(
             issue_id,
             crate::checkpoint::LockEntry {

--- a/crosslink/src/shared_writer/tests.rs
+++ b/crosslink/src/shared_writer/tests.rs
@@ -447,10 +447,8 @@ mod lock_v2_tests {
             agent_seq: 1,
         };
 
-        let mut state = CheckpointState {
-            watermark: Some(watermark),
-            ..CheckpointState::default()
-        };
+        let mut state = CheckpointState::default();
+        state.activate_legacy(Some(watermark));
         state.locks.insert(
             5,
             LockEntry {

--- a/crosslink/src/sync/cache.rs
+++ b/crosslink/src/sync/cache.rs
@@ -18,6 +18,35 @@ enum ReconciliationRemoteError {
     Rejected(String),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CheckpointAdoption {
+    AdoptRemote,
+    KeepLocal,
+    Recompute,
+}
+
+fn checkpoint_adoption(
+    local: &crate::checkpoint::CheckpointState,
+    remote: &crate::checkpoint::CheckpointState,
+) -> CheckpointAdoption {
+    match remote.frontier.relation(&local.frontier) {
+        crate::checkpoint::FrontierRelation::Dominates => CheckpointAdoption::AdoptRemote,
+        crate::checkpoint::FrontierRelation::Dominated => CheckpointAdoption::KeepLocal,
+        crate::checkpoint::FrontierRelation::Concurrent => CheckpointAdoption::Recompute,
+        crate::checkpoint::FrontierRelation::Equal => {
+            let equal = match (serde_json::to_value(local), serde_json::to_value(remote)) {
+                (Ok(local), Ok(remote)) => local == remote,
+                _ => false,
+            };
+            if equal {
+                CheckpointAdoption::KeepLocal
+            } else {
+                CheckpointAdoption::Recompute
+            }
+        }
+    }
+}
+
 impl std::fmt::Display for ReconciliationRemoteError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -555,7 +584,7 @@ impl SyncManager {
             }
         }
 
-        self.adopt_checkpoint_by_watermark();
+        self.adopt_checkpoint_by_frontier();
     }
 
     fn list_remote_agent_tips(&self) -> Result<Vec<(String, String)>> {
@@ -581,7 +610,7 @@ impl SyncManager {
         Ok(out)
     }
 
-    fn adopt_checkpoint_by_watermark(&self) {
+    fn adopt_checkpoint_by_frontier(&self) {
         let remote_tracking = "refs/crosslink-remote/checkpoint";
         let Some(remote_tip) =
             crate::hub_v3::git_rev_parse_optional(&self.cache_dir, remote_tracking)
@@ -590,36 +619,98 @@ impl SyncManager {
         else {
             return;
         };
-        let local_wm = self.checkpoint_watermark_count(crate::hub_v3::CHECKPOINT_REF);
-        let remote_wm = self.checkpoint_watermark_count(remote_tracking);
-        if remote_wm >= local_wm {
-            if let Err(e) =
-                self.git_in_cache(&["update-ref", crate::hub_v3::CHECKPOINT_REF, &remote_tip])
-            {
-                tracing::warn!("v3 fetch: failed to adopt remote checkpoint: {e}");
+        let remote = match self.verified_checkpoint(remote_tracking) {
+            Ok(Some(state)) if !state.is_legacy() => state,
+            Ok(Some(_)) => {
+                tracing::warn!("v3 fetch: remote checkpoint uses the legacy watermark schema");
+                return;
+            }
+            Ok(None) => return,
+            Err(error) => {
+                tracing::warn!("v3 fetch: rejected invalid remote checkpoint: {error:#}");
+                return;
+            }
+        };
+        let local = match self.verified_checkpoint(crate::hub_v3::CHECKPOINT_REF) {
+            Ok(Some(state)) if !state.is_legacy() => state,
+            Ok(Some(_)) => {
+                tracing::warn!(
+                    "v3 fetch: local checkpoint uses the legacy watermark schema and will be recomputed"
+                );
+                self.recompute_checkpoint_from_authority();
+                return;
+            }
+            Ok(None) => crate::checkpoint::CheckpointState::default(),
+            Err(error) => {
+                tracing::warn!(
+                    "v3 fetch: local checkpoint is invalid and will be recovered from pinned authority: {error:#}"
+                );
+                self.recompute_checkpoint_from_authority();
+                return;
+            }
+        };
+        match checkpoint_adoption(&local, &remote) {
+            CheckpointAdoption::AdoptRemote => {
+                if let Err(error) =
+                    self.git_in_cache(&["update-ref", crate::hub_v3::CHECKPOINT_REF, &remote_tip])
+                {
+                    tracing::warn!(
+                        "v3 fetch: failed to adopt causally dominant remote checkpoint: {error}"
+                    );
+                }
+            }
+            CheckpointAdoption::KeepLocal => {}
+            CheckpointAdoption::Recompute => {
+                self.recompute_checkpoint_from_authority();
             }
         }
     }
 
-    fn checkpoint_watermark_count(&self, ref_name: &str) -> i64 {
+    fn verified_checkpoint(
+        &self,
+        ref_name: &str,
+    ) -> Result<Option<crate::checkpoint::CheckpointState>> {
         let Some(tip) = crate::hub_v3::git_rev_parse_optional(&self.cache_dir, ref_name)
-            .ok()
-            .flatten()
+            .with_context(|| format!("reading checkpoint ref '{ref_name}'"))?
         else {
-            return -1;
+            return Ok(None);
         };
-        let spec = format!("{tip}:state.json");
-        let Some(bytes) = crate::hub_v3::git_cat_file_blob_optional(&self.cache_dir, &spec)
-            .ok()
-            .flatten()
-        else {
-            return 0;
+        let source = crate::hub_source::RefHubSource::at_checkpoint(&self.cache_dir, Some(tip))?;
+        let state = crate::hub_source::HubSource::read_checkpoint(&source)?;
+        crate::compaction::reduce(&source)?;
+        Ok(Some(state))
+    }
+
+    fn recompute_checkpoint_from_authority(&self) {
+        let source = match crate::hub_source::RefHubSource::at_checkpoint(&self.cache_dir, None) {
+            Ok(source) => source,
+            Err(error) => {
+                tracing::warn!("v3 fetch: could not pin authority for recomputation: {error:#}");
+                return;
+            }
         };
-        match crate::checkpoint::CheckpointState::from_slice(&bytes) {
-            Ok(state) => state
-                .watermark
-                .map_or(0, |w| i64::try_from(w.agent_seq).unwrap_or(i64::MAX)),
-            Err(_) => 0,
+        let state = match crate::compaction::rebuild_from_authority(&source) {
+            Ok(outcome) => outcome.state,
+            Err(error) => {
+                tracing::warn!("v3 fetch: authority recomputation failed: {error:#}");
+                return;
+            }
+        };
+        let bytes = match serde_json::to_vec_pretty(&state) {
+            Ok(bytes) => bytes,
+            Err(error) => {
+                tracing::warn!("v3 fetch: recomputed checkpoint serialization failed: {error}");
+                return;
+            }
+        };
+        if let Err(error) = crate::hub_v3::commit_blob_to_ref(
+            &self.cache_dir,
+            crate::hub_v3::CHECKPOINT_REF,
+            "state.json",
+            &bytes,
+            "crosslink v3 checkpoint (causal recompute)",
+        ) {
+            tracing::warn!("v3 fetch: authority recomputation publication failed: {error:#}");
         }
     }
 
@@ -691,6 +782,212 @@ mod tests {
     use super::*;
     use std::process::Command;
     use tempfile::tempdir;
+
+    fn checkpoint_with_sequences(sequences: &[(&str, u64)]) -> crate::checkpoint::CheckpointState {
+        let mut state = crate::checkpoint::CheckpointState::default();
+        for (agent, sequence) in sequences {
+            state.frontier.agents.insert(
+                (*agent).to_string(),
+                crate::checkpoint::AgentFrontier {
+                    sequence: *sequence,
+                    tip_oid: format!("{agent}-{sequence}"),
+                    prefix_sha256: format!("hash-{agent}-{sequence}"),
+                },
+            );
+        }
+        state
+    }
+
+    #[test]
+    fn phase2_causality_checkpoint_adoption_requires_dominance_and_recomputes_concurrency() {
+        let local = checkpoint_with_sequences(&[("a", 2), ("b", 1)]);
+        let dominant = checkpoint_with_sequences(&[("a", 2), ("b", 2)]);
+        let concurrent = checkpoint_with_sequences(&[("a", 1), ("b", 2)]);
+        assert_eq!(
+            checkpoint_adoption(&local, &dominant),
+            CheckpointAdoption::AdoptRemote
+        );
+        assert_eq!(
+            checkpoint_adoption(&dominant, &local),
+            CheckpointAdoption::KeepLocal
+        );
+        assert_eq!(
+            checkpoint_adoption(&local, &concurrent),
+            CheckpointAdoption::Recompute
+        );
+        assert_eq!(
+            checkpoint_adoption(&local, &local),
+            CheckpointAdoption::KeepLocal
+        );
+        let mut inconsistent = local.clone();
+        inconsistent.next_display_id += 1;
+        assert_eq!(
+            checkpoint_adoption(&local, &inconsistent),
+            CheckpointAdoption::Recompute
+        );
+    }
+
+    #[test]
+    fn phase2_causality_concurrent_remote_checkpoint_recomputes_union_without_losing_local_agent_history(
+    ) {
+        let root = initialize_repository();
+        let remote = tempdir().unwrap();
+        assert!(Command::new("git")
+            .current_dir(remote.path())
+            .args(["init", "--bare", "-b", "main"])
+            .status()
+            .unwrap()
+            .success());
+        assert!(Command::new("git")
+            .current_dir(root.path())
+            .args(["remote", "add", "origin", remote.path().to_str().unwrap()])
+            .status()
+            .unwrap()
+            .success());
+        assert!(Command::new("git")
+            .current_dir(root.path())
+            .args(["push", "-u", "origin", "main"])
+            .status()
+            .unwrap()
+            .success());
+        let crosslink = root.path().join(".crosslink");
+        crate::identity::AgentConfig::init(&crosslink, "agent-b", None).unwrap();
+        let sync = SyncManager::new(&crosslink).unwrap();
+        sync.init_cache().unwrap();
+        let cache = sync.cache_path();
+
+        let make_event = |agent: &str, sequence: u64| crate::events::EventEnvelope {
+            agent_id: agent.to_string(),
+            agent_seq: sequence,
+            timestamp: chrono::Utc::now(),
+            event: crate::events::Event::IssueCreated {
+                uuid: uuid::Uuid::new_v4(),
+                title: format!("{agent}-{sequence}"),
+                description: None,
+                priority: "medium".to_string(),
+                labels: Vec::new(),
+                parent_uuid: None,
+                created_by: agent.to_string(),
+                display_id: None,
+                scheduled_at: None,
+                due_at: None,
+            },
+            signed_by: None,
+            signature: None,
+        };
+        let log_bytes = |events: &[crate::events::EventEnvelope]| {
+            let dir = tempdir().unwrap();
+            let path = dir.path().join("events.log");
+            for event in events {
+                crate::events::append_event(&path, event).unwrap();
+            }
+            std::fs::read(path).unwrap()
+        };
+        let a1 = make_event("agent-a", 1);
+        let a2 = make_event("agent-a", 2);
+        let b1 = make_event("agent-b", 1);
+        let b2 = make_event("agent-b", 2);
+        let a1_tip = crate::hub_v3::commit_log_bytes(
+            cache,
+            "agent-a",
+            &log_bytes(std::slice::from_ref(&a1)),
+            "agent a sequence 1",
+        )
+        .unwrap();
+        let a2_tip = crate::hub_v3::commit_log_bytes(
+            cache,
+            "agent-a",
+            &log_bytes(&[a1, a2]),
+            "agent a sequence 2",
+        )
+        .unwrap();
+        let b1_tip = crate::hub_v3::commit_log_bytes(
+            cache,
+            "agent-b",
+            &log_bytes(std::slice::from_ref(&b1)),
+            "agent b sequence 1",
+        )
+        .unwrap();
+        let b2_tip = crate::hub_v3::commit_log_bytes(
+            cache,
+            "agent-b",
+            &log_bytes(&[b1, b2]),
+            "agent b sequence 2",
+        )
+        .unwrap();
+        let a_ref = format!("{}agent-a", crate::hub_v3::AGENT_REF_PREFIX);
+        assert!(Command::new("git")
+            .current_dir(cache)
+            .args(["update-ref", &a_ref, &a1_tip, &a2_tip])
+            .status()
+            .unwrap()
+            .success());
+
+        let local = crate::compaction::rebuild_from_authority(
+            &crate::hub_source::RefHubSource::at_checkpoint(cache, None).unwrap(),
+        )
+        .unwrap()
+        .state;
+        crate::hub_v3::commit_blob_to_ref(
+            cache,
+            crate::hub_v3::CHECKPOINT_REF,
+            "state.json",
+            &serde_json::to_vec_pretty(&local).unwrap(),
+            "local concurrent checkpoint",
+        )
+        .unwrap();
+
+        let remote_source = crate::hub_source::RefHubSource::at_tips(
+            cache,
+            None,
+            None,
+            vec![
+                ("agent-a".to_string(), a2_tip.clone()),
+                ("agent-b".to_string(), b1_tip.clone()),
+            ],
+        )
+        .unwrap();
+        let remote_state = crate::compaction::rebuild_from_authority(&remote_source)
+            .unwrap()
+            .state;
+        let remote_checkpoint = crate::hub_v3::commit_blob_to_ref(
+            cache,
+            "refs/crosslink/test/remote-checkpoint",
+            "state.json",
+            &serde_json::to_vec_pretty(&remote_state).unwrap(),
+            "remote concurrent checkpoint",
+        )
+        .unwrap();
+        for refspec in [
+            format!("{a2_tip}:refs/heads/crosslink/agents/agent-a"),
+            format!("{b1_tip}:refs/heads/crosslink/agents/agent-b"),
+            format!("{remote_checkpoint}:refs/heads/crosslink/checkpoint"),
+        ] {
+            assert!(Command::new("git")
+                .current_dir(cache)
+                .args(["push", "--force", "origin", &refspec])
+                .status()
+                .unwrap()
+                .success());
+        }
+
+        sync.fetch_and_adopt_v3_refs();
+        let state = crate::hub_source::HubSource::read_checkpoint(
+            &crate::hub_source::RefHubSource::new(cache).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(state.frontier.agents["agent-a"].sequence, 2);
+        assert_eq!(state.frontier.agents["agent-b"].sequence, 2);
+        assert_eq!(state.issues.len(), 4);
+        assert_eq!(
+            crate::hub_v3::git_rev_parse_optional(
+                cache,
+                &format!("{}agent-b", crate::hub_v3::AGENT_REF_PREFIX)
+            )
+            .unwrap(),
+            Some(b2_tip)
+        );
+    }
 
     fn initialize_repository() -> tempfile::TempDir {
         let root = tempdir().unwrap();

--- a/crosslink/tests/cli_integration.rs
+++ b/crosslink/tests/cli_integration.rs
@@ -143,17 +143,37 @@ fn init_crosslink_unready(dir: &std::path::Path) {
 }
 
 fn add_current_reconcile_refs(dir: &std::path::Path) {
-    for ref_name in [
-        "refs/heads/crosslink/meta",
-        "refs/heads/crosslink/checkpoint",
-    ] {
-        let output = Command::new("git")
-            .current_dir(dir)
-            .args(["update-ref", ref_name, "HEAD"])
-            .output()
-            .unwrap();
-        assert!(output.status.success());
-    }
+    let checkpoint = crosslink::checkpoint::CheckpointState::default();
+    crosslink::hub_v3::commit_blob_to_ref(
+        dir,
+        crosslink::hub_v3::CHECKPOINT_REF,
+        "state.json",
+        &serde_json::to_vec_pretty(&checkpoint).unwrap(),
+        "test checkpoint",
+    )
+    .unwrap();
+    let head = Command::new("git")
+        .current_dir(dir)
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .unwrap();
+    assert!(head.status.success());
+    let meta = crosslink::hub_v3::HubMeta {
+        hub_version: 3,
+        migrated_from_commit: String::from_utf8(head.stdout).unwrap().trim().to_string(),
+        migrated_at: chrono::Utc::now(),
+        finalized_at: None,
+        genesis_checkpoint_commit: None,
+        seed_agent_tips: None,
+    };
+    crosslink::hub_v3::commit_blob_to_ref(
+        dir,
+        crosslink::hub_v3::META_REF,
+        "hub.json",
+        &serde_json::to_vec_pretty(&meta).unwrap(),
+        "test hub metadata",
+    )
+    .unwrap();
 }
 
 #[test]

--- a/crosslink/tests/cli_integration.rs
+++ b/crosslink/tests/cli_integration.rs
@@ -2198,24 +2198,63 @@ fn test_stress_very_long_description() {
     assert!(stdout.contains("BBBB"));
 }
 
-#[test]
-fn test_stress_many_issues() {
+fn run_many_issues_partition(start: usize, count: usize) {
+    assert!(count > 0);
     let dir = test_dir();
     init_crosslink(dir.path());
 
-    for i in 0..100 {
+    for i in start..start + count {
         let title = format!("Issue number {i}");
         let (success, _, stderr) = run_crosslink(dir.path(), &["create", &title]);
         assert!(success, "Failed to create issue {i}: {stderr}");
     }
 
+    let last = start + count - 1;
     let (success, stdout, _) = run_crosslink(dir.path(), &["list"]);
     assert!(success);
-    assert!(stdout.contains("Issue number 99"));
+    assert!(stdout.contains(&format!("Issue number {last}")));
 
-    let (success, stdout, _) = run_crosslink(dir.path(), &["issue", "search", "number 50"]);
+    let midpoint = start + count / 2;
+    let query = format!("number {midpoint}");
+    let (success, stdout, _) = run_crosslink(dir.path(), &["issue", "search", &query]);
     assert!(success);
-    assert!(stdout.contains("50"));
+    assert!(stdout.contains(&midpoint.to_string()));
+}
+
+#[cfg(not(windows))]
+#[test]
+fn test_stress_many_issues() {
+    run_many_issues_partition(0, 100);
+}
+
+#[cfg(windows)]
+#[test]
+fn test_stress_many_issues_000_019() {
+    run_many_issues_partition(0, 20);
+}
+
+#[cfg(windows)]
+#[test]
+fn test_stress_many_issues_020_039() {
+    run_many_issues_partition(20, 20);
+}
+
+#[cfg(windows)]
+#[test]
+fn test_stress_many_issues_040_059() {
+    run_many_issues_partition(40, 20);
+}
+
+#[cfg(windows)]
+#[test]
+fn test_stress_many_issues_060_079() {
+    run_many_issues_partition(60, 20);
+}
+
+#[cfg(windows)]
+#[test]
+fn test_stress_many_issues_080_099() {
+    run_many_issues_partition(80, 20);
 }
 
 #[test]
@@ -2378,16 +2417,16 @@ fn test_edge_large_ids() {
     assert!(!success, "Show with negative ID should fail");
 }
 
-#[test]
-fn test_stress_rapid_operations() {
+fn run_rapid_operations_partition(start: usize, count: usize) {
+    assert!(count > 0);
     let dir = test_dir();
     init_crosslink(dir.path());
 
-    for i in 0..20 {
+    for (offset, i) in (start..start + count).enumerate() {
         let title = format!("Rapid issue {i}");
         let (success, _, stderr) = run_crosslink(dir.path(), &["create", &title]);
         assert!(success, "Failed to create rapid issue {i}: {stderr}");
-        let id = (i + 1).to_string();
+        let id = (offset + 1).to_string();
         let (success, _, stderr) = run_crosslink(dir.path(), &["close", &id]);
         assert!(success, "Failed to close rapid issue {i}: {stderr}");
         let (success, _, stderr) = run_crosslink(dir.path(), &["issue", "reopen", &id]);
@@ -2399,9 +2438,46 @@ fn test_stress_rapid_operations() {
         assert!(success, "Failed to label rapid issue {i}: {stderr}");
     }
 
+    let last = start + count - 1;
     let (success, stdout, _) = run_crosslink(dir.path(), &["list"]);
     assert!(success);
-    assert!(stdout.contains("Rapid issue 19"));
+    assert!(stdout.contains(&format!("Rapid issue {last}")));
+}
+
+#[cfg(not(windows))]
+#[test]
+fn test_stress_rapid_operations() {
+    run_rapid_operations_partition(0, 20);
+}
+
+#[cfg(windows)]
+#[test]
+fn test_stress_rapid_operations_000_003() {
+    run_rapid_operations_partition(0, 4);
+}
+
+#[cfg(windows)]
+#[test]
+fn test_stress_rapid_operations_004_007() {
+    run_rapid_operations_partition(4, 4);
+}
+
+#[cfg(windows)]
+#[test]
+fn test_stress_rapid_operations_008_011() {
+    run_rapid_operations_partition(8, 4);
+}
+
+#[cfg(windows)]
+#[test]
+fn test_stress_rapid_operations_012_015() {
+    run_rapid_operations_partition(12, 4);
+}
+
+#[cfg(windows)]
+#[test]
+fn test_stress_rapid_operations_016_019() {
+    run_rapid_operations_partition(16, 4);
 }
 
 #[test]

--- a/crosslink/tests/fixtures/reconcile/checkpoint/v1-global-watermark.json
+++ b/crosslink/tests/fixtures/reconcile/checkpoint/v1-global-watermark.json
@@ -1,0 +1,12 @@
+{
+  "next_display_id": 1,
+  "next_comment_id": 1,
+  "display_id_map": {},
+  "locks": {},
+  "issues": {},
+  "watermark": {
+    "timestamp": "2026-01-01T00:00:00Z",
+    "agent_id": "legacy-agent",
+    "agent_seq": 4
+  }
+}

--- a/crosslink/tests/fixtures/reconcile/checkpoint/v2-causal-frontier.json
+++ b/crosslink/tests/fixtures/reconcile/checkpoint/v2-causal-frontier.json
@@ -1,0 +1,14 @@
+{
+  "checkpoint_schema_version": 2,
+  "frontier": {
+    "agents": {}
+  },
+  "next_display_id": 1,
+  "next_comment_id": 1,
+  "display_id_map": {},
+  "locks": {},
+  "issues": {},
+  "watermark": {
+    "unsupported_checkpoint_schema": 2
+  }
+}

--- a/crosslink/tests/fixtures/reconcile/checkpoint/v2-forged-guard.json
+++ b/crosslink/tests/fixtures/reconcile/checkpoint/v2-forged-guard.json
@@ -1,0 +1,11 @@
+{
+  "checkpoint_schema_version": 2,
+  "next_display_id": 1,
+  "next_comment_id": 1,
+  "display_id_map": {},
+  "locks": {},
+  "issues": {},
+  "watermark": {
+    "unsupported_checkpoint_schema": 1
+  }
+}

--- a/crosslink/tests/fixtures/reconcile/checkpoint/v3-future.json
+++ b/crosslink/tests/fixtures/reconcile/checkpoint/v3-future.json
@@ -1,0 +1,11 @@
+{
+  "checkpoint_schema_version": 3,
+  "next_display_id": 1,
+  "next_comment_id": 1,
+  "display_id_map": {},
+  "locks": {},
+  "issues": {},
+  "watermark": {
+    "unsupported_checkpoint_schema": 3
+  }
+}

--- a/crosslink/tests/fixtures/reconcile/manifest.json
+++ b/crosslink/tests/fixtures/reconcile/manifest.json
@@ -21,6 +21,12 @@
     { "file": "sqlite/v17.sql", "version": 17, "source": "728ad5ff" },
     { "file": "sqlite/v18.sql", "version": 18, "source": "dd0b7173" }
   ],
+  "checkpoint": [
+    { "file": "checkpoint/v1-global-watermark.json", "version": 1, "valid": true },
+    { "file": "checkpoint/v2-causal-frontier.json", "version": 2, "valid": true },
+    { "file": "checkpoint/v2-forged-guard.json", "version": 2, "valid": false },
+    { "file": "checkpoint/v3-future.json", "version": 3, "valid": false }
+  ],
   "git": [
     { "file": "git/absent.refs", "expected_kind": "absent" },
     { "file": "git/legacy-locks.refs", "expected_kind": "legacy_locks" },

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -156,7 +156,7 @@ refs/heads/crosslink/agents/{agent-id}
   └─ events.log          ← one append-only stream per writer
 
 refs/heads/crosslink/checkpoint
-  └─ state.json          ← reduced projection state
+  └─ state.json          ← versioned reduced state plus per-agent causal frontier
 
 refs/heads/crosslink/meta
   └─ trust and format metadata
@@ -167,6 +167,15 @@ crosslink/knowledge      ← shared research (orphan branch)
   └─ pages/
       └─ {slug}.md       ← knowledge pages with YAML frontmatter
 ```
+
+Each causal-frontier entry records the highest contiguous sequence applied for
+one agent, the pinned Git tip that proves the prefix, and a digest of the event
+prefix. Reduction selects unseen events independently per agent before applying
+the deterministic total order used for conflict resolution. Checkpoints are
+adopted only when a verified frontier dominates the local frontier; concurrent
+frontiers are recomputed from pinned authority. Daemon reconciliation upgrades
+legacy global-watermark checkpoints from their recorded genesis snapshot and
+complete agent histories before publishing the replacement schema.
 
 ## Command Modules (src/commands/)
 


### PR DESCRIPTION
## Summary
- replace the global checkpoint watermark with a versioned per-agent causal frontier
- validate contiguous histories, pinned tips, prefix hashes, and checkpoint semantics
- adopt only causally dominant checkpoints and recompute concurrent authority
- automatically migrate legacy checkpoints during daemon reconciliation while preserving eventless records and recovery evidence
- update dashboard readers, reconciliation fixtures, architecture documentation, and bounded cross-platform CI coverage

## Verification
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo clippy --locked -- -D warnings -W clippy::unwrap_used -W clippy::expect_used
- cargo test --all-features --quiet: 5,460 executed tests passed; 4 intentionally ignored
- cargo test --doc --all-features
- cargo build --release --all-features
- cargo check --locked --target x86_64-pc-windows-gnu --all-targets --all-features
- python3 scripts/sync-codex-plugin.py --check
- feature-branch CI run 33823538068 passed

Closes #798