### PR TITLE
fix(reconcile): recover interrupted SQLite and legacy histories

### DIFF
--- a/crosslink/src/compaction.rs
+++ b/crosslink/src/compaction.rs
@@ -221,6 +221,18 @@ pub fn reduce(source: &dyn HubSource) -> Result<ReductionOutcome> {
     })
 }
 
+pub(crate) fn reduce_legacy_compatible(source: &dyn HubSource) -> Result<ReductionOutcome> {
+    let state = source.read_checkpoint()?;
+    state.validate_schema()?;
+    anyhow::ensure!(
+        state.is_legacy(),
+        "legacy-compatible reduction requires a schema-1 checkpoint"
+    );
+    let external_watermark = source.read_legacy_watermark()?;
+    let watermark = state.legacy_watermark().cloned().or(external_watermark);
+    reduce_legacy_snapshot(source, state, watermark.as_ref())
+}
+
 pub fn rebuild_from_authority(source: &dyn HubSource) -> Result<ReductionOutcome> {
     let histories = validated_histories(source)?;
     let mut state = if let Some(baseline) = source.read_authority_baseline()? {
@@ -381,10 +393,10 @@ fn validate_frontier(
             "frontier for agent '{agent_id}' contains a non-canonical zero sequence"
         );
         anyhow::ensure!(
-            entry.sequence <= history.events.len() as u64,
+            entry.sequence <= history.last_sequence(),
             "frontier for agent '{agent_id}' claims sequence {} but pinned history ends at {}",
             entry.sequence,
-            history.events.len()
+            history.last_sequence()
         );
         anyhow::ensure!(
             source.tip_contains(agent_id, &entry.tip_oid)?,
@@ -414,7 +426,7 @@ fn frontier_for_histories(
 ) -> Result<CausalFrontier> {
     let mut agents = BTreeMap::new();
     for (agent_id, history) in histories {
-        let sequence = history.events.len() as u64;
+        let sequence = history.last_sequence();
         if sequence == 0 {
             continue;
         }

--- a/crosslink/src/db/core.rs
+++ b/crosslink/src/db/core.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use rusqlite::{Connection, Transaction};
+use rusqlite::{Connection, OpenFlags, Transaction};
 use std::path::Path;
 
 pub const SCHEMA_VERSION: i32 = 18;
@@ -80,6 +80,30 @@ impl Database {
             "database schema version {version} is newer than supported version {SCHEMA_VERSION}"
         );
         Ok(db)
+    }
+
+    pub(crate) fn recover_interrupted_transaction(path: &Path) -> Result<()> {
+        if !path.is_file() || !rollback_journal_path(path).is_file() {
+            return Ok(());
+        }
+        let connection = Connection::open_with_flags(
+            path,
+            OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        )
+        .with_context(|| {
+            format!(
+                "failed to recover interrupted SQLite transaction in {}",
+                path.display()
+            )
+        })?;
+        let quick_check: String = connection
+            .query_row("PRAGMA quick_check(1)", [], |row| row.get(0))
+            .context("failed to verify SQLite database after transaction recovery")?;
+        anyhow::ensure!(
+            quick_check == "ok",
+            "SQLite quick_check reported {quick_check} after transaction recovery"
+        );
+        Ok(())
     }
 
     pub(crate) fn open_without_migrations(path: &Path) -> Result<Self> {
@@ -527,4 +551,10 @@ impl Database {
             .query_row("PRAGMA user_version", [], |row| row.get(0))?;
         Ok(version)
     }
+}
+
+fn rollback_journal_path(path: &Path) -> std::path::PathBuf {
+    let mut value = path.as_os_str().to_os_string();
+    value.push("-journal");
+    value.into()
 }

--- a/crosslink/src/hub_source.rs
+++ b/crosslink/src/hub_source.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::{Arc, Mutex};
 
 use crate::checkpoint::{
     event_prefix_sha256, read_checkpoint, read_watermark, AgentFrontier, CausalFrontier,
@@ -65,6 +66,14 @@ pub struct AuthorityBaseline {
     pub frontier: CausalFrontier,
 }
 
+type RefHistoryKey = (PathBuf, String, String);
+type RefHistoryMap = BTreeMap<RefHistoryKey, AgentHistory>;
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct RefHistoryCache {
+    histories: Arc<Mutex<RefHistoryMap>>,
+}
+
 #[derive(serde::Deserialize)]
 struct AuthorityBaselineMeta {
     #[serde(default)]
@@ -76,8 +85,10 @@ struct AuthorityBaselineMeta {
 impl AgentHistory {
     pub fn validate(&mut self) -> Result<()> {
         self.events.sort_by_key(|event| event.agent_seq);
-        for (index, event) in self.events.iter().enumerate() {
-            let expected = index as u64 + 1;
+        let mut normalized = Vec::with_capacity(self.events.len());
+        let mut previous_sequence = None;
+        let mut encodings = std::collections::BTreeSet::new();
+        for event in self.events.drain(..) {
             anyhow::ensure!(
                 event.agent_id == self.agent_id,
                 "agent '{}' history contains an event owned by '{}' at sequence {}",
@@ -85,14 +96,33 @@ impl AgentHistory {
                 event.agent_id,
                 event.agent_seq
             );
-            anyhow::ensure!(
-                event.agent_seq == expected,
-                "agent '{}' history is not a contiguous prefix: expected sequence {expected}, found {}",
-                self.agent_id,
-                event.agent_seq
-            );
+            if previous_sequence != Some(event.agent_seq) {
+                let expected = previous_sequence.map_or(1, |sequence| sequence + 1);
+                anyhow::ensure!(
+                    event.agent_seq == expected,
+                    "agent '{}' history is not a contiguous prefix: expected sequence {expected}, found {}",
+                    self.agent_id,
+                    event.agent_seq
+                );
+                previous_sequence = Some(event.agent_seq);
+                encodings.clear();
+            }
+            let encoded = serde_json::to_vec(&event)
+                .context("failed to encode event while validating agent history")?;
+            if encodings.insert(encoded) {
+                normalized.push(event);
+            }
         }
+        self.events = normalized;
         Ok(())
+    }
+
+    pub(crate) fn last_sequence(&self) -> u64 {
+        self.events
+            .iter()
+            .map(|event| event.agent_seq)
+            .max()
+            .unwrap_or(0)
     }
 }
 
@@ -373,6 +403,8 @@ pub struct RefHubSource {
     _allowed_signers_dir: Option<tempfile::TempDir>,
 
     allowed_signers_path: Option<PathBuf>,
+
+    history_cache: RefHistoryCache,
 }
 
 #[allow(dead_code)]
@@ -405,6 +437,7 @@ impl RefHubSource {
             agent_tips,
             _allowed_signers_dir: allowed_signers_dir,
             allowed_signers_path,
+            history_cache: RefHistoryCache::default(),
         })
     }
 
@@ -413,6 +446,22 @@ impl RefHubSource {
         checkpoint_sha: Option<String>,
         meta_sha: Option<String>,
         agent_tips: Vec<(String, String)>,
+    ) -> Result<Self> {
+        Self::at_tips_cached(
+            repo_dir,
+            checkpoint_sha,
+            meta_sha,
+            agent_tips,
+            RefHistoryCache::default(),
+        )
+    }
+
+    pub(crate) fn at_tips_cached(
+        repo_dir: &Path,
+        checkpoint_sha: Option<String>,
+        meta_sha: Option<String>,
+        agent_tips: Vec<(String, String)>,
+        history_cache: RefHistoryCache,
     ) -> Result<Self> {
         let (allowed_signers_dir, allowed_signers_path) = match &meta_sha {
             Some(sha) => extract_meta_allowed_signers(repo_dir, sha)?,
@@ -425,6 +474,7 @@ impl RefHubSource {
             agent_tips,
             _allowed_signers_dir: allowed_signers_dir,
             allowed_signers_path,
+            history_cache,
         })
     }
 
@@ -512,40 +562,29 @@ impl HubSource for RefHubSource {
         let Some((_, tip)) = self.agent_tips.iter().find(|(id, _)| id == agent_id) else {
             anyhow::bail!("agent ref for '{agent_id}' is missing from the pinned authority");
         };
-        let commits = git_first_parent_history(&self.repo_path, tip)?;
-        let mut by_sequence: BTreeMap<u64, (Vec<u8>, EventEnvelope)> = BTreeMap::new();
-        for commit in commits {
-            let Some(bytes) = git_cat_file_blob(&self.repo_path, &commit, "events.log")? else {
-                continue;
-            };
-            let events = read_events_from_bytes(&bytes).with_context(|| {
-                format!("failed to parse agent '{agent_id}' history at pinned commit {commit}")
-            })?;
-            let mut seen = std::collections::BTreeSet::new();
-            for event in events {
-                anyhow::ensure!(
-                    seen.insert(event.agent_seq),
-                    "agent '{agent_id}' history repeats sequence {} in pinned commit {commit}",
-                    event.agent_seq
-                );
-                let encoded = serde_json::to_vec(&event)
-                    .context("failed to encode event while validating agent history")?;
-                if let Some((existing, _)) = by_sequence.get(&event.agent_seq) {
-                    anyhow::ensure!(
-                        *existing == encoded,
-                        "agent '{agent_id}' history rewrites sequence {} between pinned commits",
-                        event.agent_seq
-                    );
-                } else {
-                    by_sequence.insert(event.agent_seq, (encoded, event));
-                }
-            }
+        let key = (self.repo_path.clone(), agent_id.to_string(), tip.clone());
+        let cached = {
+            let histories = self
+                .history_cache
+                .histories
+                .lock()
+                .map_err(|_| anyhow::anyhow!("agent history cache lock was poisoned"))?;
+            histories.get(&key).cloned()
+        };
+        if let Some(history) = cached {
+            return Ok(history);
         }
-        Ok(AgentHistory {
+        let history = AgentHistory {
             agent_id: agent_id.to_string(),
             tip_oid: tip.clone(),
-            events: by_sequence.into_values().map(|(_, event)| event).collect(),
-        })
+            events: read_git_event_history(&self.repo_path, tip, agent_id)?,
+        };
+        self.history_cache
+            .histories
+            .lock()
+            .map_err(|_| anyhow::anyhow!("agent history cache lock was poisoned"))?
+            .insert(key, history.clone());
+        Ok(history)
     }
 
     fn tip_contains(&self, agent_id: &str, claimed_tip: &str) -> Result<bool> {
@@ -575,11 +614,12 @@ impl HubSource for RefHubSource {
                 "pinned hub metadata must record both genesis_checkpoint_commit and seed_agent_tips"
             ),
         };
-        let seed = Self::at_tips(
+        let seed = Self::at_tips_cached(
             &self.repo_path,
             Some(checkpoint),
             Some(meta_sha.clone()),
             tips.into_iter().collect(),
+            self.history_cache.clone(),
         )?;
         let mut state = seed.read_checkpoint()?;
         let mut agents = BTreeMap::new();
@@ -591,7 +631,7 @@ impl HubSource for RefHubSource {
                 "pinned authority baseline tip {} for agent '{agent_id}' is not a prefix of the current authority",
                 history.tip_oid
             );
-            let sequence = history.events.len() as u64;
+            let sequence = history.last_sequence();
             if sequence == 0 {
                 continue;
             }
@@ -610,10 +650,18 @@ impl HubSource for RefHubSource {
     }
 }
 
+#[cfg(test)]
 fn git_first_parent_history(repo_path: &Path, tip: &str) -> Result<Vec<String>> {
     let output = Command::new("git")
         .current_dir(repo_path)
-        .args(["rev-list", "--first-parent", "--reverse", tip])
+        .args([
+            "rev-list",
+            "--first-parent",
+            "--reverse",
+            tip,
+            "--",
+            "events.log",
+        ])
         .output()
         .with_context(|| format!("failed to enumerate pinned agent history at {tip}"))?;
     if !output.status.success() {
@@ -628,6 +676,131 @@ fn git_first_parent_history(repo_path: &Path, tip: &str) -> Result<Vec<String>> 
         .filter(|line| !line.is_empty())
         .map(str::to_string)
         .collect())
+}
+
+fn read_git_event_history(
+    repo_path: &Path,
+    tip: &str,
+    agent_id: &str,
+) -> Result<Vec<EventEnvelope>> {
+    let output = Command::new("git")
+        .current_dir(repo_path)
+        .args([
+            "log",
+            "--first-parent",
+            "--reverse",
+            "--diff-merges=first-parent",
+            "--format=commit:%H",
+            "--patch",
+            "--unified=0",
+            "--no-color",
+            "--no-ext-diff",
+            "--no-renames",
+            tip,
+            "--",
+            "events.log",
+        ])
+        .output()
+        .with_context(|| format!("reading Git event history for agent '{agent_id}'"))?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "failed to read Git event history for agent '{agent_id}': {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    let mut commit = None::<String>;
+    let mut removed = BTreeMap::<u64, Vec<Vec<u8>>>::new();
+    let mut added = BTreeMap::<u64, Vec<(Vec<u8>, EventEnvelope)>>::new();
+    let mut history = BTreeMap::<u64, Vec<(Vec<u8>, EventEnvelope)>>::new();
+    for line in String::from_utf8_lossy(&output.stdout).lines() {
+        if let Some(oid) = line.strip_prefix("commit:") {
+            apply_event_delta(
+                agent_id,
+                commit.as_deref(),
+                &mut history,
+                &mut removed,
+                &mut added,
+            )?;
+            commit = Some(oid.to_string());
+            continue;
+        }
+        if line.starts_with("Binary files ") {
+            anyhow::bail!(
+                "agent '{agent_id}' history became binary at pinned commit {}",
+                commit.as_deref().unwrap_or("unknown")
+            );
+        }
+        if line.starts_with("+++ ") || line.starts_with("--- ") {
+            continue;
+        }
+        if let Some(content) = line.strip_prefix('+') {
+            let (encoded, event) = decode_delta_event(content, agent_id, commit.as_deref())?;
+            added
+                .entry(event.agent_seq)
+                .or_default()
+                .push((encoded, event));
+        } else if let Some(content) = line.strip_prefix('-') {
+            let (encoded, event) = decode_delta_event(content, agent_id, commit.as_deref())?;
+            removed.entry(event.agent_seq).or_default().push(encoded);
+        }
+    }
+    apply_event_delta(
+        agent_id,
+        commit.as_deref(),
+        &mut history,
+        &mut removed,
+        &mut added,
+    )?;
+    Ok(history
+        .into_values()
+        .flatten()
+        .map(|(_, event)| event)
+        .collect())
+}
+
+fn decode_delta_event(
+    content: &str,
+    agent_id: &str,
+    commit: Option<&str>,
+) -> Result<(Vec<u8>, EventEnvelope)> {
+    let event: EventEnvelope = serde_json::from_str(content).with_context(|| {
+        format!(
+            "failed to parse agent '{agent_id}' history delta at pinned commit {}",
+            commit.unwrap_or("unknown")
+        )
+    })?;
+    let encoded = serde_json::to_vec(&event)
+        .context("failed to encode event while validating agent history")?;
+    Ok((encoded, event))
+}
+
+fn apply_event_delta(
+    agent_id: &str,
+    commit: Option<&str>,
+    history: &mut BTreeMap<u64, Vec<(Vec<u8>, EventEnvelope)>>,
+    removed: &mut BTreeMap<u64, Vec<Vec<u8>>>,
+    added: &mut BTreeMap<u64, Vec<(Vec<u8>, EventEnvelope)>>,
+) -> Result<()> {
+    let commit = commit.unwrap_or("unknown");
+    for (sequence, additions) in std::mem::take(added) {
+        let existing = history.entry(sequence).or_default();
+        let new = additions
+            .into_iter()
+            .filter(|(encoding, _)| !existing.iter().any(|(prior, _)| prior == encoding))
+            .collect::<Vec<_>>();
+        let removed_existing = removed.get(&sequence).is_some_and(|deletions| {
+            deletions
+                .iter()
+                .any(|encoding| existing.iter().any(|(prior, _)| prior == encoding))
+        });
+        anyhow::ensure!(
+            new.is_empty() || !removed_existing,
+            "agent '{agent_id}' history rewrites sequence {sequence} at pinned commit {commit}"
+        );
+        existing.extend(new);
+    }
+    removed.clear();
+    Ok(())
 }
 
 fn git_is_ancestor(repo_path: &Path, ancestor: &str, descendant: &str) -> Result<bool> {
@@ -1061,6 +1234,169 @@ mod tests {
             crate::compaction::reduce(&RefHubSource::new(repo.path()).unwrap()).unwrap_err();
         let message = format!("{error:#}");
         assert!(message.contains("rewrites sequence 1"), "{message}");
+    }
+
+    #[test]
+    fn phase2_causality_preserves_distinct_legacy_sequence_collisions() {
+        let repo = tempfile::tempdir().unwrap();
+        ref_repo_init(repo.path());
+        let first_id = Uuid::new_v4();
+        let second_id = Uuid::new_v4();
+        let third_id = Uuid::new_v4();
+        let first = make_issue_created("agent-a", 1, first_id);
+        let second = make_issue_created("agent-a", 1, second_id);
+        let third = make_issue_created("agent-a", 2, third_id);
+        crate::hub_v3::commit_log_bytes(
+            repo.path(),
+            "agent-a",
+            &log_bytes(std::slice::from_ref(&first)),
+            "first",
+        )
+        .unwrap();
+        crate::hub_v3::commit_log_bytes(
+            repo.path(),
+            "agent-a",
+            &log_bytes(&[first.clone(), second.clone()]),
+            "collision",
+        )
+        .unwrap();
+        crate::hub_v3::commit_log_bytes(
+            repo.path(),
+            "agent-a",
+            &log_bytes(&[first.clone(), second.clone(), third.clone()]),
+            "advance",
+        )
+        .unwrap();
+
+        let outcome = crate::compaction::reduce(&RefHubSource::new(repo.path()).unwrap()).unwrap();
+        assert_eq!(outcome.events_processed, 3);
+        assert!(outcome.state.issues.contains_key(&first_id));
+        assert!(outcome.state.issues.contains_key(&second_id));
+        assert!(outcome.state.issues.contains_key(&third_id));
+        let frontier = &outcome.state.frontier.agents["agent-a"];
+        assert_eq!(frontier.sequence, 2);
+        assert_eq!(
+            frontier.prefix_sha256,
+            event_prefix_sha256(&[first, second, third], 2).unwrap()
+        );
+
+        let bytes = serde_json::to_vec_pretty(&outcome.state).unwrap();
+        crate::hub_v3::commit_blob_to_ref(
+            repo.path(),
+            crate::hub_v3::CHECKPOINT_REF,
+            "state.json",
+            &bytes,
+            "causal checkpoint",
+        )
+        .unwrap();
+        let repeated = crate::compaction::reduce(&RefHubSource::new(repo.path()).unwrap()).unwrap();
+        assert_eq!(repeated.events_processed, 0);
+    }
+
+    #[test]
+    fn phase2_causality_git_deltas_preserve_pruned_history() {
+        let repo = tempfile::tempdir().unwrap();
+        ref_repo_init(repo.path());
+        let first = make_issue_created("agent-a", 1, Uuid::new_v4());
+        let second = make_issue_created("agent-a", 2, Uuid::new_v4());
+        let third = make_issue_created("agent-a", 3, Uuid::new_v4());
+        crate::hub_v3::commit_log_bytes(
+            repo.path(),
+            "agent-a",
+            &log_bytes(&[first.clone(), second.clone()]),
+            "initial",
+        )
+        .unwrap();
+        crate::hub_v3::commit_log_bytes(
+            repo.path(),
+            "agent-a",
+            &log_bytes(std::slice::from_ref(&second)),
+            "prune",
+        )
+        .unwrap();
+        crate::hub_v3::commit_log_bytes(
+            repo.path(),
+            "agent-a",
+            &log_bytes(&[second, third]),
+            "append",
+        )
+        .unwrap();
+
+        let mut history = RefHubSource::new(repo.path())
+            .unwrap()
+            .read_agent_history("agent-a")
+            .unwrap();
+        history.validate().unwrap();
+        assert_eq!(history.events.len(), 3);
+        assert_eq!(history.last_sequence(), 3);
+        assert_eq!(history.events[0].agent_seq, first.agent_seq);
+    }
+
+    #[test]
+    fn complete_history_skips_heartbeat_only_commits() {
+        let repo = tempfile::tempdir().unwrap();
+        ref_repo_init(repo.path());
+        let event = make_issue_created("agent-a", 1, Uuid::new_v4());
+        crate::hub_v3::commit_log_bytes(
+            repo.path(),
+            "agent-a",
+            &log_bytes(std::slice::from_ref(&event)),
+            "event",
+        )
+        .unwrap();
+        let heartbeat = crate::locks::Heartbeat {
+            agent_id: "agent-a".to_string(),
+            last_heartbeat: Utc::now(),
+            active_issue_id: None,
+            machine_id: "test-machine".to_string(),
+        };
+        crate::hub_v3::write_heartbeat_to_ref(repo.path(), "agent-a", &heartbeat).unwrap();
+        crate::hub_v3::write_heartbeat_to_ref(repo.path(), "agent-a", &heartbeat).unwrap();
+        let tip = git_rev_parse(
+            repo.path(),
+            &format!("{}agent-a", crate::hub_v3::AGENT_REF_PREFIX),
+        )
+        .unwrap();
+
+        assert_eq!(
+            git_first_parent_history(repo.path(), &tip).unwrap().len(),
+            1
+        );
+        let mut history = RefHubSource::new(repo.path())
+            .unwrap()
+            .read_agent_history("agent-a")
+            .unwrap();
+        history.validate().unwrap();
+        assert_eq!(history.events.len(), 1);
+        assert_eq!(history.events[0].agent_seq, 1);
+    }
+
+    #[test]
+    fn phase2_causality_rejects_sequence_collision_after_checkpoint() {
+        let repo = tempfile::tempdir().unwrap();
+        ref_repo_init(repo.path());
+        let first = make_issue_created("agent-a", 1, Uuid::new_v4());
+        crate::hub_v3::commit_log_bytes(
+            repo.path(),
+            "agent-a",
+            &log_bytes(std::slice::from_ref(&first)),
+            "first",
+        )
+        .unwrap();
+        commit_reduced_checkpoint(repo.path());
+        let collision = make_issue_created("agent-a", 1, Uuid::new_v4());
+        crate::hub_v3::commit_log_bytes(
+            repo.path(),
+            "agent-a",
+            &log_bytes(&[first, collision]),
+            "collision",
+        )
+        .unwrap();
+
+        let error =
+            crate::compaction::reduce(&RefHubSource::new(repo.path()).unwrap()).unwrap_err();
+        let message = format!("{error:#}");
+        assert!(message.contains("forged or rewritten"), "{message}");
     }
 
     #[test]

--- a/crosslink/src/reconcile/migration.rs
+++ b/crosslink/src/reconcile/migration.rs
@@ -14,7 +14,7 @@ use crate::checkpoint::{
     CheckpointState, CompactComment, CompactIssue, CompactMilestone, CompactTimeEntry,
 };
 use crate::compaction;
-use crate::hub_source::{HubSource, RefHubSource};
+use crate::hub_source::{HubSource, RefHistoryCache, RefHubSource};
 use crate::hub_v3::{self, HubMeta, CHECKPOINT_REF, META_REF};
 use crate::issue_file::{
     read_all_issue_files, read_all_milestone_files, read_comment_files, read_counters, IssueFile,
@@ -41,6 +41,7 @@ pub enum RepositoryActivation {
 }
 
 pub fn activate_repository(crosslink_dir: &Path) -> Result<RepositoryActivation> {
+    crate::db::Database::recover_interrupted_transaction(&crosslink_dir.join("issues.db"))?;
     let sync = SyncManager::new(crosslink_dir)?;
     match sync.init_cache_for_reconciliation() {
         crate::sync::ReconciliationCacheOutcome::Ready => {}
@@ -252,6 +253,7 @@ struct MigrationImporter<'a> {
     cache_dir: &'a Path,
     hub_lock: &'a crate::sync::HubWriteLock,
     agent_id: String,
+    history_cache: RefHistoryCache,
 }
 
 impl MigrationImporter<'_> {
@@ -462,7 +464,7 @@ impl HistoricalImporter for MigrationImporter<'_> {
         let database = self.crosslink_dir.join("issues.db");
         if database.is_file() && has_complete_v3_source(source) {
             let targets = direct_v3_targets(source)?;
-            let current = reduce_v3_state(self.cache_dir, &targets)?;
+            let current = reduce_v3_state(self.cache_dir, &targets, &self.history_cache)?;
             let (_workspace, snapshot) = logical_sqlite_snapshot(&database, "issues.db")?;
             let local = build_genesis_from_database(&snapshot, &self.agent_id)?;
             let requires_import = merge_local_database_projection(&current, &local).1;
@@ -519,7 +521,7 @@ impl HistoricalImporter for MigrationImporter<'_> {
                 let semantic = self.read_target_semantic(repository, &current_targets)?;
                 return Ok(PreparedImport::new(current_targets, semantic));
             }
-            let state = reduce_v3_state(repository, &current_targets)?;
+            let state = reduce_v3_state(repository, &current_targets, &self.history_cache)?;
             anyhow::ensure!(
                 state.checkpoint_schema_version == crate::checkpoint::CHECKPOINT_SCHEMA_VERSION,
                 "legacy checkpoint replay did not produce the current causal schema"
@@ -563,7 +565,7 @@ impl HistoricalImporter for MigrationImporter<'_> {
         materialize_commit_tree(self.cache_dir, database_evidence.oid(), materialized.path())?;
         let local =
             build_genesis_from_database(&materialized.path().join("issues.db"), &self.agent_id)?;
-        let current = reduce_v3_state(self.cache_dir, &current_targets)?;
+        let current = reduce_v3_state(self.cache_dir, &current_targets, &self.history_cache)?;
         let (merged, changed) = merge_local_database_projection(&current, &local);
         anyhow::ensure!(changed, "local database contains no unshared state");
         let signers = read_v3_allowed_signers(self.cache_dir, &current_targets)?;
@@ -603,7 +605,13 @@ impl HistoricalImporter for MigrationImporter<'_> {
                     .map(|agent| (agent.to_string(), oid.clone()))
             })
             .collect();
-        let source = RefHubSource::at_tips(repository, checkpoint, meta, agents)?;
+        let source = RefHubSource::at_tips_cached(
+            repository,
+            checkpoint,
+            meta,
+            agents,
+            self.history_cache.clone(),
+        )?;
         let outcome =
             compaction::reduce(&source).context("reducing prepared reconciliation targets")?;
         let allowed_signers = source
@@ -612,6 +620,44 @@ impl HistoricalImporter for MigrationImporter<'_> {
             .transpose()
             .context("reading allowed_signers from prepared reconciliation target")?;
         canonical_semantic(&outcome.state, allowed_signers)
+    }
+
+    fn read_legacy_target_semantic(
+        &self,
+        repository: &Path,
+        targets: &BTreeMap<String, String>,
+    ) -> Result<Option<CanonicalSemantic>> {
+        let checkpoint = read_checkpoint_target(repository, targets)?;
+        if !checkpoint.is_legacy() {
+            return Ok(None);
+        }
+        let checkpoint = targets.get(CHECKPOINT_REF).cloned();
+        let meta = targets.get(META_REF).cloned();
+        let agents = targets
+            .iter()
+            .filter_map(|(name, oid)| {
+                name.strip_prefix(hub_v3::AGENT_REF_PREFIX)
+                    .map(|agent| (agent.to_string(), oid.clone()))
+            })
+            .collect();
+        let source = RefHubSource::at_tips_cached(
+            repository,
+            checkpoint,
+            meta,
+            agents,
+            self.history_cache.clone(),
+        )?;
+        let outcome = compaction::reduce_legacy_compatible(&source)
+            .context("reducing legacy reconciliation targets")?;
+        let allowed_signers = source
+            .allowed_signers_file()?
+            .map(fs::read)
+            .transpose()
+            .context("reading allowed_signers from legacy reconciliation target")?;
+        Ok(Some(legacy_canonical_semantic(
+            &outcome.state,
+            allowed_signers,
+        )?))
     }
 }
 
@@ -948,9 +994,26 @@ fn canonical_semantic(
     }))
 }
 
+fn legacy_canonical_semantic(
+    state: &CheckpointState,
+    allowed_signers: Option<Vec<u8>>,
+) -> Result<CanonicalSemantic> {
+    let mut state = serde_json::to_value(state).context("serializing legacy semantic state")?;
+    let object = state
+        .as_object_mut()
+        .context("legacy semantic state is not an object")?;
+    object.remove("checkpoint_schema_version");
+    object.remove("frontier");
+    CanonicalSemantic::from_value(serde_json::json!({
+        "state": state,
+        "trust": allowed_signers.map(hex::encode),
+    }))
+}
+
 fn reduce_v3_state(
     repository: &Path,
     targets: &BTreeMap<String, String>,
+    history_cache: &RefHistoryCache,
 ) -> Result<CheckpointState> {
     let checkpoint = targets.get(CHECKPOINT_REF).cloned();
     let meta = targets.get(META_REF).cloned();
@@ -961,7 +1024,8 @@ fn reduce_v3_state(
                 .map(|agent| (agent.to_string(), oid.clone()))
         })
         .collect();
-    let source = RefHubSource::at_tips(repository, checkpoint, meta, agents)?;
+    let source =
+        RefHubSource::at_tips_cached(repository, checkpoint, meta, agents, history_cache.clone())?;
     Ok(compaction::reduce(&source)
         .context("reducing current v3 state for local database reconciliation")?
         .state)
@@ -1673,6 +1737,7 @@ pub fn reconcile_repository(
         cache_dir,
         hub_lock,
         agent_id,
+        history_cache: RefHistoryCache::default(),
     };
     let journal_path = crosslink_dir.join("reconciliation-journal.json");
     let outcome = RepositoryReconciler::new(cache_dir, journal_path, remote, &importer)
@@ -2722,6 +2787,14 @@ pub(crate) mod tests {
             targets: &BTreeMap<String, String>,
         ) -> Result<CanonicalSemantic> {
             HistoricalImporter::read_target_semantic(&self.inner, repository, targets)
+        }
+
+        fn read_legacy_target_semantic(
+            &self,
+            repository: &Path,
+            targets: &BTreeMap<String, String>,
+        ) -> Result<Option<CanonicalSemantic>> {
+            HistoricalImporter::read_legacy_target_semantic(&self.inner, repository, targets)
         }
     }
 
@@ -4210,6 +4283,7 @@ pub(crate) mod tests {
             cache_dir: &cache_dir,
             hub_lock: &lock,
             agent_id: "alpha".to_string(),
+            history_cache: RefHistoryCache::default(),
         };
         let failed = RepositoryReconciler::new(
             &cache_dir,
@@ -5136,6 +5210,7 @@ pub(crate) mod tests {
                 cache_dir: &source_cache,
                 hub_lock: &source_lock,
                 agent_id: "alpha".to_string(),
+                history_cache: RefHistoryCache::default(),
             },
             barrier: Arc::clone(&barrier),
             fingerprints: Arc::clone(&fingerprints),
@@ -5146,6 +5221,7 @@ pub(crate) mod tests {
                 cache_dir: &second_cache,
                 hub_lock: &second_lock,
                 agent_id: "alpha".to_string(),
+                history_cache: RefHistoryCache::default(),
             },
             barrier,
             fingerprints: Arc::clone(&fingerprints),

--- a/crosslink/src/reconcile/publication.rs
+++ b/crosslink/src/reconcile/publication.rs
@@ -179,6 +179,20 @@ pub trait HistoricalImporter {
         repository: &Path,
         targets: &BTreeMap<String, String>,
     ) -> Result<CanonicalSemantic>;
+
+    fn read_legacy_target_semantic(
+        &self,
+        _repository: &Path,
+        _targets: &BTreeMap<String, String>,
+    ) -> Result<Option<CanonicalSemantic>> {
+        Ok(None)
+    }
+}
+
+#[derive(Debug)]
+struct VerifiedBaseline {
+    semantic: CanonicalSemantic,
+    legacy_encoding: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -734,16 +748,21 @@ impl<'a, I: HistoricalImporter> RepositoryReconciler<'a, I> {
             }
             fetch_oid(self.repository, self.remote, winner)?;
             let committed = read_descriptor(self.repository, winner)?;
-            if committed.source.fingerprint == journal.descriptor.source.fingerprint {
-                return self.adopt_winner(journal, winner);
-            }
-            if let Err(error) = self.verified_baseline_semantic(&committed) {
-                if error.downcast_ref::<RemoteGitError>().is_some() {
+            let verified = match self.verified_baseline_semantic(&committed) {
+                Ok(verified) => verified,
+                Err(error) if error.downcast_ref::<RemoteGitError>().is_some() => {
                     return Err(error);
                 }
-                return Ok(PublicationOutcome::BlockedCorrupt {
-                    reason: format!("committed remote generation is unverifiable: {error:#}"),
-                });
+                Err(error) => {
+                    return Ok(PublicationOutcome::BlockedCorrupt {
+                        reason: format!("committed remote generation is unverifiable: {error:#}"),
+                    });
+                }
+            };
+            if committed.source.fingerprint == journal.descriptor.source.fingerprint
+                && !verified.legacy_encoding
+            {
+                return self.adopt_winner(journal, winner);
             }
             let expectations = alias_expectations_from_source(&committed);
             match self.complete_committed_generation(&committed, winner, &expectations, true)? {
@@ -1255,8 +1274,8 @@ impl<'a, I: HistoricalImporter> RepositoryReconciler<'a, I> {
                     ),
                 });
             }
-            let semantic = match self.verified_baseline_semantic(&winner) {
-                Ok(semantic) => semantic,
+            let verified = match self.verified_baseline_semantic(&winner) {
+                Ok(verified) => verified,
                 Err(error) if error.downcast_ref::<RemoteGitError>().is_some() => {
                     return Err(error);
                 }
@@ -1266,15 +1285,16 @@ impl<'a, I: HistoricalImporter> RepositoryReconciler<'a, I> {
                     });
                 }
             };
-            if semantic.digest() != winner.semantic_digest
-                || semantic.digest() != journal.descriptor.semantic_digest
+            if verified.legacy_encoding
+                || verified.semantic.digest() != winner.semantic_digest
+                || verified.semantic.digest() != journal.descriptor.semantic_digest
             {
                 return Ok(PublicationOutcome::BlockedCorrupt {
                     reason: format!(
                         "remote winner failed independent semantic verification (winner {}, local {}, verified {})",
                         winner.semantic_digest,
                         journal.descriptor.semantic_digest,
-                        semantic.digest()
+                        verified.semantic.digest()
                     ),
                 });
             }
@@ -1731,14 +1751,23 @@ impl<'a, I: HistoricalImporter> RepositoryReconciler<'a, I> {
         ))
     }
 
-    fn fetch_and_verify_target_objects(
+    fn verified_baseline_semantic(
         &self,
         descriptor: &GenerationDescriptor,
-    ) -> Result<BTreeMap<String, String>> {
+    ) -> Result<VerifiedBaseline> {
         validate_descriptor_schema(descriptor)?;
+        let immutable_refs = descriptor
+            .targets
+            .values()
+            .chain(descriptor.archives.values())
+            .map(|target| target.immutable_ref.clone())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        fetch_refs(self.repository, self.remote, &immutable_refs)?;
+        let advertised = remote_ref_map(self.repository, self.remote, &immutable_refs)?;
         let mut targets = BTreeMap::new();
         for (canonical, target) in &descriptor.targets {
-            fetch_ref(self.repository, self.remote, &target.immutable_ref)?;
             anyhow::ensure!(
                 object_exists(self.repository, &target.oid)?,
                 "remote target object {} is unavailable after fetching {}",
@@ -1746,27 +1775,16 @@ impl<'a, I: HistoricalImporter> RepositoryReconciler<'a, I> {
                 target.immutable_ref
             );
             validate_object_type(self.repository, &target.oid, "commit")?;
-            let advertised = remote_ref_oid(self.repository, self.remote, &target.immutable_ref)?;
             anyhow::ensure!(
-                advertised.as_deref() == Some(target.oid.as_str()),
+                advertised.get(&target.immutable_ref) == Some(&target.oid),
                 "remote immutable target {} does not match its descriptor",
                 target.immutable_ref
             );
             targets.insert(canonical.clone(), target.oid.clone());
         }
-        Ok(targets)
-    }
-
-    fn verified_baseline_semantic(
-        &self,
-        descriptor: &GenerationDescriptor,
-    ) -> Result<CanonicalSemantic> {
-        let targets = self.fetch_and_verify_target_objects(descriptor)?;
         for archive in descriptor.archives.values() {
-            fetch_ref(self.repository, self.remote, &archive.immutable_ref)?;
-            let advertised = remote_ref_oid(self.repository, self.remote, &archive.immutable_ref)?;
             anyhow::ensure!(
-                advertised.as_deref() == Some(archive.oid.as_str()),
+                advertised.get(&archive.immutable_ref) == Some(&archive.oid),
                 "remote immutable archive {} does not match its descriptor",
                 archive.immutable_ref
             );
@@ -1776,11 +1794,24 @@ impl<'a, I: HistoricalImporter> RepositoryReconciler<'a, I> {
         let semantic = self
             .importer
             .read_target_semantic(self.repository, &targets)?;
+        if semantic.digest() == descriptor.semantic_digest {
+            return Ok(VerifiedBaseline {
+                semantic,
+                legacy_encoding: false,
+            });
+        }
+        let legacy = self
+            .importer
+            .read_legacy_target_semantic(self.repository, &targets)?
+            .context("immutable generation targets differ from the descriptor semantic digest")?;
         anyhow::ensure!(
-            semantic.digest() == descriptor.semantic_digest,
-            "immutable generation targets differ from the descriptor semantic digest"
+            legacy.digest() == descriptor.semantic_digest,
+            "immutable generation targets differ from both current and legacy semantic digests"
         );
-        Ok(semantic)
+        Ok(VerifiedBaseline {
+            semantic: legacy,
+            legacy_encoding: true,
+        })
     }
 
     fn verify_remote_targets(
@@ -3708,6 +3739,29 @@ fn fetch_ref(repository: &Path, remote: &str, reference: &str) -> Result<()> {
     }
 }
 
+fn fetch_refs(repository: &Path, remote: &str, references: &[String]) -> Result<()> {
+    if references.is_empty() {
+        return Ok(());
+    }
+    let mut command = Command::new("git");
+    command
+        .current_dir(repository)
+        .args(["fetch", "--no-tags", remote])
+        .args(references);
+    let output = command
+        .output()
+        .context("fetching immutable reconciliation refs")?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(classify_remote_error(
+            "git fetch immutable reconciliation refs",
+            &output_message(&output),
+        )
+        .into())
+    }
+}
+
 pub(crate) fn refresh_generation_ref(
     repository: &Path,
     remote: &str,
@@ -4015,6 +4069,66 @@ mod tests {
             targets: &BTreeMap<String, String>,
         ) -> Result<CanonicalSemantic> {
             self.target.read_target_semantic(repository, targets)
+        }
+    }
+
+    struct VerificationImporter {
+        current: Value,
+        legacy: Option<Value>,
+    }
+
+    impl HistoricalImporter for VerificationImporter {
+        fn prepare_file_source(
+            &self,
+            _repository: &Path,
+            _source: &SourceEvidence,
+            _generation_id: &str,
+        ) -> Result<PreparedImport> {
+            bail!("verification importer cannot prepare a file source")
+        }
+
+        fn prepare_local_source(
+            &self,
+            _repository: &Path,
+            _source: &SourceEvidence,
+            _generation_id: &str,
+        ) -> Result<PreparedImport> {
+            bail!("verification importer cannot prepare a local source")
+        }
+
+        fn prepare_current_source(
+            &self,
+            _repository: &Path,
+            _source: &SourceEvidence,
+        ) -> Result<PreparedImport> {
+            bail!("verification importer cannot prepare a current source")
+        }
+
+        fn file_source_is_newer(
+            &self,
+            _repository: &Path,
+            _source: &SourceEvidence,
+        ) -> Result<bool> {
+            Ok(false)
+        }
+
+        fn read_target_semantic(
+            &self,
+            _repository: &Path,
+            _targets: &BTreeMap<String, String>,
+        ) -> Result<CanonicalSemantic> {
+            CanonicalSemantic::from_value(self.current.clone())
+        }
+
+        fn read_legacy_target_semantic(
+            &self,
+            _repository: &Path,
+            _targets: &BTreeMap<String, String>,
+        ) -> Result<Option<CanonicalSemantic>> {
+            self.legacy
+                .clone()
+                .map(CanonicalSemantic::from_value)
+                .transpose()
         }
     }
 
@@ -4555,6 +4669,43 @@ mod tests {
         assert!(matches!(outcome, PublicationOutcome::BlockedCorrupt { .. }));
         assert_eq!(remote_oid(&fixture, GENERATION_REF), Some(descriptor_oid));
         assert_eq!(local_ref_oid(fixture.repository.path(), V2).unwrap(), None);
+    }
+
+    #[test]
+    fn verified_legacy_digest_allows_upgrade_without_accepting_arbitrary_mismatch() {
+        let fixture = v2_fixture();
+        let original = ObjectImporter::new("legacy-generation");
+        reconcile_fixture(&fixture, &original).unwrap();
+        let descriptor_oid = remote_oid(&fixture, GENERATION_REF).unwrap();
+        let descriptor = read_descriptor(fixture.repository.path(), &descriptor_oid).unwrap();
+        let verifier = VerificationImporter {
+            current: serde_json::json!({"encoding": "current"}),
+            legacy: Some(original.semantic),
+        };
+        let reconciler = RepositoryReconciler::new(
+            fixture.repository.path(),
+            fixture.journal.clone(),
+            "origin",
+            &verifier,
+        );
+        let verified = reconciler.verified_baseline_semantic(&descriptor).unwrap();
+        assert!(verified.legacy_encoding);
+        assert_eq!(verified.semantic.digest(), descriptor.semantic_digest);
+
+        let corrupt = VerificationImporter {
+            current: serde_json::json!({"encoding": "current"}),
+            legacy: Some(serde_json::json!({"encoding": "unrelated"})),
+        };
+        let reconciler = RepositoryReconciler::new(
+            fixture.repository.path(),
+            fixture.journal.clone(),
+            "origin",
+            &corrupt,
+        );
+        let error = reconciler
+            .verified_baseline_semantic(&descriptor)
+            .unwrap_err();
+        assert!(error.to_string().contains("current and legacy"));
     }
 
     #[test]

--- a/crosslink/tests/daemon_readiness.rs
+++ b/crosslink/tests/daemon_readiness.rs
@@ -3,6 +3,7 @@ use std::process::{Child, Command, Output, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
+use rusqlite::{Connection, OpenFlags};
 use serde_json::Value;
 
 const CLI_PROCESS_TIMEOUT: Duration = Duration::from_secs(15);
@@ -188,6 +189,33 @@ fn ensure_child(directory: &Path) -> Child {
         .unwrap()
 }
 
+fn rollback_journal_path(path: &Path) -> PathBuf {
+    let mut value = path.as_os_str().to_os_string();
+    value.push("-journal");
+    value.into()
+}
+
+fn install_hot_rollback_journal(database_path: &Path) {
+    let source = tempfile::tempdir().unwrap();
+    let source_database = source.path().join("issues.db");
+    std::fs::copy(database_path, &source_database).unwrap();
+    let connection = Connection::open(&source_database).unwrap();
+    connection
+        .execute_batch(
+            "PRAGMA journal_mode=DELETE;\
+             PRAGMA synchronous=FULL;\
+             PRAGMA cache_size=1;\
+             BEGIN IMMEDIATE;\
+             UPDATE issues SET title = 'uncommitted title' WHERE id = 1;",
+        )
+        .unwrap();
+    connection.cache_flush().unwrap();
+    let source_journal = rollback_journal_path(&source_database);
+    assert!(source_journal.metadata().unwrap().len() > 512);
+    std::fs::copy(&source_database, database_path).unwrap();
+    std::fs::copy(&source_journal, rollback_journal_path(database_path)).unwrap();
+}
+
 #[cfg(unix)]
 fn ensure_child_in_own_group(directory: &Path) -> Child {
     use std::os::unix::process::CommandExt;
@@ -225,6 +253,61 @@ fn fresh_hook_initialized_local_repository_bootstraps_to_ready() {
     ));
     assert!(work.path().join(".crosslink/issues.db").is_file());
     assert!(work.path().join(".crosslink/.hub-cache").is_dir());
+}
+
+#[test]
+fn daemon_recovers_hot_rollback_journal_before_reconciliation() {
+    let work = fresh_local_repository();
+    let _cleanup = DaemonCleanup::new(work.path());
+    let database_path = work.path().join(".crosslink/issues.db");
+    let database = crosslink::db::Database::open(&database_path).unwrap();
+    database
+        .create_issue("durable title", None, "medium")
+        .unwrap();
+    drop(database);
+    install_hot_rollback_journal(&database_path);
+
+    let read_only =
+        Connection::open_with_flags(&database_path, OpenFlags::SQLITE_OPEN_READ_ONLY).unwrap();
+    let failure = read_only
+        .query_row::<String, _, _>("PRAGMA quick_check(1)", [], |row| row.get(0))
+        .unwrap_err();
+    assert!(matches!(
+        failure,
+        rusqlite::Error::SqliteFailure(error, _)
+            if error.extended_code == rusqlite::ffi::SQLITE_READONLY_ROLLBACK
+    ));
+    drop(read_only);
+
+    let database_before = std::fs::read(&database_path).unwrap();
+    let journal_before = std::fs::read(rollback_journal_path(&database_path)).unwrap();
+    let diagnostic = crosslink(work.path(), &["reconcile", "--check"]);
+    assert!(
+        diagnostic.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&diagnostic.stdout),
+        String::from_utf8_lossy(&diagnostic.stderr)
+    );
+    assert_eq!(std::fs::read(&database_path).unwrap(), database_before);
+    assert_eq!(
+        std::fs::read(rollback_journal_path(&database_path)).unwrap(),
+        journal_before
+    );
+
+    let ready = wait_output(ensure_child(work.path()), DAEMON_PROCESS_TIMEOUT);
+    assert!(
+        ready.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&ready.stdout),
+        String::from_utf8_lossy(&ready.stderr)
+    );
+    let ready = parse(&ready);
+    assert_eq!(ready["ready"], true);
+    assert!(!rollback_journal_path(&database_path).exists());
+
+    let recovered = crosslink::db::Database::open_read_only(&database_path).unwrap();
+    let issue = recovered.get_issue(1).unwrap().unwrap();
+    assert_eq!(issue.title, "durable title");
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary

- recover hot SQLite rollback journals before mutating repository reconciliation while keeping diagnostics read-only
- accept preserved legacy same-sequence events and schema-1 generation encodings without weakening current-history validation
- replace quadratic historical snapshot scans with first-parent delta reconstruction, exact-tip caching, and batched immutable-ref verification
- cover interrupted transactions, legacy collisions, pruning, history rewrites, and legacy descriptor supersession

## Verification

- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-features: 5,473 passed, 4 ignored
- Project-Peritus database quick_check: ok
- Project-Peritus daemon readiness: ready_current
- clean cold readiness completed in 57.79 seconds; warm status completed in 0.09 seconds